### PR TITLE
fix: patch_status with resource name, not kanidmName

### DIFF
--- a/libs/group/src/reconcile.rs
+++ b/libs/group/src/reconcile.rs
@@ -678,11 +678,14 @@ impl KanidmGroup {
         let patch = PatchParams::apply(GROUP_OPERATOR_NAME).force();
         let kanidm_api = Api::<KanidmGroup>::namespaced(ctx.client.clone(), &namespace);
         let _o = kanidm_api
-            .patch_status(&name, &patch, &status_patch)
+            .patch_status(&self.name_any(), &patch, &status_patch)
             .await
             .map_err(|e| {
                 Error::KubeError(
-                    format!("failed to patch KanidmGroup/status {namespace}/{name}"),
+                    format!(
+                        "failed to patch KanidmGroup/status {namespace}/{name}",
+                        name = self.name_any()
+                    ),
                     Box::new(e),
                 )
             })?;

--- a/libs/oauth2/src/reconcile/status.rs
+++ b/libs/oauth2/src/reconcile/status.rs
@@ -113,11 +113,14 @@ impl StatusExt for KanidmOAuth2Client {
         let kanidm_api =
             Api::<KanidmOAuth2Client>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
         let _o = kanidm_api
-            .patch_status(&name, &patch, &status_patch)
+            .patch_status(&self.name_any(), &patch, &status_patch)
             .await
             .map_err(|e| {
                 Error::KubeError(
-                    format!("failed to patch KanidmOAuth2Client/status {namespace}/{name}"),
+                    format!(
+                        "failed to patch KanidmOAuth2Client/status {namespace}/{name}",
+                        name = self.name_any()
+                    ),
                     Box::new(e),
                 )
             })?;

--- a/libs/person/src/reconcile.rs
+++ b/libs/person/src/reconcile.rs
@@ -459,11 +459,14 @@ impl KanidmPersonAccount {
         let kanidm_api =
             Api::<KanidmPersonAccount>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
         let _o = kanidm_api
-            .patch_status(&name, &patch, &status_patch)
+            .patch_status(&self.name_any(), &patch, &status_patch)
             .await
             .map_err(|e| {
                 Error::KubeError(
-                    format!("failed to patch KanidmPersonAccount/status {namespace}/{name}"),
+                    format!(
+                        "failed to patch KanidmPersonAccount/status {namespace}/{name}",
+                        name = self.name_any()
+                    ),
                     Box::new(e),
                 )
             })?;

--- a/libs/service-account/src/reconcile/status.rs
+++ b/libs/service-account/src/reconcile/status.rs
@@ -121,11 +121,14 @@ impl StatusExt for KanidmServiceAccount {
         let kanidm_api =
             Api::<KanidmServiceAccount>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
         let _o = kanidm_api
-            .patch_status(&name, &patch, &status_patch)
+            .patch_status(&self.name_any(), &patch, &status_patch)
             .await
             .map_err(|e| {
                 Error::KubeError(
-                    format!("failed to patch KanidmServiceAccount/status {namespace}/{name}"),
+                    format!(
+                        "failed to patch KanidmServiceAccount/status {namespace}/{name}",
+                        name = self.name_any()
+                    ),
                     Box::new(e),
                 )
             })?;


### PR DESCRIPTION
`kanidmName` is useful when we want to update builtin kanidm entities like the `id_admins` group. It overrides the `name` we usually get.

However, when this was added, modules were still using this derived `name` variable to update the status of the kubernetes resource, and should have been using the resource name.