### PR TITLE
build(ci): Fix `managerFilePatterns` expresions in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
       customType: 'regex',
       description: 'Process custom dependencies in Rust',
       managerFilePatterns: [
-        '//.+\\.rs$//',
+        '/.+\\.rs$/',
       ],
       matchStrings: [
         '//\\srenovate: datasource=(?<datasource>\\S+)( versioning=(?<versioning>\\S+))?\n.*?= "(?<depName>\\S+):(?<currentValue>.*)";\n',
@@ -25,8 +25,8 @@
       customType: 'regex',
       description: 'Process custom dependencies in Yaml',
       managerFilePatterns: [
-        '//.+\\.yaml$//',
-        '//.+\\.yml$//',
+        '/.+\\.yaml$/',
+        '/.+\\.yml$/',
       ],
       matchStrings: [
         '#\\srenovate: datasource=(?<datasource>\\S+)( versioning=(?<versioning>\\S+))?\n.*?: (?<depName>\\S+):(?<currentValue>.*)\n',


### PR DESCRIPTION
During migration double `/` were added.