### PR TITLE
feat: managed secret templates

### DIFF
--- a/cmd/examples/src/oauth2.rs
+++ b/cmd/examples/src/oauth2.rs
@@ -2,7 +2,7 @@ use kaniop_oauth2::crd::{
     KanidmClaimMap, KanidmClaimMapJoinStrategy, KanidmClaimsValuesMap, KanidmOAuth2Client,
     KanidmOAuth2ClientSpec, KanidmScopeMap, OAuth2ClientImageSpec,
 };
-use kaniop_operator::crd::{KanidmRef, SecretRotation};
+use kaniop_operator::crd::{KanidmRef, MetadataTemplate, SecretRotation};
 
 use std::collections::BTreeSet;
 
@@ -57,6 +57,16 @@ pub fn example() -> KanidmOAuth2Client {
             image: Some(OAuth2ClientImageSpec {
                 url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/argo-cd.svg"
                     .to_string(),
+            }),
+            secret_template: Some(MetadataTemplate {
+                labels: Some(std::collections::BTreeMap::from([(
+                    "example.com/app".to_string(),
+                    "my-service".to_string(),
+                )])),
+                annotations: Some(std::collections::BTreeMap::from([(
+                    "reflector.v1.k8s.emberstack.com/reflection-allowed".to_string(),
+                    "true".to_string(),
+                )])),
             }),
         },
         status: Default::default(),

--- a/examples/oauth2.yaml
+++ b/examples/oauth2.yaml
@@ -190,6 +190,21 @@ spec:
   #   # Defaults to 90 days.
   #   periodDays: 90
 
+  # # Template applied to the Secret created for confidential clients (public: false).
+  # # Allows attaching custom annotations and labels to the generated Secret. The operator's own
+  # # labels and annotations take precedence over any conflicting keys in the template.
+  # # Changes to this template are enforced on the next reconciliation, overwriting any manual
+  # # modifications made to the Secret
+  # secretTemplate:
+  #   # Annotations to add to the object. The operator's own annotations take precedence over
+  #   # any keys specified here.
+  #   annotations:
+  #     reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+  #   # Labels to add to the object. The operator's own labels take precedence over any keys
+  #   # specified here.
+  #   labels:
+  #     example.com/app: my-service
+
   # # Optional URL to an image for the OAuth2 client application.
   # # The image will be downloaded and set in Kanidm for display in the application portal.
   # # Constraints:

--- a/libs/oauth2/src/crd.rs
+++ b/libs/oauth2/src/crd.rs
@@ -1,6 +1,6 @@
 use kaniop_k8s_util::types::normalize_spn;
 use kaniop_operator::controller::kanidm::KanidmResource;
