### PR TITLE
build: Improv ecompile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,8 @@ opt-level = 3
 lto = "fat"
 panic = "abort"
 strip = "symbols"
+
+[profile.release-e2e]
+inherits = "release"
+lto = "thin"
+codegen-units = 32

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ LABEL mantainer=pando855@gmail.com
 
 ARG CARGO_TARGET_DIR=target
 ARG CARGO_BUILD_TARGET=
+ARG CARGO_RELEASE_PROFILE=release
 
-COPY ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/release/kaniop /bin/kaniop
+COPY ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/${CARGO_RELEASE_PROFILE}/kaniop /bin/kaniop
 
 ENTRYPOINT ["/bin/kaniop"]


### PR DESCRIPTION
- Add release-e2e profile for using in local testing.
- Remove the two threads limitation on Makefile.
- Build just kaniop for make build and release targets.