### PR TITLE
fix: free unused memory and refine lock usage

### DIFF
--- a/libs/group/src/reconcile.rs
+++ b/libs/group/src/reconcile.rs
@@ -26,7 +26,7 @@ use kube::{Resource, ResourceExt};
 use tracing::{Span, debug, field, info, instrument, trace, warn};
 
 pub static GROUP_OPERATOR_NAME: &str = "kanidmgroups.kaniop.rs";
-pub static GROUP_FINALIZER: &str = "kanidms.kaniop.rs/group";
+pub static GROUP_FINALIZER: &str = "kanidmgroups.kaniop.rs/finalizer";
 
 const TYPE_EXISTS: &str = "Exists";
 const TYPE_MAIL_UPDATED: &str = "MailUpdated";
@@ -95,11 +95,11 @@ pub async fn reconcile_group(
             ctx.metrics.status_update_errors_inc();
             e
         })?;
-    let persons_api: Api<KanidmGroup> = Api::namespaced(ctx.client.clone(), &namespace);
-    finalizer(&persons_api, GROUP_FINALIZER, group, |event| async {
+    let groups_api: Api<KanidmGroup> = Api::namespaced(ctx.client.clone(), &namespace);
+    finalizer(&groups_api, GROUP_FINALIZER, group, |event| async {
         match event {
-            Finalizer::Apply(p) => p.reconcile(kanidm_client, status, ctx).await,
-            Finalizer::Cleanup(p) => p.cleanup(kanidm_client, status).await,
+            Finalizer::Apply(g) => g.reconcile(kanidm_client, status, ctx).await,
+            Finalizer::Cleanup(g) => g.cleanup(kanidm_client, status).await,
         }
     })
     .await

--- a/libs/oauth2/src/reconcile/mod.rs
+++ b/libs/oauth2/src/reconcile/mod.rs
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Span, debug, field, info, instrument, trace, warn};
 
 static OAUTH2_OPERATOR_NAME: &str = "kanidmoauth2clients.kaniop.rs";
-static OAUTH2_FINALIZER: &str = "kanidms.kaniop.rs/oauth2-client";
+static OAUTH2_FINALIZER: &str = "kanidmoauth2clients.kaniop.rs/finalizer";
 
 pub fn watched_resource(oauth2: &KanidmOAuth2Client, ctx: Arc<Context>) -> bool {
     let kanidm = if let Some(k) = ctx.kaniop_ctx.get_kanidm(oauth2) {

--- a/libs/operator/src/controller/kanidm.rs
+++ b/libs/operator/src/controller/kanidm.rs
@@ -114,6 +114,12 @@ impl KanidmClients {
         self.0.insert(key, client)
     }
 
+    pub fn remove(&mut self, key: &KanidmKey) -> Option<Arc<KanidmClient>> {
+        let client = self.0.remove(key);
+        self.0.shrink_to_fit();
+        client
+    }
+
     pub async fn create_client(
         namespace: &str,
         name: &str,

--- a/libs/operator/src/kanidm/controller/context.rs
+++ b/libs/operator/src/kanidm/controller/context.rs
@@ -32,7 +32,7 @@ impl Context {
         Context {
             kaniop_ctx,
             stores: Arc::new(stores),
-            repl_cert_exp_cache: Arc::new(RwLock::new(ReplicaCertExpiration::default())),
+            repl_cert_exp_cache: Arc::default(),
         }
     }
 

--- a/libs/person/src/controller.rs
+++ b/libs/person/src/controller.rs
@@ -69,6 +69,7 @@ pub async fn cleanup_expired_tokens(ctx: Arc<Context>) {
         {
             let mut cache = ctx.internal_cache.write().await;
             cache.retain(|_, v| *v > now);
+            cache.shrink_to_fit();
         }
     }
 }

--- a/libs/person/src/reconcile.rs
+++ b/libs/person/src/reconcile.rs
@@ -29,7 +29,7 @@ use time::{OffsetDateTime, UtcOffset};
 use tracing::{Span, debug, field, info, instrument, trace, warn};
 
 pub static PERSON_OPERATOR_NAME: &str = "kanidmpersonsaccounts.kaniop.rs";
-pub static PERSON_FINALIZER: &str = "kanidms.kaniop.rs/person";
+pub static PERSON_FINALIZER: &str = "kanidmpersonsaccounts.kaniop.rs/finalizer";
 
 const TYPE_CREDENTIAL: &str = "Credential";
 const TYPE_EXISTS: &str = "Exists";


### PR DESCRIPTION
BREAKING CHANGE: After update you have to clean up old finalizers. Execute:
```bash
for resource in kanidmgroup person oauth2; do
  kubectl get $resource -A -o \
    custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name' \
    --no-headers 2>/dev/null | \
    while read ns name; do
      kubectl -n "$ns" patch $resource "$name" \
        -p '{"metadata":{"finalizers":[]}}' --type=merge || true
    done
done
```