### PR TITLE
feat(kanidm): renew replication certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "base64urlsafedata"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +361,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -572,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +760,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +784,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -778,6 +835,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -880,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -951,6 +1009,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -1964,7 +2028,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2204,7 +2268,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2292,6 +2356,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanidm-hsm-crypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b3ed8e86cda3da4f274c677a3057d567bd7b715a0feb06a656e55cc75faf5e"
+dependencies = [
+ "argon2",
+ "hex",
+ "openssl",
+ "serde",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "kanidm_build_profiles"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,6 +2404,31 @@ dependencies = [
  "url",
  "uuid",
  "webauthn-rs-proto",
+]
+
+[[package]]
+name = "kanidm_lib_crypto"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1501c6819db7a0ae3685b41a8faf20da62c47bab26f100a092346c20dd7e72"
+dependencies = [
+ "argon2",
+ "base64 0.22.1",
+ "base64urlsafedata",
+ "hex",
+ "kanidm-hsm-crypto",
+ "kanidm_proto",
+ "md-5",
+ "md4",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.1",
+ "serde",
+ "sha-crypt",
+ "sha2",
+ "tracing",
+ "uuid",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2514,6 +2617,7 @@ version = "0.0.0-beta.5"
 dependencies = [
  "axum",
  "backon",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "futures",
@@ -2521,6 +2625,7 @@ dependencies = [
  "hyper",
  "k8s-openapi",
  "kanidm_client",
+ "kanidm_lib_crypto",
  "kanidm_proto",
  "kaniop-k8s-util",
  "kube",
@@ -2763,6 +2868,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.103",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "md4"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3173,6 +3297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3348,15 @@ checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3540,7 +3684,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3775,7 +3919,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4128,6 +4272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-crypt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e79009728d8311d42d754f2f319a975f9e38f156fd5e422d2451486c78b286"
+dependencies = [
+ "base64ct",
+ "rand 0.8.5",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,6 +4387,16 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4361,7 +4527,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4500,6 +4666,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "tokio"
@@ -5294,7 +5481,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5475,6 +5662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5770,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ http = "1.1"
 json-patch = "4.0"
 k8s-openapi = { version = "0.26", default-features = false, features = ["v1_32"] }
 kanidm_client = "1.6.2"
+kanidm_lib_crypto = "1.6.2"
 kanidm_proto = "1.6.2"
 kube = { version = "2.0", default-features = true, features = ["client", "derive", "unstable-runtime"] }
 prometheus-client = "0.24.0"

--- a/libs/oauth2/src/reconcile/mod.rs
+++ b/libs/oauth2/src/reconcile/mod.rs
@@ -345,7 +345,7 @@ impl KanidmOAuth2Client {
             .iter()
             .map(|u| {
                 url::Url::parse(u).map_err(|e| {
-                    Error::ParseError(
+                    Error::UrlParseError(
                         format!(
                             "failed to parse redirect URL {u} for {name} from {namespace}/{kanidm}",
                             namespace = self.kanidm_namespace(),

--- a/libs/operator/Cargo.toml
+++ b/libs/operator/Cargo.toml
@@ -23,6 +23,7 @@ examples-gen = []
 [dependencies]
 kaniop-k8s-util = { workspace = true }
 kanidm_client = { workspace = true }
+kanidm_lib_crypto = { workspace = true }
 kanidm_proto = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
@@ -50,6 +51,7 @@ tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 schemars = { workspace = true, optional = true }
 openssl = { workspace = true }
 url = { workspace = true }
+base64 = "0.22"
 
 [build-dependencies]
 openssl = { workspace = true }

--- a/libs/operator/src/error.rs
+++ b/libs/operator/src/error.rs
@@ -26,16 +26,19 @@ pub enum Error {
     #[error("{0}")]
     MissingData(String),
 
-    #[error("{0}: {1}")]
-    ParseError(String, #[source] url::ParseError),
+    #[error("parse error: {0}")]
+    ParseError(String),
 
     #[error("receive output error: {0}")]
     ReceiveOutput(String),
 
-    #[error("{0}: {0}")]
+    #[error("{0}: {1}")]
     SerializationError(String, #[source] serde_json::Error),
 
-    #[error("{0}: {0}")]
+    #[error("{0}: {1}")]
+    UrlParseError(String, #[source] url::ParseError),
+
+    #[error("{0}: {1}")]
     Utf8Error(String, #[source] std::str::Utf8Error),
 }
 

--- a/libs/operator/src/kanidm/controller/context.rs
+++ b/libs/operator/src/kanidm/controller/context.rs
@@ -1,20 +1,30 @@
 use crate::controller::context::BackoffContext;
+use crate::error::{Error, Result};
+use crate::kanidm::reconcile::secret::REPLICA_SECRET_KEY;
 use crate::metrics::ControllerMetrics;
 use crate::{controller::context::Context as KaniopContext, kanidm::crd::Kanidm};
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use kanidm_lib_crypto::x509_cert::Certificate;
+use kanidm_lib_crypto::x509_cert::der::Decode;
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE};
 use k8s_openapi::api::apps::v1::StatefulSet;
 use k8s_openapi::api::core::v1::{Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::runtime::reflector::{ObjectRef, Store};
+use tokio::sync::RwLock;
+use tracing::trace;
 
 #[derive(Clone)]
 pub struct Context {
     pub kaniop_ctx: KaniopContext<Kanidm>,
     /// Shared store
     pub stores: Arc<Stores>,
+    repl_cert_exp_cache: Arc<RwLock<ReplicaCertExpiration>>,
 }
 
 impl Context {
@@ -22,7 +32,53 @@ impl Context {
         Context {
             kaniop_ctx,
             stores: Arc::new(stores),
+            repl_cert_exp_cache: Arc::new(RwLock::new(ReplicaCertExpiration::default())),
         }
+    }
+
+    pub async fn get_repl_cert_exp(&self, secret_ref: &ObjectRef<Secret>) -> Option<i64> {
+        trace!(msg = format!("getting replica certificate expiration for {secret_ref}"));
+        self.repl_cert_exp_cache
+            .read()
+            .await
+            .0
+            .get(secret_ref)
+            .cloned()
+    }
+
+    pub async fn insert_repl_cert_exp(&self, secret: &Secret) -> Result<()> {
+        trace!(
+            msg = format!(
+                "inserting replica certificate expiration for {:?}",
+                &ObjectRef::from(secret)
+            )
+        );
+        match &secret.data {
+            None => Err(Error::MissingData("secret data empty".to_string())),
+            Some(data) => match data.get(REPLICA_SECRET_KEY) {
+                None => Err(Error::MissingData(format!(
+                    "secret data missing key {REPLICA_SECRET_KEY}"
+                ))),
+                Some(cert_b64url) => {
+                    let expiration =
+                        get_cert_expiration(String::from_utf8_lossy(&cert_b64url.0).as_ref())?;
+                    let obj_ref = ObjectRef::from(secret);
+                    {
+                        self.repl_cert_exp_cache
+                            .write()
+                            .await
+                            .0
+                            .insert(obj_ref, expiration);
+                    }
+                    Ok(())
+                }
+            },
+        }
+    }
+
+    pub async fn remove_repl_cert_exp(&self, secret_ref: &ObjectRef<Secret>) {
+        trace!(msg = format!("removing replica certificate expiration for {secret_ref}",));
+        self.repl_cert_exp_cache.write().await.0.remove(secret_ref);
     }
 }
 
@@ -44,4 +100,32 @@ pub struct Stores {
     pub service_store: Store<Service>,
     pub ingress_store: Store<Ingress>,
     pub secret_store: Store<Secret>,
+}
+
+#[derive(Default)]
+struct ReplicaCertExpiration(HashMap<ObjectRef<Secret>, i64>);
+
+fn get_cert_expiration(cert_b64url: &str) -> Result<i64> {
+    let der_bytes = URL_SAFE
+        .decode(cert_b64url)
+        .map_err(|e| Error::ParseError(format!("invalid base64url encoding: {e}")))?;
+
+    let cert = Certificate::from_der(&der_bytes)
+        .map_err(|e| Error::ParseError(format!("failed to parse DER certificate: {e}")))?;
+    let not_after = cert.tbs_certificate.validity.not_after;
+    trace!(msg = format!("certificate not after: {not_after}"));
+    let timestamp = not_after.to_unix_duration().as_secs() as i64;
+    Ok(timestamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_cert_expiration_valid_cert() {
+        let cert_b64url = "MIIB_DCCAaGgAwIBAgIBATAKBggqhkjOPQQDAjBMMRswGQYDVQQKDBJLYW5pZG0gUmVwbGljYXRpb24xLTArBgNVBAMMJDJiYTgzMTZhLWViYWEtNGJjMS04NDkzLTVmODZmYWZhZTU5NDAeFw0yNDExMDYxOTEzMjdaFw0yODExMDYxOTEzMjdaMEwxGzAZBgNVBAoMEkthbmlkbSBSZXBsaWNhdGlvbjEtMCsGA1UEAwwkMmJhODMxNmEtZWJhYS00YmMxLTg0OTMtNWY4NmZhZmFlNTk0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuXp1hNNZerxDQbCh7rAGW6uM0CPECNd3IvbSh7qH34MkO_plwwDVKFbzcTG8HJE2ouIJlJYN8P4wf6qmrRQMAKN0MHIwDAYDVR0TAQH_BAIwADAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBTaOaPuXmtLDTJVv--VYBiQr9gHCTAUBgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSQAwRgIhAIZD_J4LyR7D0kg41GRg_TcRxm5mEVhM6WL9BO3XmfUsAiEA7Wpbkvd0b1e-Sg8AS9jP-CpBpmTnC7oEChkyhUYKyFc=";
+        let expiration = get_cert_expiration(cert_b64url).unwrap();
+        assert_eq!(expiration, 1857150807);
+    }
 }

--- a/libs/operator/src/kanidm/crd.rs
+++ b/libs/operator/src/kanidm/crd.rs
@@ -552,6 +552,7 @@ pub struct KanidmReplicaStatus {
 pub enum KanidmReplicaState {
     Initialized,
     Pending,
+    CertificateExpiring,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
BREAKING CHANGE: Replica certificates secrets has to be recreated after this change for being able to renew them.