### PR TITLE
fix(chart): Check 4|5xx status code for KaniopK8sApiErrors rule

### DIFF
--- a/charts/kaniop/files/prometheusrules.yaml
+++ b/charts/kaniop/files/prometheusrules.yaml
@@ -47,10 +47,10 @@ groups:
           description: "{{$labels.controller}} deleted/recreated deployments more than twice in 10 minutes."
 
       - alert: KaniopK8sApiErrors
-        expr: sum by(status_code) (increase(kaniop_kubernetes_client_http_requests_total{status_code!~"2.."}[5m])) > 0
+        expr: sum by(status_code) (increase(kaniop_kubernetes_client_http_requests_total{status_code~"[4-5].."}[5m])) > 0
         for: 2m
         labels:
           severity: warning
         annotations:
           summary: "Kaniop Kubernetes API errors"
-          description: "Non-2xx API responses detected in the last 5 minutes."
+          description: "4|5xx API responses detected in the last 5 minutes."


### PR DESCRIPTION
We were checking non 2xx codes and it caused false positives with 101.