### PR TITLE
refactor(deps): Move validations from admission policy to schemars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GH_ORG ?= pando85
 VERSION ?= $(shell git rev-parse --short HEAD)
 # renovate: datasource=docker depName=kindest/node
-KIND_IMAGE_TAG ?= v1.32.3
+KIND_IMAGE_TAG ?= v1.33.4
 KIND_CLUSTER_NAME = chart-testing
 KUBE_CONTEXT := kind-$(KIND_CLUSTER_NAME)
 KANIOP_NAMESPACE := kaniop

--- a/charts/kaniop/templates/validating-admission-policy-kanidm-oauth2.yaml
+++ b/charts/kaniop/templates/validating-admission-policy-kanidm-oauth2.yaml
@@ -15,8 +15,6 @@ spec:
         resources:
           - kanidmoauth2clients
   validations:
-    - expression: "oldObject == null || object.spec.public == oldObject.spec.public"
-      message: "Public cannot be changed."
     - expression: "!has(object.spec.allowInsecureClientDisablePkce) || (has(object.spec.allowInsecureClientDisablePkce) && !object.spec.public)"
       message: "Public clients cannot disable PKCE."
     - expression: "!has(object.spec.allowLocalhostRedirect) || (has(object.spec.allowLocalhostRedirect) && object.spec.public)"

--- a/charts/kaniop/templates/validating-admission-policy-kanidm.yaml
+++ b/charts/kaniop/templates/validating-admission-policy-kanidm.yaml
@@ -20,8 +20,6 @@ spec:
     - expression: |
         object.metadata.name.size() <= 48 && object.metadata.name.size() + object.spec.replicaGroups.map(rg, rg.name.size()).max() <= 62
       message: "Invalid name. Too long name, subresource names must no more than 63 characters."
-    - expression: "oldObject == null || object.spec.domain == oldObject.spec.domain"
-      message: "Domain cannot be changed."
     - expression: |
         (
           has(object.spec.storage) && has(object.spec.storage.volumeClaimTemplate) &&

--- a/libs/oauth2/src/crd.rs
+++ b/libs/oauth2/src/crd.rs
@@ -63,9 +63,7 @@ pub struct KanidmOAuth2ClientSpec {
     /// rfc7662 token introspection requires client authentication.
     ///
     /// This cannot be changed after creation. Default value is false.
-    // TODO: move from ValidatingAdmissionPolicy to here when schemars 1.0.0 is released and k8s-openapi implements it
-    // schemars = 1.0.0
-    //#[schemars(extend("x-kubernetes-validations" = [{"message": "Value is immutable", "rule": "self == oldSelf"}]))]
+    #[schemars(extend("x-kubernetes-validations" = [{"message": "Public cannot be changed.", "rule": "self == oldSelf"}]))]
     #[serde(default)]
     pub public: bool,
 

--- a/libs/operator/src/kanidm/crd.rs
+++ b/libs/operator/src/kanidm/crd.rs
@@ -55,9 +55,7 @@ pub struct KanidmSpec {
     /// Names (spns) throughout the topology.
     ///
     /// This cannot be changed after creation.
-    // TODO: move from ValidatingAdmissionPolicy to here when schemars 1.0.0 is released and k8s-openapi implements it
-    // schemars = 1.0.0
-    //#[schemars(extend("x-kubernetes-validations" = [{"message": "Value is immutable", "rule": "self == oldSelf"}]))]
+    #[schemars(extend("x-kubernetes-validations" = [{"message": "Domain cannot be changed.", "rule": "self == oldSelf"}]))]
     #[schemars(regex(
         pattern = r"^([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
     ))]
@@ -65,8 +63,7 @@ pub struct KanidmSpec {
 
     /// Different group of replicas with specific configuration as role, resources, affinity rules, and more.
     /// Each group will be deployed as a separate StatefulSet.
-    // TODO: move from ValidatingAdmissionPolicy to here when schemars 1.0.0 is released
-    //#[schemars(extend("x-kubernetes-validations" = [{"message": "Value is immutable", "rule": "self.size() > 0"}]))]
+    #[schemars(extend("x-kubernetes-validations" = [{"message": "At least one ReplicaGroup is required", "rule": "self.size() > 0"}]))]
     // max is defined for allowing CEL expression in validation admission policy estimate
     // expression costs
     #[validate(length(min = 1, max = 100))]


### PR DESCRIPTION
Require Kubernetes 1.33+.