### PR TITLE
fix(webhook): Increase TLS reload debounce to 5s

### DIFF
--- a/cmd/webhook/src/main.rs
+++ b/cmd/webhook/src/main.rs
@@ -101,8 +101,8 @@ async fn watch_tls_files(
 
     // Reload TLS config when file changes are detected
     while rx.recv().await.is_some() {
-        // Add a small delay to ensure file write is complete
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Add a small delay to ensure all files are written
+        tokio::time::sleep(Duration::from_secs(5)).await;
 
         match load_tls_config(&cert_path, &key_path) {
             Ok(new_config) => {


### PR DESCRIPTION
Increase the delay before reloading TLS config from short bursts to 5s. This debounces rapid filesystem events (e.g. symlink swaps or multi-step certificate writes) so multiple quick changes are grouped into a single reload. Reduces reload churn and transient failures during cert rotation.