### PR TITLE
build(ci): Fix docker multiarch image push

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -44,6 +44,8 @@ jobs:
       - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - name: Push image
+        env:
+          TMP_DIR: ${{ runner.temp }}
         run: |
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')


### PR DESCRIPTION
Docker push was pushing just the latest architecture image instead of all. We refactor the target to push docker images digests for all architectures and then create the tagged image.