### PR TITLE
refactor: Replace chrono with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
 dependencies = [
  "cc",
  "cmake",
@@ -632,10 +632,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2640,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2862,8 +2860,8 @@ name = "kaniop-e2e-tests"
 version = "0.3.2"
 dependencies = [
  "backon",
- "chrono",
  "futures",
+ "jiff",
  "json-patch",
  "k8s-openapi",
  "kanidm_client",
@@ -2976,7 +2974,6 @@ dependencies = [
  "axum",
  "backon",
  "base64 0.22.1",
- "chrono",
  "clap",
  "futures",
  "http",
@@ -5934,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5947,11 +5944,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -5960,9 +5958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5970,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5983,18 +5981,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ kaniop-oauth2 = { path = "libs/oauth2", version = "0.3.2" }
 kaniop-operator = { path = "libs/operator", version = "0.3.2" }
 kaniop-person = { path = "libs/person", version = "0.3.2" }
 kaniop-service-account = { path = "libs/service-account", version = "0.3.2" }
-chrono = "0.4.26"
+jiff = "0.2.18"
 clap = { version = "4.5", features = ["std", "derive"] }
 futures = "0.3"
 http = "1.1"

--- a/libs/operator/Cargo.toml
+++ b/libs/operator/Cargo.toml
@@ -37,7 +37,6 @@ serde_plain = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-chrono = { workspace = true, features = ["serde"] }
 axum = "0.8"
 backon = "1.3"
 thiserror = "2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 backon = "1.3"
-chrono = { workspace = true }
+jiff = { workspace = true }
 time = "0.3"
 # Kanidm dependency
 rustls = { workspace = true }

--- a/tests/e2e/test/person.rs
+++ b/tests/e2e/test/person.rs
@@ -708,13 +708,15 @@ async fn person_update_credential_token() {
     )
     .unwrap();
 
-    let now = chrono::Utc::now();
-    let expected_expire_time = now + chrono::Duration::seconds(7200);
+    let now = jiff::Zoned::now();
+    let expected_expire_time = now.checked_add(jiff::ToSpan::seconds(7200)).unwrap();
 
-    let expire_time_chrono =
-        chrono::DateTime::from_timestamp(expire_time.unix_timestamp(), 0).unwrap();
-    let time_diff = (expire_time_chrono - expected_expire_time)
-        .num_seconds()
+    let expire_time_jiff = jiff::Timestamp::from_second(expire_time.unix_timestamp())
+        .unwrap()
+        .to_zoned(jiff::tz::TimeZone::UTC);
+    let time_diff = expire_time_jiff
+        .duration_since(&expected_expire_time)
+        .as_secs()
         .abs();
 
     assert!(
@@ -722,7 +724,7 @@ async fn person_update_credential_token() {
         "Expected expiry time difference should be <= 120 seconds, got: {} seconds. Expected: {}, Got: {}",
         time_diff,
         expected_expire_time,
-        expire_time_chrono
+        expire_time_jiff
     );
 }
 


### PR DESCRIPTION
Replace chrono dependency with jiff throughout the codebase. The chrono library was only used in a single test case for time calculations.

Changes:
- Update workspace dependencies in Cargo.toml (chrono -> jiff)
- Update libs/operator and tests Cargo.toml dependencies
- Replace chrono API calls with jiff equivalents in person e2e test:
  - chrono::Utc::now() -> jiff::Zoned::now()
  - chrono::Duration::seconds() -> jiff::ToSpan::seconds()
  - chrono::DateTime::from_timestamp() -> jiff::Timestamp::from_second()

All tests pass with the new jiff implementation.