-use kaniop_operator::crd::{KanidmRef, SecretRotation};
+use kaniop_operator::crd::{KanidmRef, SecretRotation, MetadataTemplate};
 use kaniop_operator::kanidm::crd::Kanidm;
 
 use std::{
@@ -138,6 +138,14 @@ pub struct KanidmOAuth2ClientSpec {
     /// periodically based on the configured rotation period.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret_rotation: Option<SecretRotation>,
+
+    /// Template applied to the Secret created for confidential clients (public: false).
+    /// Allows attaching custom annotations and labels to the generated Secret. The operator's own
+    /// labels and annotations take precedence over any conflicting keys in the template.
+    /// Changes to this template are enforced on the next reconciliation, overwriting any manual
+    /// modifications made to the Secret
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_template: Option<MetadataTemplate>,
 
     /// Optional URL to an image for the OAuth2 client application.
     /// The image will be downloaded and set in Kanidm for display in the application portal.

--- a/libs/oauth2/src/reconcile/mod.rs
+++ b/libs/oauth2/src/reconcile/mod.rs
@@ -7,7 +7,8 @@ use self::status::{
     TYPE_CLAIMS_MAP_UPDATED, TYPE_DISABLE_PKCE_UPDATED, TYPE_EXISTS, TYPE_IMAGE_UPDATED,
     TYPE_LEGACY_CRYPTO_UPDATED, TYPE_PREFER_SHORT_NAME_UPDATED, TYPE_REDIRECT_URL_UPDATED,
     TYPE_SCOPE_MAP_UPDATED, TYPE_SECRET_INITIALIZED, TYPE_SECRET_ROTATED,
-    TYPE_STRICT_REDIRECT_URL_UPDATED, TYPE_SUP_SCOPE_MAP_UPDATED, TYPE_UPDATED,
+    TYPE_SECRET_TEMPLATE_SYNCED, TYPE_STRICT_REDIRECT_URL_UPDATED, TYPE_SUP_SCOPE_MAP_UPDATED,
+    TYPE_UPDATED,
 };
 use crate::image::{download_image, fetch_headers, headers_changed};
 
@@ -24,6 +25,7 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_operator::controller::context::{IdmClientContext, KubeOperations};
 use kaniop_operator::controller::idm_reconcile_interval;
 use kaniop_operator::controller::kanidm::{KanidmResource, is_resource_watched};
+use kaniop_operator::object_meta_template::ObjectMetaTemplateExt;
 use kaniop_operator::telemetry;
 
 use std::collections::BTreeSet;
@@ -249,6 +251,7 @@ impl KanidmOAuth2Client {
         ctx: Arc<Context>,
     ) -> Result<Action> {
         let name = &self.kanidm_entity_name();
+        let namespace = self.get_namespace();
         let mut require_status_update = false;
         let force_secret_rotation_requested = self.force_secret_rotation_requested();
 
@@ -281,6 +284,76 @@ impl KanidmOAuth2Client {
             self.rotate_secret(&kanidm_client, name, ctx.clone())
                 .await?;
             require_status_update = true;
+        }
+
+        // Note: when the Secret is created in this same reconcile cycle,
+        // TYPE_SECRET_TEMPLATE_SYNCED is absent (not False) in `status` because the Secret
+        // didn't exist when `update_status` ran. The template apply is therefore deferred to
+        // the next reconcile after the watch delivers the new Secret to the store.
+        if is_oauth2_false(TYPE_SECRET_TEMPLATE_SYNCED, status.clone()) {
+            match ctx.secret_store.find(|s| {
+                s.name_any() == self.secret_name() && s.namespace().as_ref() == Some(&namespace)
+            }) {
+                None => debug!(msg = "secret not yet in store, deferring secretTemplate apply"),
+                Some(secret_meta) => {
+                    // Re-evaluate here rather than reusing the status result: the store may
+                    // have been updated between update_status and now, and we need the
+                    // FilteredMetadata value (including has_discards) which is not carried
+                    // through the status conditions.
+                    if let Some(filtered) = self.needs_meta_template_apply(&secret_meta) {
+                        if filtered.has_discards() {
+                            warn!(
+                                msg = "secretTemplate contains keys already owned by the operator; they will be ignored",
+                                discarded_labels = ?filtered.discarded_labels,
+                                discarded_annotations = ?filtered.discarded_annotations,
+                            );
+                            ctx.kaniop_ctx
+                                .recorder
+                                .publish(
+                                    &Event {
+                                        type_: EventType::Warning,
+                                        reason: "SecretTemplateConflict".to_string(),
+                                        note: Some(format!(
+                                            "secretTemplate contains keys already owned by the \
+                                             operator and will be ignored. Labels: [{}]. \
+                                             Annotations: [{}].",
+                                            filtered
+                                                .discarded_labels
+                                                .iter()
+                                                .cloned()
+                                                .collect::<Vec<_>>()
+                                                .join(", "),
+                                            filtered
+                                                .discarded_annotations
+                                                .iter()
+                                                .cloned()
+                                                .collect::<Vec<_>>()
+                                                .join(", "),
+                                        )),
+                                        action: "ApplySecretTemplate".to_string(),
+                                        secondary: None,
+                                    },
+                                    &self.object_ref(&()),
+                                )
+                                .await
+                                .map_err(|e| {
+                                    warn!(msg = "failed to publish SecretTemplateConflict event", %e);
+                                    Error::KubeError(
+                                        "failed to publish event".to_string(),
+                                        Box::new(e),
+                                    )
+                                })?;
+                        }
+                        self.apply_meta_template(
+                            ctx.kaniop_ctx.client.clone(),
+                            &ctx.kaniop_ctx.metrics,
+                            filtered,
+                        )
+                        .await?;
+                        require_status_update = true;
+                    }
+                }
+            }
         }
 
         if is_oauth2_false(TYPE_UPDATED, status.clone()) {

--- a/libs/oauth2/src/reconcile/secret.rs
+++ b/libs/oauth2/src/reconcile/secret.rs
@@ -1,12 +1,14 @@
 use crate::controller::CONTROLLER_ID;
 use crate::crd::KanidmOAuth2Client;
+use crate::reconcile::OAUTH2_OPERATOR_NAME;
 
 use kanidm_client::KanidmClient;
 use kaniop_k8s_util::error::{Error, Result};
 use kaniop_k8s_util::rotation::add_rotation_annotations as add_annotations;
 use kaniop_operator::controller::kanidm::KanidmResource;
 use kaniop_operator::controller::{INSTANCE_LABEL, MANAGED_BY_LABEL, NAME_LABEL};
-use kaniop_operator::crd::SecretRotation;
+use kaniop_operator::crd::{MetadataTemplate, SecretRotation};
+use kaniop_operator::object_meta_template::ObjectMetaTemplateExt;
 
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
@@ -115,4 +117,12 @@ impl SecretExt for KanidmOAuth2Client {
     }
 }
 
-impl KanidmOAuth2Client {}
+impl ObjectMetaTemplateExt<Secret> for KanidmOAuth2Client {
+    const OPERATOR_NAME: &'static str = OAUTH2_OPERATOR_NAME;
+    fn managed_object_name(&self) -> String {
+        self.secret_name()
+    }
+    fn metadata_template(&self) -> Option<&MetadataTemplate> {
+        self.spec.secret_template.as_ref()
+    }
+}

--- a/libs/oauth2/src/reconcile/status.rs
+++ b/libs/oauth2/src/reconcile/status.rs
@@ -10,6 +10,7 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_k8s_util::rotation::needs_rotation as rotation_check;
 use kaniop_k8s_util::types::{compare_urls, get_first_as_bool, get_first_cloned, normalize_url};
 use kaniop_operator::controller::kanidm::KanidmResource;
+use kaniop_operator::object_meta_template::ObjectMetaTemplateExt;
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -45,6 +46,7 @@ pub const TYPE_PREFER_SHORT_NAME_UPDATED: &str = "PreferShortNameUpdated";
 pub const TYPE_ALLOW_LOCALHOST_REDIRECT_UPDATED: &str = "AllowLocalhostRedirectUpdated";
 pub const TYPE_LEGACY_CRYPTO_UPDATED: &str = "LegacyCryptoUpdated";
 pub const TYPE_IMAGE_UPDATED: &str = "ImageUpdated";
+pub const TYPE_SECRET_TEMPLATE_SYNCED: &str = "SecretTemplateSynced";
 pub const CONDITION_TRUE: &str = "True";
 pub const CONDITION_FALSE: &str = "False";
 const REASON_ATTRIBUTE_MATCH: &str = "AttributeMatch";
@@ -100,7 +102,7 @@ impl StatusExt for KanidmOAuth2Client {
         let status = self.generate_status(
             current_oauth2,
             secret,
-            secret_meta.as_ref(),
+            secret_meta.as_deref(),
             current_image_status,
         )?;
         let status_patch = Patch::Apply(KanidmOAuth2Client {
@@ -133,7 +135,7 @@ impl KanidmOAuth2Client {
         &self,
         oauth2_opt: Option<Entry>,
         secret: Option<String>,
-        secret_meta: Option<&Arc<PartialObjectMeta<Secret>>>,
+        secret_meta: Option<&PartialObjectMeta<Secret>>,
         current_image_status: Option<OAuth2ClientImageStatus>,
     ) -> Result<KanidmOAuth2ClientStatus> {
         let now = Timestamp::now();
@@ -167,6 +169,45 @@ impl KanidmOAuth2Client {
                         message: "Secret does not exist.".to_string(),
                         last_transition_time: Time(now),
                         observed_generation: self.metadata.generation,
+                    })
+                };
+                // Emitted for confidential clients when the Secret exists and either a
+                // secretTemplate is configured or the template manager still owns fields that
+                // need a cleanup apply (i.e. template was removed or shrank but stale keys remain).
+                //
+                // When `secret_meta` is None (Secret not yet created), the condition is absent
+                // entirely. The template will be applied after the Secret is initialized on the
+                // next reconcile pass that sees TYPE_SECRET_INITIALIZED=True.
+                let secret_template_condition = if self.spec.public {
+                    None
+                } else {
+                    secret_meta.and_then(|meta| {
+                        let in_sync = self.needs_meta_template_apply(meta).is_none();
+                        // Suppress the condition only when no template is set AND no cleanup
+                        // is needed — avoids noise for resources that never used secretTemplate.
+                        if self.spec.secret_template.is_none() && in_sync {
+                            return None;
+                        }
+                        Some(if in_sync {
+                            Condition {
+                                type_: TYPE_SECRET_TEMPLATE_SYNCED.to_string(),
+                                status: CONDITION_TRUE.to_string(),
+                                reason: REASON_ATTRIBUTE_MATCH.to_string(),
+                                message: "Secret metadata matches secretTemplate.".to_string(),
+                                last_transition_time: Time(now),
+                                observed_generation: self.metadata.generation,
+                            }
+                        } else {
+                            Condition {
+                                type_: TYPE_SECRET_TEMPLATE_SYNCED.to_string(),
+                                status: CONDITION_FALSE.to_string(),
+                                reason: REASON_ATTRIBUTE_NOT_MATCH.to_string(),
+                                message: "Secret metadata does not match secretTemplate."
+                                    .to_string(),
+                                last_transition_time: Time(now),
+                                observed_generation: self.metadata.generation,
+                            }
+                        })
                     })
                 };
                 // Check if secret rotation is needed (only for confidential clients with rotation enabled)
@@ -528,6 +569,7 @@ impl KanidmOAuth2Client {
                 vec![exist_condition, updated_condition, redirect_url_condition]
                     .into_iter()
                     .chain(secret_initialized_condition)
+                    .chain(secret_template_condition)
                     .chain(secret_rotated_condition)
                     .chain(scope_map_condition)
                     .chain(sup_scope_map_condition)

--- a/libs/operator/src/crd.rs
+++ b/libs/operator/src/crd.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use kaniop_k8s_util::types::get_first_cloned;
 
 use kanidm_proto::{
@@ -56,6 +58,28 @@ pub fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     {
         value == &T::default()
     }
+}
+
+/// Template for metadata that may be attached to objects managed by the operator.
+/// Inspired by cert-manager's Certificate `secretTemplate` field.
+///
+/// Allows attaching custom annotations and labels to operator-managed objects. The operator's own
+/// labels and annotations take precedence over any conflicting keys in the template. Changes to
+/// this template are enforced on the next reconciliation, overwriting any manual modifications
+/// made to the object.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataTemplate {
+    /// Annotations to add to the object. The operator's own annotations take precedence over
+    /// any keys specified here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
+
+    /// Labels to add to the object. The operator's own labels take precedence over any keys
+    /// specified here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BTreeMap<String, String>>,
 }
 
 /// KanidmRef is a reference to a Kanidm object in the same cluster. It is used to specify where

--- a/libs/operator/src/lib.rs
+++ b/libs/operator/src/lib.rs
@@ -2,6 +2,7 @@ pub mod controller;
 pub mod crd;
 pub mod kanidm;
 pub mod metrics;
+pub mod object_meta_template;
 pub mod prometheus_exporter;
 pub mod telemetry;
 pub mod version;

--- a/libs/operator/src/object_meta_template.rs
+++ b/libs/operator/src/object_meta_template.rs
@@ -120,10 +120,6 @@ fn split_owned(
     (kept, discarded)
 }
 
-// ---------------------------------------------------------------------------
-// ObjectMetaTemplateExt – template application trait
-// ---------------------------------------------------------------------------
-
 /// Implemented by operator resources that manage a child Kubernetes object whose metadata
 /// (labels and annotations) can be customized via a [`MetadataTemplate`].
 ///
@@ -567,6 +563,197 @@ mod tests {
         assert!(filtered.annotations.is_empty());
         assert!(!filtered.has_discards());
     }
+
+    #[test]
+    fn test_filter_owned_both_fields_none() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: ["app.kubernetes.io/name".to_string()].into(),
+            annotations: ["kaniop.rs/managed".to_string()].into(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: None,
+            annotations: None,
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert!(filtered.labels.is_empty());
+        assert!(filtered.annotations.is_empty());
+        assert!(!filtered.has_discards());
+    }
+
+    #[test]
+    fn test_filter_owned_all_keys_conflict() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: [
+                "app.kubernetes.io/name".to_string(),
+                "app.kubernetes.io/instance".to_string(),
+            ]
+            .into(),
+            annotations: ["kaniop.rs/managed".to_string()].into(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/name".to_string(),
+                    "user-name".to_string(),
+                ),
+                (
+                    "app.kubernetes.io/instance".to_string(),
+                    "user-instance".to_string(),
+                ),
+            ])),
+            annotations: Some(BTreeMap::from([(
+                "kaniop.rs/managed".to_string(),
+                "user-val".to_string(),
+            )])),
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert!(filtered.labels.is_empty(), "all labels should be discarded");
+        assert!(
+            filtered.annotations.is_empty(),
+            "all annotations should be discarded"
+        );
+        assert!(filtered.has_discards());
+        assert_eq!(
+            filtered.discarded_labels,
+            BTreeSet::from([
+                "app.kubernetes.io/name".to_string(),
+                "app.kubernetes.io/instance".to_string()
+            ])
+        );
+        assert_eq!(
+            filtered.discarded_annotations,
+            BTreeSet::from(["kaniop.rs/managed".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_has_discards_only_labels_discarded() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: ["app.kubernetes.io/name".to_string()].into(),
+            annotations: BTreeSet::new(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "app.kubernetes.io/name".to_string(),
+                "val".to_string(),
+            )])),
+            annotations: Some(BTreeMap::from([(
+                "example.com/note".to_string(),
+                "kept".to_string(),
+            )])),
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert!(filtered.discarded_labels.contains("app.kubernetes.io/name"));
+        assert!(filtered.discarded_annotations.is_empty());
+        assert!(
+            filtered.has_discards(),
+            "should have discards (labels only)"
+        );
+    }
+
+    #[test]
+    fn test_has_discards_only_annotations_discarded() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: BTreeSet::new(),
+            annotations: ["kaniop.rs/managed".to_string()].into(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/custom".to_string(),
+                "kept".to_string(),
+            )])),
+            annotations: Some(BTreeMap::from([(
+                "kaniop.rs/managed".to_string(),
+                "val".to_string(),
+            )])),
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert!(filtered.discarded_labels.is_empty());
+        assert!(filtered.discarded_annotations.contains("kaniop.rs/managed"));
+        assert!(
+            filtered.has_discards(),
+            "should have discards (annotations only)"
+        );
+    }
+
+    /// `build_object_metadata` produces `None` for empty maps and `Some` for non-empty.
+    #[test]
+    fn test_build_object_metadata_non_empty() {
+        let labels = BTreeMap::from([("example.com/env".to_string(), "prod".to_string())]);
+        let annotations =
+            BTreeMap::from([("example.com/team".to_string(), "platform".to_string())]);
+        let obj: Secret = build_object_metadata(
+            "my-secret".to_string(),
+            "default".to_string(),
+            labels.clone(),
+            annotations.clone(),
+        );
+        assert_eq!(obj.metadata.name.as_deref(), Some("my-secret"));
+        assert_eq!(obj.metadata.namespace.as_deref(), Some("default"));
+        assert_eq!(obj.metadata.labels.as_ref(), Some(&labels));
+        assert_eq!(obj.metadata.annotations.as_ref(), Some(&annotations));
+    }
+
+    #[test]
+    fn test_build_object_metadata_empty_maps_produce_none() {
+        let obj: Secret = build_object_metadata(
+            "my-secret".to_string(),
+            "default".to_string(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        assert!(
+            obj.metadata.labels.is_none(),
+            "empty labels should produce None"
+        );
+        assert!(
+            obj.metadata.annotations.is_none(),
+            "empty annotations should produce None"
+        );
+    }
+
+    #[test]
+    fn test_build_object_metadata_labels_only() {
+        let labels = BTreeMap::from([("example.com/env".to_string(), "prod".to_string())]);
+        let obj: Secret = build_object_metadata(
+            "my-secret".to_string(),
+            "default".to_string(),
+            labels.clone(),
+            BTreeMap::new(),
+        );
+        assert_eq!(obj.metadata.labels.as_ref(), Some(&labels));
+        assert!(obj.metadata.annotations.is_none());
+    }
+
+    #[test]
+    fn test_build_object_metadata_annotations_only() {
+        let annotations =
+            BTreeMap::from([("example.com/team".to_string(), "platform".to_string())]);
+        let obj: Secret = build_object_metadata(
+            "my-secret".to_string(),
+            "default".to_string(),
+            BTreeMap::new(),
+            annotations.clone(),
+        );
+        assert!(obj.metadata.labels.is_none());
+        assert_eq!(obj.metadata.annotations.as_ref(), Some(&annotations));
+    }
 }
 
 #[cfg(test)]
@@ -856,5 +1043,85 @@ mod needs_meta_template_apply_tests {
             ..Default::default()
         };
         assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+
+    #[test]
+    fn test_out_of_sync_annotation_value_mismatch() {
+        // Exercises the annotation branch of the value_mismatch closure separately.
+        let owner = owner(Some(MetadataTemplate {
+            labels: None,
+            annotations: Some(BTreeMap::from([(
+                "example.com/team".to_string(),
+                "platform".to_string(),
+            )])),
+        }));
+        // Annotation key present but with the wrong value.
+        let live = secret_meta(
+            BTreeMap::new(),
+            BTreeMap::from([("example.com/team".to_string(), "other-team".to_string())]),
+            &[],
+            &["example.com/team"],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_out_of_sync_label_key_absent_from_live() {
+        // Key is not present at all in the live object's labels (not just wrong value).
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: None,
+        }));
+        // Live has no labels at all; template manager owns the key (preventing a stale-key
+        // misdiagnosis), but the value is missing.
+        let live = secret_meta(BTreeMap::new(), BTreeMap::new(), &["example.com/env"], &[]);
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_in_sync_empty_template_no_stale_fields() {
+        // `secretTemplate: {}` — Some but with neither labels nor annotations set.
+        // Template manager owns nothing → in sync, no apply needed.
+        let owner = owner(Some(MetadataTemplate {
+            labels: None,
+            annotations: None,
+        }));
+        let live: PartialObjectMeta<Secret> = PartialObjectMeta::default();
+        assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+
+    #[test]
+    fn test_out_of_sync_empty_template_stale_fields_remain() {
+        // `secretTemplate: {}` but the template manager still owns a stale label from a
+        // previous (larger) template → cleanup apply needed.
+        let owner = owner(Some(MetadataTemplate {
+            labels: None,
+            annotations: None,
+        }));
+        let live = secret_meta(
+            BTreeMap::new(),
+            BTreeMap::new(),
+            &["example.com/stale"],
+            &[],
+        );
+        let result = owner.needs_meta_template_apply(&live);
+        assert!(result.is_some());
+        let filtered = result.unwrap();
+        // The filtered result must be empty (nothing to apply — SSA will release ownership).
+        assert!(filtered.labels.is_empty());
+        assert!(filtered.annotations.is_empty());
+        assert!(!filtered.has_discards());
+    }
+
+    #[test]
+    fn test_in_sync_template_operator_name_prefix() {
+        // template_operator_name() must prepend "template." to OPERATOR_NAME.
+        assert_eq!(
+            TestOwner::template_operator_name(),
+            "template.test-operator"
+        );
     }
 }

--- a/libs/operator/src/object_meta_template.rs
+++ b/libs/operator/src/object_meta_template.rs
@@ -1,0 +1,860 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use k8s_openapi::NamespaceResourceScope;
+use kaniop_k8s_util::error::Result;
+use kube::{
+    Client, Resource, ResourceExt,
+    api::{ObjectMeta, PartialObjectMeta},
+    runtime::reflector::Lookup,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    controller::context::KubeOperations, crd::MetadataTemplate, metrics::ControllerMetrics,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ManagedMetadataKeys {
+    pub annotations: BTreeSet<String>,
+    pub labels: BTreeSet<String>,
+}
+
+/// Extracts the metadata keys owned by `manager` from the managed-fields list of `meta`.
+/// Only entries with `operation = "Apply"` and no subresource are considered.
+fn managed_metadata_keys<K>(meta: &PartialObjectMeta<K>, manager: &str) -> ManagedMetadataKeys {
+    let mut keys = ManagedMetadataKeys::default();
+
+    let Some(managed_fields) = meta.metadata.managed_fields.as_ref() else {
+        return keys;
+    };
+
+    for entry in managed_fields.iter().filter(|f| {
+        f.operation.as_deref() == Some("Apply")
+            && f.subresource.is_none()
+            && f.manager.as_deref() == Some(manager)
+    }) {
+        let Some(field_meta) = entry
+            .fields_v1
+            .as_ref()
+            .and_then(|f| f.0.as_object())
+            .and_then(|o| o.get("f:metadata"))
+            .and_then(|m| m.as_object())
+        else {
+            continue;
+        };
+
+        if let Some(labels) = field_meta.get("f:labels").and_then(|l| l.as_object()) {
+            for k in labels.keys() {
+                if let Some(stripped) = k.strip_prefix("f:").filter(|&c| c != ".") {
+                    keys.labels.insert(stripped.to_string());
+                }
+            }
+        }
+        if let Some(annotations) = field_meta.get("f:annotations").and_then(|a| a.as_object()) {
+            for k in annotations.keys() {
+                if let Some(stripped) = k.strip_prefix("f:").filter(|&c| c != ".") {
+                    keys.annotations.insert(stripped.to_string());
+                }
+            }
+        }
+    }
+
+    keys
+}
+
+/// Result of filtering a [`MetadataTemplate`] against the set of fields already owned by the
+/// main operator manager. Labels and annotations that would conflict are separated out so callers
+/// can apply the safe subset and surface the discarded keys in logs or events.
+#[derive(Default)]
+pub struct FilteredMetadata {
+    pub labels: BTreeMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
+    /// Label keys from the template that were discarded because the main operator already owns them.
+    pub discarded_labels: BTreeSet<String>,
+    /// Annotation keys from the template that were discarded because the main operator already owns them.
+    pub discarded_annotations: BTreeSet<String>,
+}
+
+impl FilteredMetadata {
+    pub fn has_discards(&self) -> bool {
+        !self.discarded_labels.is_empty() || !self.discarded_annotations.is_empty()
+    }
+}
+
+impl MetadataTemplate {
+    /// Returns the labels and annotations that are safe to apply — i.e. those not already owned
+    /// by the main operator manager — alongside any keys that were discarded due to conflicts.
+    fn filter_owned(&self, owned: &ManagedMetadataKeys) -> FilteredMetadata {
+        let (labels, discarded_labels) = split_owned(self.labels.as_ref(), &owned.labels);
+        let (annotations, discarded_annotations) =
+            split_owned(self.annotations.as_ref(), &owned.annotations);
+        FilteredMetadata {
+            labels,
+            annotations,
+            discarded_labels,
+            discarded_annotations,
+        }
+    }
+}
+
+/// Partitions `source` into keys the template manager may own (not in `owned`) and keys it
+/// may not (already claimed by the main manager). Returns `(kept, discarded)`.
+fn split_owned(
+    source: Option<&BTreeMap<String, String>>,
+    owned: &BTreeSet<String>,
+) -> (BTreeMap<String, String>, BTreeSet<String>) {
+    let Some(m) = source else {
+        return Default::default();
+    };
+    let mut kept = BTreeMap::new();
+    let mut discarded = BTreeSet::new();
+    for (k, v) in m {
+        if owned.contains(k) {
+            discarded.insert(k.clone());
+        } else {
+            kept.insert(k.clone(), v.clone());
+        }
+    }
+    (kept, discarded)
+}
+
+// ---------------------------------------------------------------------------
+// ObjectMetaTemplateExt – template application trait
+// ---------------------------------------------------------------------------
+
+/// Implemented by operator resources that manage a child Kubernetes object whose metadata
+/// (labels and annotations) can be customized via a [`MetadataTemplate`].
+///
+/// Generic over `K` so the same mechanism can serve any resource type that has `ObjectMeta`
+/// (Secret, ConfigMap, …). The default implementations of [`needs_meta_template_apply`] and
+/// [`apply_meta_template`] cover the common SSA cleanup/apply flow; implementors only need to
+/// supply the three required methods.
+pub trait ObjectMetaTemplateExt<K>
+where
+    Self: KubeOperations<Self, K> + ResourceExt + Clone + 'static,
+    <Self as Lookup>::DynamicType: Eq + Hash + Clone,
+    K: Resource<Scope = NamespaceResourceScope>
+        + Default
+        + Clone
+        + Debug
+        + Serialize
+        + for<'de> Deserialize<'de>,
+    <K as Resource>::DynamicType: Default,
+{
+    /// The SSA field-manager name used for the main operator apply.
+    const OPERATOR_NAME: &'static str;
+    /// Name of the managed child object.
+    fn managed_object_name(&self) -> String;
+    /// Template supplying extra labels/annotations, if configured.
+    fn metadata_template(&self) -> Option<&MetadataTemplate>;
+
+    /// Name of the SSA field manager used for template-owned metadata fields.
+    fn template_operator_name() -> String {
+        format!("template.{}", Self::OPERATOR_NAME)
+    }
+
+    /// Checks whether the live object's metadata matches the desired template state and, if not,
+    /// returns the pre-filtered [`FilteredMetadata`] ready to pass to [`apply_meta_template`].
+    ///
+    /// Reads the managed-fields list for both the main operator and the template manager,
+    /// covering all three out-of-sync cases:
+    /// - A desired key is missing or has the wrong value.
+    /// - The desired template is empty but the template manager still owns fields (template removed).
+    /// - The desired template shrank and the template manager owns stale keys.
+    fn needs_meta_template_apply(&self, live: &PartialObjectMeta<K>) -> Option<FilteredMetadata> {
+        let main_keys = managed_metadata_keys(live, Self::OPERATOR_NAME);
+        let template_keys = managed_metadata_keys(live, &Self::template_operator_name());
+        let filtered = self
+            .metadata_template()
+            .map(|t| t.filter_owned(&main_keys))
+            .unwrap_or_default();
+
+        let value_mismatch =
+            |desired: &BTreeMap<String, String>, actual: Option<&BTreeMap<String, String>>| {
+                desired
+                    .iter()
+                    .any(|(k, v)| actual.and_then(|m| m.get(k)) != Some(v))
+            };
+        if value_mismatch(&filtered.labels, live.metadata.labels.as_ref())
+            || value_mismatch(&filtered.annotations, live.metadata.annotations.as_ref())
+        {
+            return Some(filtered);
+        }
+
+        if filtered.labels.is_empty() && filtered.annotations.is_empty() {
+            // No desired fields: in sync only if the template manager owns nothing.
+            if template_keys.labels.is_empty() && template_keys.annotations.is_empty() {
+                return None;
+            }
+            return Some(filtered);
+        }
+
+        // Desired fields non-empty: also verify the template manager owns *exactly* the desired
+        // keys — no stale extras left over from a previously larger template.
+        let desired_labels: BTreeSet<String> = filtered.labels.keys().cloned().collect();
+        let desired_annotations: BTreeSet<String> = filtered.annotations.keys().cloned().collect();
+        if template_keys.labels == desired_labels
+            && template_keys.annotations == desired_annotations
+        {
+            None
+        } else {
+            Some(filtered)
+        }
+    }
+
+    /// Applies `filtered` to the managed child object using the template SSA field manager.
+    ///
+    /// Passing an empty [`FilteredMetadata`] (no labels, no annotations) causes SSA to release any
+    /// previously template-owned keys. Obtain `filtered` from [`needs_meta_template_apply`].
+    /// Callers are responsible for surfacing any discarded keys (see [`FilteredMetadata::has_discards`]).
+    #[allow(async_fn_in_trait)]
+    async fn apply_meta_template(
+        &self,
+        client: Client,
+        metrics: &ControllerMetrics,
+        filtered: FilteredMetadata,
+    ) -> Result<K> {
+        // safe unwrap: implementor is namespaced
+        let namespace = self.namespace().unwrap();
+
+        let obj = build_object_metadata(
+            self.managed_object_name(),
+            namespace,
+            filtered.labels,
+            filtered.annotations,
+        );
+        self.kube_patch(client, metrics, obj, &Self::template_operator_name())
+            .await
+    }
+}
+
+/// Builds an object containing only pre-filtered template metadata for SSA via the template
+/// manager. Passing empty maps causes SSA to release any previously template-owned keys.
+fn build_object_metadata<K: Resource + Default>(
+    name: String,
+    namespace: String,
+    labels: BTreeMap<String, String>,
+    annotations: BTreeMap<String, String>,
+) -> K {
+    let mut obj = K::default();
+    *obj.meta_mut() = ObjectMeta {
+        name: Some(name),
+        namespace: Some(namespace),
+        labels: if labels.is_empty() {
+            None
+        } else {
+            Some(labels)
+        },
+        annotations: if annotations.is_empty() {
+            None
+        } else {
+            Some(annotations)
+        },
+        ..ObjectMeta::default()
+    };
+    obj
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use k8s_openapi::api::core::v1::Secret;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
+        FieldsV1, ManagedFieldsEntry, ObjectMeta,
+    };
+    use serde_json::json;
+
+    fn meta_with_managed_fields(
+        manager: &str,
+        operation: &str,
+        subresource: Option<&str>,
+        fields: serde_json::Value,
+    ) -> PartialObjectMeta<Secret> {
+        PartialObjectMeta {
+            metadata: ObjectMeta {
+                managed_fields: Some(vec![ManagedFieldsEntry {
+                    manager: Some(manager.to_string()),
+                    operation: Some(operation.to_string()),
+                    subresource: subresource.map(str::to_string),
+                    fields_v1: Some(FieldsV1(fields)),
+                    fields_type: Some("FieldsV1".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_extracts_label_keys() {
+        let fields = json!({
+            "f:metadata": {
+                "f:labels": {
+                    ".": {},
+                    "f:app.kubernetes.io/name": {},
+                    "f:example.com/foo": {},
+                }
+            }
+        });
+        let meta = meta_with_managed_fields("test-manager", "Apply", None, fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(keys.labels.contains("app.kubernetes.io/name"));
+        assert!(keys.labels.contains("example.com/foo"));
+        assert!(
+            !keys.labels.contains("."),
+            "existence marker must be filtered out"
+        );
+        assert!(keys.annotations.is_empty());
+    }
+
+    #[test]
+    fn test_extracts_annotation_keys() {
+        let fields = json!({
+            "f:metadata": {
+                "f:annotations": {
+                    ".": {},
+                    "f:kaniop.rs/rotation-enabled": {},
+                    "f:example.com/note": {},
+                }
+            }
+        });
+        let meta = meta_with_managed_fields("test-manager", "Apply", None, fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(keys.annotations.contains("kaniop.rs/rotation-enabled"));
+        assert!(keys.annotations.contains("example.com/note"));
+        assert!(keys.labels.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_wrong_manager() {
+        let fields = json!({ "f:metadata": { "f:labels": { "f:example.com/foo": {} } } });
+        let meta = meta_with_managed_fields("other-manager", "Apply", None, fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(
+            keys.labels.is_empty(),
+            "keys from a different manager must not be returned"
+        );
+    }
+
+    #[test]
+    fn test_ignores_update_operation() {
+        let fields = json!({ "f:metadata": { "f:labels": { "f:example.com/foo": {} } } });
+        // "Update" operation entries must not be considered for SSA staleness checks.
+        let meta = meta_with_managed_fields("test-manager", "Update", None, fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(
+            keys.labels.is_empty(),
+            "Update-operation entries must not be returned"
+        );
+    }
+
+    #[test]
+    fn test_ignores_subresource_entry() {
+        let fields = json!({ "f:metadata": { "f:labels": { "f:example.com/foo": {} } } });
+        // e.g. a status subresource entry must not be included.
+        let meta = meta_with_managed_fields("test-manager", "Apply", Some("status"), fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(
+            keys.labels.is_empty(),
+            "subresource entries must not be returned"
+        );
+    }
+
+    #[test]
+    fn test_no_metadata_fields_returns_none() {
+        // The manager owns only data fields, not metadata labels or annotations.
+        let fields = json!({ "f:data": { ".": {}, "f:CLIENT_ID": {}, "f:CLIENT_SECRET": {} } });
+        let meta = meta_with_managed_fields("test-manager", "Apply", None, fields);
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(keys.labels.is_empty());
+        assert!(keys.annotations.is_empty());
+    }
+
+    #[test]
+    fn test_no_managed_fields_returns_none() {
+        let meta: PartialObjectMeta<Secret> = PartialObjectMeta::default();
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(keys.labels.is_empty());
+        assert!(keys.annotations.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_entries_for_same_manager_are_accumulated() {
+        // The same manager can appear more than once in managed_fields when separate Apply
+        // operations owned different subsets of fields (e.g. labels in one apply, annotations
+        // in a later apply). All entries must be accumulated into a single result.
+        let meta: PartialObjectMeta<Secret> = PartialObjectMeta {
+            metadata: ObjectMeta {
+                managed_fields: Some(vec![
+                    ManagedFieldsEntry {
+                        manager: Some("test-manager".to_string()),
+                        operation: Some("Apply".to_string()),
+                        subresource: None,
+                        fields_v1: Some(FieldsV1(json!({
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                }
+                            }
+                        }))),
+                        fields_type: Some("FieldsV1".to_string()),
+                        ..Default::default()
+                    },
+                    ManagedFieldsEntry {
+                        manager: Some("test-manager".to_string()),
+                        operation: Some("Apply".to_string()),
+                        subresource: None,
+                        fields_v1: Some(FieldsV1(json!({
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:example.com/note": {},
+                                }
+                            }
+                        }))),
+                        fields_type: Some("FieldsV1".to_string()),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let keys = managed_metadata_keys(&meta, "test-manager");
+        assert!(
+            keys.labels.contains("app.kubernetes.io/name"),
+            "label from first entry must be present"
+        );
+        assert!(
+            keys.annotations.contains("example.com/note"),
+            "annotation from second entry must be present"
+        );
+    }
+
+    #[test]
+    fn test_extracts_keys_for_each_manager_independently() {
+        let meta: PartialObjectMeta<Secret> = PartialObjectMeta {
+            metadata: ObjectMeta {
+                managed_fields: Some(vec![
+                    ManagedFieldsEntry {
+                        manager: Some("operator".to_string()),
+                        operation: Some("Apply".to_string()),
+                        subresource: None,
+                        fields_v1: Some(FieldsV1(json!({
+                            "f:metadata": {
+                                "f:labels": { ".": {}, "f:app.kubernetes.io/name": {} }
+                            }
+                        }))),
+                        fields_type: Some("FieldsV1".to_string()),
+                        ..Default::default()
+                    },
+                    ManagedFieldsEntry {
+                        manager: Some("template.operator".to_string()),
+                        operation: Some("Apply".to_string()),
+                        subresource: None,
+                        fields_v1: Some(FieldsV1(json!({
+                            "f:metadata": {
+                                "f:labels": { ".": {}, "f:example.com/custom": {} },
+                                "f:annotations": { ".": {}, "f:example.com/note": {} },
+                            }
+                        }))),
+                        fields_type: Some("FieldsV1".to_string()),
+                        ..Default::default()
+                    },
+                    // unrelated manager — must not appear in either result
+                    ManagedFieldsEntry {
+                        manager: Some("other".to_string()),
+                        operation: Some("Apply".to_string()),
+                        subresource: None,
+                        fields_v1: Some(FieldsV1(json!({
+                            "f:metadata": { "f:labels": { "f:other.io/x": {} } }
+                        }))),
+                        fields_type: Some("FieldsV1".to_string()),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let main_keys = managed_metadata_keys(&meta, "operator");
+        let tmpl_keys = managed_metadata_keys(&meta, "template.operator");
+
+        assert!(main_keys.labels.contains("app.kubernetes.io/name"));
+        assert!(main_keys.annotations.is_empty());
+        assert!(
+            !main_keys.labels.contains("example.com/custom"),
+            "template key must not appear in main_keys"
+        );
+
+        assert!(tmpl_keys.labels.contains("example.com/custom"));
+        assert!(tmpl_keys.annotations.contains("example.com/note"));
+        assert!(
+            !tmpl_keys.labels.contains("app.kubernetes.io/name"),
+            "main key must not appear in tmpl_keys"
+        );
+        assert!(
+            !tmpl_keys.labels.contains("other.io/x"),
+            "unrelated manager key must not appear"
+        );
+    }
+
+    #[test]
+    fn test_filter_owned_removes_conflicting_keys() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: ["app.kubernetes.io/name".to_string()].into(),
+            annotations: ["kaniop.rs/managed".to_string()].into(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: Some(BTreeMap::from([
+                (
+                    "app.kubernetes.io/name".to_string(),
+                    "user-value".to_string(),
+                ),
+                ("example.com/custom".to_string(), "ok".to_string()),
+            ])),
+            annotations: Some(BTreeMap::from([
+                ("kaniop.rs/managed".to_string(), "ignored".to_string()),
+                ("example.com/note".to_string(), "kept".to_string()),
+            ])),
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert!(!filtered.labels.contains_key("app.kubernetes.io/name"));
+        assert_eq!(filtered.labels["example.com/custom"], "ok");
+        assert!(!filtered.annotations.contains_key("kaniop.rs/managed"));
+        assert_eq!(filtered.annotations["example.com/note"], "kept");
+
+        assert_eq!(
+            filtered.discarded_labels,
+            BTreeSet::from(["app.kubernetes.io/name".to_string()])
+        );
+        assert_eq!(
+            filtered.discarded_annotations,
+            BTreeSet::from(["kaniop.rs/managed".to_string()])
+        );
+        assert!(filtered.has_discards());
+    }
+
+    #[test]
+    fn test_filter_owned_no_conflicts() {
+        use crate::crd::MetadataTemplate;
+
+        let owned = ManagedMetadataKeys {
+            labels: ["app.kubernetes.io/name".to_string()].into(),
+            annotations: BTreeSet::new(),
+        };
+        let tmpl = MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/custom".to_string(),
+                "val".to_string(),
+            )])),
+            annotations: None,
+        };
+
+        let filtered = tmpl.filter_owned(&owned);
+
+        assert_eq!(filtered.labels["example.com/custom"], "val");
+        assert!(filtered.annotations.is_empty());
+        assert!(!filtered.has_discards());
+    }
+}
+
+#[cfg(test)]
+mod needs_meta_template_apply_tests {
+    use super::*;
+    use crate::crd::MetadataTemplate;
+
+    use k8s_openapi::NamespaceResourceScope;
+    use k8s_openapi::api::core::v1::Secret;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
+        FieldsV1, ManagedFieldsEntry, ObjectMeta,
+    };
+    use kube::Resource;
+    use kube::api::PartialObjectMeta;
+    use serde_json::json;
+    use std::borrow::Cow;
+
+    /// Minimal parent resource for testing [`ObjectMetaTemplateExt::needs_meta_template_apply`]
+    /// without pulling in a full CRD type.
+    #[derive(Clone, Default)]
+    struct TestOwner {
+        metadata: ObjectMeta,
+        template: Option<MetadataTemplate>,
+    }
+
+    impl Resource for TestOwner {
+        type DynamicType = ();
+        type Scope = NamespaceResourceScope;
+
+        fn kind(_: &()) -> Cow<'_, str> {
+            "TestOwner".into()
+        }
+        fn group(_: &()) -> Cow<'_, str> {
+            "test.rs".into()
+        }
+        fn version(_: &()) -> Cow<'_, str> {
+            "v1".into()
+        }
+        fn plural(_: &()) -> Cow<'_, str> {
+            "testowners".into()
+        }
+        fn meta(&self) -> &ObjectMeta {
+            &self.metadata
+        }
+        fn meta_mut(&mut self) -> &mut ObjectMeta {
+            &mut self.metadata
+        }
+    }
+
+    impl ObjectMetaTemplateExt<Secret> for TestOwner {
+        const OPERATOR_NAME: &'static str = "test-operator";
+        fn managed_object_name(&self) -> String {
+            "test-secret".to_string()
+        }
+        fn metadata_template(&self) -> Option<&MetadataTemplate> {
+            self.template.as_ref()
+        }
+    }
+
+    fn owner(template: Option<MetadataTemplate>) -> TestOwner {
+        TestOwner {
+            metadata: ObjectMeta {
+                name: Some("my-resource".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            template,
+        }
+    }
+
+    /// Build a `PartialObjectMeta<Secret>` with both actual metadata and managed-field entries
+    /// for the template manager (`template.test-operator`).
+    fn secret_meta(
+        labels: BTreeMap<String, String>,
+        annotations: BTreeMap<String, String>,
+        template_label_keys: &[&str],
+        template_annotation_keys: &[&str],
+    ) -> PartialObjectMeta<Secret> {
+        let mut managed_fields = vec![];
+
+        if !template_label_keys.is_empty() || !template_annotation_keys.is_empty() {
+            let mut meta_fields = serde_json::Map::new();
+
+            if !template_label_keys.is_empty() {
+                let mut lf = serde_json::Map::new();
+                lf.insert(".".to_string(), json!({}));
+                for k in template_label_keys {
+                    lf.insert(format!("f:{k}"), json!({}));
+                }
+                meta_fields.insert("f:labels".to_string(), json!(lf));
+            }
+
+            if !template_annotation_keys.is_empty() {
+                let mut af = serde_json::Map::new();
+                af.insert(".".to_string(), json!({}));
+                for k in template_annotation_keys {
+                    af.insert(format!("f:{k}"), json!({}));
+                }
+                meta_fields.insert("f:annotations".to_string(), json!(af));
+            }
+
+            managed_fields.push(ManagedFieldsEntry {
+                manager: Some("template.test-operator".to_string()),
+                operation: Some("Apply".to_string()),
+                subresource: None,
+                fields_v1: Some(FieldsV1(json!({ "f:metadata": meta_fields }))),
+                fields_type: Some("FieldsV1".to_string()),
+                ..Default::default()
+            });
+        }
+
+        PartialObjectMeta {
+            metadata: ObjectMeta {
+                labels: if labels.is_empty() {
+                    None
+                } else {
+                    Some(labels)
+                },
+                annotations: if annotations.is_empty() {
+                    None
+                } else {
+                    Some(annotations)
+                },
+                managed_fields: if managed_fields.is_empty() {
+                    None
+                } else {
+                    Some(managed_fields)
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_in_sync_no_template_no_stale_fields() {
+        let owner = owner(None);
+        let live: PartialObjectMeta<Secret> = PartialObjectMeta::default();
+        assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+
+    #[test]
+    fn test_out_of_sync_no_template_stale_fields_remain() {
+        // Template was removed but the template manager still owns fields → cleanup apply needed.
+        let owner = owner(None);
+        let live = secret_meta(
+            BTreeMap::new(),
+            BTreeMap::new(),
+            &["example.com/stale"],
+            &[],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_in_sync_template_all_keys_present_and_owned() {
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: None,
+        }));
+        let live = secret_meta(
+            BTreeMap::from([("example.com/env".to_string(), "prod".to_string())]),
+            BTreeMap::new(),
+            &["example.com/env"],
+            &[],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+
+    #[test]
+    fn test_out_of_sync_value_mismatch() {
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: None,
+        }));
+        // Key is present but value differs.
+        let live = secret_meta(
+            BTreeMap::from([("example.com/env".to_string(), "staging".to_string())]),
+            BTreeMap::new(),
+            &["example.com/env"],
+            &[],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_out_of_sync_template_manager_owns_stale_extra_key() {
+        // Template shrank: manager still owns a key that is no longer desired.
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: None,
+        }));
+        let live = secret_meta(
+            BTreeMap::from([
+                ("example.com/env".to_string(), "prod".to_string()),
+                ("example.com/stale".to_string(), "old".to_string()),
+            ]),
+            BTreeMap::new(),
+            &["example.com/env", "example.com/stale"],
+            &[],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_out_of_sync_template_manager_missing_ownership() {
+        // Label present with correct value but template manager doesn't own it yet.
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: None,
+        }));
+        let live = secret_meta(
+            BTreeMap::from([("example.com/env".to_string(), "prod".to_string())]),
+            BTreeMap::new(),
+            &[], // no template manager managed fields
+            &[],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_some());
+    }
+
+    #[test]
+    fn test_in_sync_labels_and_annotations() {
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "example.com/env".to_string(),
+                "prod".to_string(),
+            )])),
+            annotations: Some(BTreeMap::from([(
+                "example.com/team".to_string(),
+                "platform".to_string(),
+            )])),
+        }));
+        let live = secret_meta(
+            BTreeMap::from([("example.com/env".to_string(), "prod".to_string())]),
+            BTreeMap::from([("example.com/team".to_string(), "platform".to_string())]),
+            &["example.com/env"],
+            &["example.com/team"],
+        );
+        assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+
+    #[test]
+    fn test_in_sync_all_template_keys_conflict_with_operator() {
+        // When every key in the template is already owned by the main operator, filter_owned
+        // discards them all. The filtered result is empty and the template manager owns nothing,
+        // so no apply is needed — the conflicting keys are silently dropped.
+        let owner = owner(Some(MetadataTemplate {
+            labels: Some(BTreeMap::from([(
+                "app.kubernetes.io/name".to_string(),
+                "user-value".to_string(),
+            )])),
+            annotations: None,
+        }));
+        // Main operator owns "app.kubernetes.io/name"; template manager owns nothing.
+        let live: PartialObjectMeta<Secret> = PartialObjectMeta {
+            metadata: ObjectMeta {
+                labels: Some(BTreeMap::from([(
+                    "app.kubernetes.io/name".to_string(),
+                    "operator-value".to_string(),
+                )])),
+                managed_fields: Some(vec![ManagedFieldsEntry {
+                    manager: Some("test-operator".to_string()),
+                    operation: Some("Apply".to_string()),
+                    subresource: None,
+                    fields_v1: Some(FieldsV1(json!({
+                        "f:metadata": {
+                            "f:labels": { ".": {}, "f:app.kubernetes.io/name": {} }
+                        }
+                    }))),
+                    fields_type: Some("FieldsV1".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(owner.needs_meta_template_apply(&live).is_none());
+    }
+}

--- a/tests/e2e/test/mod.rs
+++ b/tests/e2e/test/mod.rs
@@ -2,6 +2,7 @@ mod group;
 mod kanidm;
 mod kanidm_ref;
 mod oauth2;
+mod oauth2_secret_template;
 mod person;
 mod service_account;
 

--- a/tests/e2e/test/oauth2_secret_template.rs
+++ b/tests/e2e/test/oauth2_secret_template.rs
@@ -1,0 +1,1317 @@
+use super::{check_event_with_timeout, setup_kanidm_connection, wait_for};
+
+use kaniop_oauth2::crd::KanidmOAuth2Client;
+
+use std::ops::Not;
+
+use k8s_openapi::api::core::v1::{Event, Secret};
+use k8s_openapi::jiff::Timestamp;
+use kube::{
+    Api, ResourceExt,
+    api::{ListParams, Patch, PatchParams, PostParams},
+    runtime::wait::Condition,
+};
+use serde_json::json;
+
+const KANIDM_NAME: &str = "test-oauth2";
+const MAIN_MANAGER: &str = "kanidmoauth2clients.kaniop.rs";
+const TEMPLATE_MANAGER: &str = "template.kanidmoauth2clients.kaniop.rs";
+
+fn is_oauth2(cond: &str) -> impl Condition<KanidmOAuth2Client> + '_ {
+    move |obj: Option<&KanidmOAuth2Client>| {
+        obj.and_then(|o| o.status.as_ref())
+            .and_then(|s| s.conditions.as_ref())
+            .is_some_and(|conds| conds.iter().any(|c| c.type_ == cond && c.status == "True"))
+    }
+}
+
+fn is_oauth2_false(cond: &str) -> impl Condition<KanidmOAuth2Client> + '_ {
+    move |obj: Option<&KanidmOAuth2Client>| {
+        obj.and_then(|o| o.status.as_ref())
+            .and_then(|s| s.conditions.as_ref())
+            .is_some_and(|conds| conds.iter().any(|c| c.type_ == cond && c.status == "False"))
+    }
+}
+
+fn is_oauth2_ready() -> impl Condition<KanidmOAuth2Client> {
+    move |obj: Option<&KanidmOAuth2Client>| {
+        obj.and_then(|o| o.status.as_ref()).is_some_and(|s| s.ready)
+    }
+}
+
+/// Returns true once status.ready is true AND the named condition is absent from the conditions list.
+/// The ready check acts as a stabilization guard: it ensures the reconciler has committed its
+/// latest status update before we conclude the condition is absent.
+fn is_oauth2_condition_absent(cond: &str) -> impl Condition<KanidmOAuth2Client> + '_ {
+    move |obj: Option<&KanidmOAuth2Client>| {
+        let Some(oauth2) = obj else {
+            return false;
+        };
+        let Some(status) = &oauth2.status else {
+            return false;
+        };
+        if !status.ready {
+            return false;
+        }
+        status
+            .conditions
+            .as_ref()
+            .is_none_or(|conds| conds.iter().all(|c| c.type_ != cond))
+    }
+}
+
+// Basic application of template
+#[tokio::test]
+async fn oauth2_secret_template_labels() {
+    let name = "test-st-labels";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Labels Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/env": "test",
+                "example.com/team": "platform"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/env"),
+        Some(&"test".to_string()),
+        "template label example.com/env should be set"
+    );
+    assert_eq!(
+        labels.get("example.com/team"),
+        Some(&"platform".to_string()),
+        "template label example.com/team should be set"
+    );
+
+    // Operator-managed labels must still be present
+    assert!(
+        labels.contains_key("app.kubernetes.io/name"),
+        "operator name label must not be lost"
+    );
+    assert!(
+        labels.contains_key("app.kubernetes.io/instance"),
+        "operator instance label must not be lost"
+    );
+    assert!(
+        labels.contains_key("app.kubernetes.io/managed-by"),
+        "operator managed-by label must not be lost"
+    );
+
+    // status.secretName must be populated
+    let status = oauth2_api.get(name).await.unwrap().status.unwrap();
+    assert_eq!(
+        status.secret_name,
+        Some(secret_name),
+        "status.secretName should be populated"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_annotations() {
+    let name = "test-st-annotations";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Annotations Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "annotations": {
+                "example.com/owner": "platform-team",
+                "example.com/environment": "testing"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    let annotations = secret
+        .metadata
+        .annotations
+        .as_ref()
+        .expect("Secret should have annotations");
+    assert_eq!(
+        annotations.get("example.com/owner"),
+        Some(&"platform-team".to_string()),
+        "template annotation example.com/owner should be set"
+    );
+    assert_eq!(
+        annotations.get("example.com/environment"),
+        Some(&"testing".to_string()),
+        "template annotation example.com/environment should be set"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_labels_and_annotations() {
+    let name = "test-st-labels-annots";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Labels+Annotations Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/tier": "backend"
+            },
+            "annotations": {
+                "example.com/contact": "ops@example.com"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/tier"),
+        Some(&"backend".to_string()),
+        "template label example.com/tier should be set"
+    );
+
+    let annotations = secret
+        .metadata
+        .annotations
+        .as_ref()
+        .expect("Secret should have annotations");
+    assert_eq!(
+        annotations.get("example.com/contact"),
+        Some(&"ops@example.com".to_string()),
+        "template annotation example.com/contact should be set"
+    );
+}
+
+// Lifecycle changes after creation
+#[tokio::test]
+async fn oauth2_secret_template_add_after_creation() {
+    let name = "test-st-add-after";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // Create WITHOUT secretTemplate
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Add After Creation Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2_ready()).await;
+
+    // Assert SecretTemplateSynced is absent before the patch
+    let initial = oauth2_api.get(name).await.unwrap();
+    let initial_conditions = initial.status.as_ref().and_then(|s| s.conditions.as_ref());
+    assert!(
+        initial_conditions
+            .is_none_or(|conds| conds.iter().all(|c| c.type_ != "SecretTemplateSynced")),
+        "SecretTemplateSynced should be absent before secretTemplate is set"
+    );
+
+    // Patch to add secretTemplate.labels
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "spec": {
+                    "secretTemplate": {
+                        "labels": {
+                            "example.com/added-later": "yes"
+                        }
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // Condition should transition False → True
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/added-later"),
+        Some(&"yes".to_string()),
+        "label added via patch should appear on Secret"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_remove() {
+    let name = "test-st-remove";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Remove Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/to-be-removed": "value"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Remove secretTemplate entirely
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({"spec": {"secretTemplate": null}})),
+        )
+        .await
+        .unwrap();
+
+    // Wait for SecretTemplateSynced to become absent (via False → absent)
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_condition_absent("SecretTemplateSynced"),
+    )
+    .await;
+
+    // The previously applied labels must be gone
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret.metadata.labels.as_ref();
+    assert!(
+        labels.is_none_or(|l| !l.contains_key("example.com/to-be-removed")),
+        "previously applied template label should be removed from Secret after template removal"
+    );
+
+    // Operator-managed labels must remain
+    let labels = labels.expect("Secret should still have operator labels");
+    assert!(labels.contains_key("app.kubernetes.io/name"));
+    assert!(labels.contains_key("app.kubernetes.io/instance"));
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_update_value() {
+    let name = "test-st-update-val";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Update Value Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/env": "staging"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Update label value staging → prod
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "spec": {
+                    "secretTemplate": {
+                        "labels": {"example.com/env": "prod"}
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // True → False → True
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/env"),
+        Some(&"prod".to_string()),
+        "label value should be updated to prod"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_add_key() {
+    let name = "test-st-add-key";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Add Key Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/key-a": "val-a"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Add a second key
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "spec": {
+                    "secretTemplate": {
+                        "labels": {
+                            "example.com/key-a": "val-a",
+                            "example.com/key-b": "val-b"
+                        }
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // True → False → True
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/key-a"),
+        Some(&"val-a".to_string()),
+        "key-a should still be present"
+    );
+    assert_eq!(
+        labels.get("example.com/key-b"),
+        Some(&"val-b".to_string()),
+        "newly added key-b should be present"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_remove_key() {
+    let name = "test-st-remove-key";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Remove Key Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/key-a": "val-a",
+                "example.com/key-b": "val-b"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Remove key-b using a JSON merge patch with an explicit null — the same patch that
+    // client-side `kubectl apply` would compute from a 3-way merge when the desired manifest
+    // omits key-b but the last-applied config included it.
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "spec": {
+                    "secretTemplate": {
+                        "labels": {
+                            "example.com/key-b": null
+                        }
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // True → False → True
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/key-a"),
+        Some(&"val-a".to_string()),
+        "key-a should still be present"
+    );
+    assert!(
+        !labels.contains_key("example.com/key-b"),
+        "key-b should be absent after removal (SSA releases ownership)"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_reclaim() {
+    let name = "test-st-reclaim";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // Create with a secretTemplate annotation that would conflict with rotation,
+    // but WITHOUT rotation enabled — so the template manager owns the annotation.
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Reclaim Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "annotations": {
+                "kaniop.rs/rotation-enabled": "from-template"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Assert annotation owned by template manager with the template value
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let annotations = secret
+        .metadata
+        .annotations
+        .as_ref()
+        .expect("Secret should have annotations");
+    assert_eq!(
+        annotations.get("kaniop.rs/rotation-enabled"),
+        Some(&"from-template".to_string()),
+        "annotation should be set from secretTemplate when rotation is disabled"
+    );
+
+    // Enable rotation: the main operator re-applies the Secret with rotation annotations,
+    // taking SSA ownership of kaniop.rs/rotation-enabled. filter_owned then discards the
+    // conflicting template annotation; with nothing left to apply and nothing template-manager-
+    // owned, needs_meta_template_apply returns None → SecretTemplateSynced stays True.
+    //
+    // Wait for SecretRotated=True: this condition only appears once secretRotation.enabled=true
+    // has been processed, guaranteeing the Secret reflects the new rotation annotations.
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "spec": {
+                    "secretRotation": {
+                        "enabled": true,
+                        "periodDays": 90
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretRotated")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Main operator now owns the annotation with value "true"
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let annotations = secret
+        .metadata
+        .annotations
+        .as_ref()
+        .expect("Secret should have annotations");
+    assert_eq!(
+        annotations.get("kaniop.rs/rotation-enabled"),
+        Some(&"true".to_string()),
+        "annotation should be owned by main operator with value 'true' when rotation is enabled"
+    );
+    assert_ne!(
+        annotations.get("kaniop.rs/rotation-enabled"),
+        Some(&"from-template".to_string()),
+        "template value should not win against main operator"
+    );
+
+    // NOTE: the reverse direction — disabling rotation and having the template manager
+    // reclaim the annotation — is intentionally not tested here. When secretRotation is
+    // removed from the spec the operator does not re-apply the Secret to
+    // strip the rotation annotations; the Secret is only re-written on SecretInitialized=False
+    // or a rotation event. The rotation annotations therefore remain on the Secret under the
+    // main operator's SSA ownership until the next rotation cycle or a force-rotation.
+    // If reclaim-on-disable is desired it would require a new reconcile branch that detects
+    // stale rotation annotations (present on Secret, absent from spec) and triggers a re-apply.
+}
+
+// Conflict handling
+#[tokio::test]
+async fn oauth2_secret_template_conflict_partial() {
+    let name = "test-st-conflict-partial";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Conflict Partial Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                // Conflicting: operator already owns this label
+                "app.kubernetes.io/name": "my-custom-name",
+                // Non-conflicting: template manager may own this
+                "example.com/env": "production"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    let uid = oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap()
+        .uid()
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // A SecretTemplateConflict warning event must have been emitted
+    let event_api = Api::<Event>::namespaced(s.client.clone(), "default");
+    let opts = ListParams::default().fields(&format!(
+        "involvedObject.kind=KanidmOAuth2Client,involvedObject.apiVersion=kaniop.rs/v1beta1,involvedObject.uid={uid},reason=SecretTemplateConflict"
+    ));
+    check_event_with_timeout(&event_api, &opts).await;
+
+    let event_list = event_api.list(&opts).await.unwrap();
+    assert!(
+        event_list.items.is_empty().not(),
+        "SecretTemplateConflict event should be emitted"
+    );
+    let conflict_event = event_list.items.first().unwrap();
+    assert!(
+        conflict_event
+            .message
+            .as_deref()
+            .unwrap_or("")
+            .contains("app.kubernetes.io/name"),
+        "event message should name the conflicting label key"
+    );
+
+    // Non-conflicting key must be present on Secret
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/env"),
+        Some(&"production".to_string()),
+        "non-conflicting label must be present on Secret"
+    );
+
+    // Conflicting key must hold the operator's value, not the user's value
+    assert_ne!(
+        labels.get("app.kubernetes.io/name"),
+        Some(&"my-custom-name".to_string()),
+        "conflicting label must not take the user's value"
+    );
+    assert!(
+        labels.contains_key("app.kubernetes.io/name"),
+        "operator's name label must still be present"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_conflict_all_keys() {
+    let name = "test-st-conflict-all";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // Every key in the template conflicts with an operator-owned label
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Conflict All Keys Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "app.kubernetes.io/name": "conflict-name",
+                "app.kubernetes.io/instance": "conflict-instance",
+                "app.kubernetes.io/managed-by": "conflict-managed"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    let uid = oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap()
+        .uid()
+        .unwrap();
+
+    // SecretTemplateSynced=True immediately (filtered result is empty → in sync)
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // No SecretTemplateConflict event must be emitted
+    // (needs_meta_template_apply returns None, reconcile block never entered)
+    let event_api = Api::<Event>::namespaced(s.client.clone(), "default");
+    let opts = ListParams::default().fields(&format!(
+        "involvedObject.kind=KanidmOAuth2Client,involvedObject.apiVersion=kaniop.rs/v1beta1,involvedObject.uid={uid},reason=SecretTemplateConflict"
+    ));
+    let event_list = event_api.list(&opts).await.unwrap();
+    assert!(
+        event_list.items.is_empty(),
+        "No SecretTemplateConflict event should be emitted when all keys are filtered"
+    );
+
+    // Operator's values must be unmodified
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_ne!(
+        labels.get("app.kubernetes.io/name"),
+        Some(&"conflict-name".to_string()),
+        "operator label value must not be overwritten"
+    );
+    assert!(
+        labels.contains_key("app.kubernetes.io/name"),
+        "operator name label must be present"
+    );
+}
+
+// SSA field manager separation
+#[tokio::test]
+async fn oauth2_secret_template_field_manager_separation() {
+    let name = "test-st-managers";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Field Manager Separation Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/managed-by-template": "true"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Fetch Secret directly (not from store) to inspect managedFields
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    let managed_fields = secret
+        .metadata
+        .managed_fields
+        .as_ref()
+        .expect("Secret should have managedFields");
+
+    let manager_names: Vec<&str> = managed_fields
+        .iter()
+        .filter_map(|e| e.manager.as_deref())
+        .collect();
+
+    assert!(
+        manager_names.contains(&MAIN_MANAGER),
+        "main operator manager '{MAIN_MANAGER}' must appear in managedFields, got: {manager_names:?}"
+    );
+    assert!(
+        manager_names.contains(&TEMPLATE_MANAGER),
+        "template manager '{TEMPLATE_MANAGER}' must appear in managedFields, got: {manager_names:?}"
+    );
+
+    // The two managers must be distinct entries
+    let main_entry = managed_fields
+        .iter()
+        .find(|e| e.manager.as_deref() == Some(MAIN_MANAGER))
+        .unwrap();
+    let template_entry = managed_fields
+        .iter()
+        .find(|e| e.manager.as_deref() == Some(TEMPLATE_MANAGER))
+        .unwrap();
+    assert_ne!(
+        main_entry.manager, template_entry.manager,
+        "main and template managers should be distinct entries"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_manual_modification_overwritten() {
+    let name = "test-st-manual-mod";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Manual Modification Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/env": "prod"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Manually change the template-owned label via a different field manager
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+
+    let mut override_secret = Secret::default();
+    override_secret.metadata.name = Some(secret_name.clone());
+    override_secret.metadata.namespace = Some("default".to_string());
+    override_secret.metadata.labels = Some(
+        [("example.com/env".to_string(), "manual".to_string())]
+            .into_iter()
+            .collect(),
+    );
+    secret_api
+        .patch(
+            &secret_name,
+            &PatchParams::apply("external-test-manager").force(),
+            &Patch::Apply(&override_secret),
+        )
+        .await
+        .unwrap();
+
+    // Trigger reconcile by patching the OAuth2 client with a dummy annotation
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "metadata": {
+                    "annotations": {
+                        "test.kaniop.rs/trigger-reconcile": Timestamp::now().to_string()
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // Operator should detect drift and re-assert the template value
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/env"),
+        Some(&"prod".to_string()),
+        "template label value should be restored to 'prod' after drift correction"
+    );
+}
+
+// Interaction with rotation
+#[tokio::test]
+async fn oauth2_secret_template_survives_rotation() {
+    let name = "test-st-rotation-survives";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Survives Rotation Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretRotation": {
+            "enabled": true,
+            "periodDays": 90
+        },
+        "secretTemplate": {
+            "labels": {
+                "example.com/persist-across-rotation": "yes"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretRotated")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Force a secret rotation via annotation
+    oauth2_api
+        .patch(
+            name,
+            &PatchParams::default(),
+            &Patch::Merge(&json!({
+                "metadata": {
+                    "annotations": {
+                        "kaniop.rs/force-secret-rotation": Timestamp::now().to_string()
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // Wait for rotation to complete
+    wait_for(oauth2_api.clone(), name, is_oauth2_false("SecretRotated")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretRotated")).await;
+
+    // After rotation, template labels must still be present
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels after rotation");
+    assert_eq!(
+        labels.get("example.com/persist-across-rotation"),
+        Some(&"yes".to_string()),
+        "template label must survive force rotation"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_coexists_with_rotation_annotations() {
+    let name = "test-st-rotation-coexist";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Coexist With Rotation Annotations Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretRotation": {
+            "enabled": true,
+            "periodDays": 90
+        },
+        "secretTemplate": {
+            "annotations": {
+                "example.com/team": "platform"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretRotated")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    let annotations = secret
+        .metadata
+        .annotations
+        .as_ref()
+        .expect("Secret should have annotations");
+
+    // Rotation annotations owned by main operator
+    assert!(
+        annotations.contains_key("kaniop.rs/rotation-enabled"),
+        "rotation-enabled annotation must be present"
+    );
+    assert_eq!(
+        annotations.get("kaniop.rs/rotation-enabled"),
+        Some(&"true".to_string()),
+        "rotation-enabled should be 'true'"
+    );
+    assert!(
+        annotations.contains_key("kaniop.rs/rotation-period-days"),
+        "rotation-period-days annotation must be present"
+    );
+
+    // Template annotation owned by template manager — must coexist
+    assert_eq!(
+        annotations.get("example.com/team"),
+        Some(&"platform".to_string()),
+        "template annotation must coexist with rotation annotations"
+    );
+}
+
+// Edge cases
+#[tokio::test]
+async fn oauth2_secret_template_condition_absent_without_template() {
+    let name = "test-st-no-template";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // Create a standard confidential client with NO secretTemplate
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Absent Without Template Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    wait_for(oauth2_api.clone(), name, is_oauth2_ready()).await;
+
+    let current = oauth2_api.get(name).await.unwrap();
+    let conditions = current.status.as_ref().and_then(|s| s.conditions.as_ref());
+    assert!(
+        conditions.is_none_or(|conds| conds.iter().all(|c| c.type_ != "SecretTemplateSynced")),
+        "SecretTemplateSynced must be completely absent when no secretTemplate is set"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_public_client_no_condition() {
+    let name = "test-st-public";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // Public client with secretTemplate set — no webhook prevents this
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Public Client Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "public": true,
+        "secretTemplate": {
+            "labels": {
+                "example.com/public-template": "should-be-ignored"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    let uid = oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap()
+        .uid()
+        .unwrap();
+
+    // Public clients have no secret, so we wait for ready (Exists + Updated)
+    wait_for(oauth2_api.clone(), name, is_oauth2_ready()).await;
+
+    // No Secret should be created for public clients
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret_result = secret_api.get(&secret_name).await;
+    assert!(
+        secret_result.is_err(),
+        "No Secret should be created for public clients"
+    );
+
+    // SecretTemplateSynced must be absent for public clients
+    let current = oauth2_api.get(name).await.unwrap();
+    let conditions = current.status.as_ref().and_then(|s| s.conditions.as_ref());
+    assert!(
+        conditions.is_none_or(|conds| conds.iter().all(|c| c.type_ != "SecretTemplateSynced")),
+        "SecretTemplateSynced must be absent for public clients"
+    );
+
+    // No SecretTemplateConflict event
+    let event_api = Api::<Event>::namespaced(s.client.clone(), "default");
+    let opts = ListParams::default().fields(&format!(
+        "involvedObject.kind=KanidmOAuth2Client,involvedObject.apiVersion=kaniop.rs/v1beta1,involvedObject.uid={uid},reason=SecretTemplateConflict"
+    ));
+    let event_list = event_api.list(&opts).await.unwrap();
+    assert!(
+        event_list.items.is_empty(),
+        "No SecretTemplateConflict event should be emitted for public clients"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_empty_template() {
+    let name = "test-st-empty";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    // secretTemplate: {} — present but with no labels or annotations
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Empty Template Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {}
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    let uid = oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap()
+        .uid()
+        .unwrap();
+
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+    // SecretTemplateSynced=True immediately (no keys → template manager owns nothing → in sync)
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // Secret must not have any extra labels/annotations beyond operator defaults
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+
+    // No unexpected annotations (beyond operator's own)
+    let annotations = secret.metadata.annotations.as_ref();
+    assert!(
+        annotations.is_none_or(|a| !a.keys().any(|k| k.starts_with("example.com/"))),
+        "Empty secretTemplate should not add any extra annotations"
+    );
+
+    // No unexpected labels beyond operator-managed ones
+    let labels = secret.metadata.labels.as_ref();
+    assert!(
+        labels.is_none_or(|l| !l.keys().any(|k| k.starts_with("example.com/"))),
+        "Empty secretTemplate should not add any extra labels"
+    );
+
+    // No SecretTemplateConflict event
+    let event_api = Api::<Event>::namespaced(s.client.clone(), "default");
+    let opts = ListParams::default().fields(&format!(
+        "involvedObject.kind=KanidmOAuth2Client,involvedObject.apiVersion=kaniop.rs/v1beta1,involvedObject.uid={uid},reason=SecretTemplateConflict"
+    ));
+    let event_list = event_api.list(&opts).await.unwrap();
+    assert!(
+        event_list.items.is_empty(),
+        "No SecretTemplateConflict event should be emitted for empty secretTemplate"
+    );
+}
+
+#[tokio::test]
+async fn oauth2_secret_template_condition_deferred_until_secret_exists() {
+    let name = "test-st-deferred";
+    let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+    let oauth2_spec = json!({
+        "kanidmRef": {"name": KANIDM_NAME},
+        "displayname": "ST Deferred Until Secret Exists Test",
+        "redirectUrl": [],
+        "origin": format!("https://{name}.example.com"),
+        "secretTemplate": {
+            "labels": {
+                "example.com/deferred-label": "value"
+            }
+        }
+    });
+    let oauth2 = KanidmOAuth2Client::new(name, serde_json::from_value(oauth2_spec).unwrap());
+    let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(s.client.clone(), "default");
+    oauth2_api
+        .create(&PostParams::default(), &oauth2)
+        .await
+        .unwrap();
+
+    // Wait for SecretInitialized=True — the Secret now exists in the operator's watch store.
+    // SecretTemplateSynced should NOT have appeared before this point (deferred behaviour),
+    // but verifying that timing reliably in a test is impractical; instead we verify that:
+    // 1. After SecretInitialized, the condition appears (False then True).
+    // 2. By the time SecretTemplateSynced=True, the Secret has the correct labels.
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretInitialized")).await;
+
+    // After SecretInitialized=True the template apply is triggered; condition reaches True.
+    wait_for(
+        oauth2_api.clone(),
+        name,
+        is_oauth2_false("SecretTemplateSynced"),
+    )
+    .await;
+    wait_for(oauth2_api.clone(), name, is_oauth2("SecretTemplateSynced")).await;
+
+    // At this point SecretInitialized must also be True (ordering guarantee)
+    let current = oauth2_api.get(name).await.unwrap();
+    let conditions = current.status.unwrap().conditions.unwrap_or_default();
+    assert!(
+        conditions
+            .iter()
+            .any(|c| c.type_ == "SecretInitialized" && c.status == "True"),
+        "SecretInitialized must be True when SecretTemplateSynced is True"
+    );
+
+    let secret_name = format!("{name}-kanidm-oauth2-credentials");
+    let secret_api = Api::<Secret>::namespaced(s.client.clone(), "default");
+    let secret = secret_api.get(&secret_name).await.unwrap();
+    let labels = secret
+        .metadata
+        .labels
+        .as_ref()
+        .expect("Secret should have labels");
+    assert_eq!(
+        labels.get("example.com/deferred-label"),
+        Some(&"value".to_string()),
+        "deferred template label should be applied after Secret is initialized"
+    );
+}


### PR DESCRIPTION
Adds `secretTemplate` to `KanidmOAuth2Client`, allowing users to attach custom labels and annotations to the `Secret` generated for confidential clients; inspired by cert-manager's Certificate.spec.secretTemplate. The motivation is similar to the motivation behind cert-manager's spec: being able to synchronize resources across namespaces and integrate with other operators.

## Implementation
`MetadataTemplate` CRD type (`libs/operator/src/crd.rs`) - a reusable `{labels, annotations}` struct designed to be embedded in any operator-managed resource that creates a child object.

`ObjectMetaTemplateExt` trait - (`libs/operator/src/object_meta_template.rs`) - a generic trait designed to make it easy to attach metadata to a managed resource. It provides two methods:
 - `needs_meta_template_apply` - compares the desired template state against the live object's `managedFields` to detect any of three out-of-sync cases: missing/wrong values, template removed (stale keys remain), or template shrank (extra owned keys remain).
 - `apply_meta_template` - SSA-applies the filtered metadata using a dedicated template.<operator-name> field manager, keeping template-owned fields strictly disjoint from operator-owned fields.

### Design
Two managers were used to keep responsibilities separate. The main operator owns the resource, and resource data (i.e. the `Secret` and secret data) as well as any annotations/labels/etc it needs for its own lifecycle handling. Any field in `secretTemplate` that would conflict with the main operator's managed fields is ignored (emits `SecretTemplateConflict` event).

`SecretTemplateSynced` condition reflects the template state: absent when no template has ever been set, `False` when a template should be applied to a resource, and `True` when the desired metadata matches the template.

This same approach should be able to be trivially applied to the `KanidmServiceAccount` CRD.

### Notes
For simplicity, this PR does not handle potentially unexpected operator behavior. One example of this is the rotation annotation. If secret rotation is removed from the CRD, the operator does not re-apply the `Secret` resource to release the managed annotation field so the template operator will not "claim" it. If the main operator does re-apply the `Secret` (or eventually release the annotation), the template operator should claim it and apply it on next reconcile. This has not been tested. 

Helm charts do not support upgrading CRD's so the upgrade path will need to be considered if this feature is accepted. Being purely additive and optional it is backwards compatible, so upgrading the CRD's should not have conflicts.

--- Edit ---

I had initially planned to submit a separate PR to allow customizing the managed secret's name to keep the scope of this one more targeted. As an alternative I could include that change in this PR to minimize the toil around handling changes to CRD's.