### PR TITLE
filter applyset labels from child resources

### DIFF
--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -436,7 +436,12 @@ impl Kanidm {
         self.generate_resource_labels()
             .clone()
             .into_iter()
-            .chain(self.labels().clone())
+            .chain(
+                self.labels()
+                    .clone()
+                    .into_iter()
+                    .filter(|(key, _)| key != "applyset.kubernetes.io/part-of"),
+            )
             .collect()
     }
 
@@ -853,5 +858,31 @@ mod test {
             .await
             .expect("reconciler");
         timeout_after_1s(mocksrv).await;
+    }
+
+    #[test]
+    fn generate_labels_filters_applyset_label() {
+        use std::collections::BTreeMap;
+
+        let mut kanidm = Kanidm::test();
+        kanidm.meta_mut().labels = Some(BTreeMap::from([
+            (
+                "applyset.kubernetes.io/part-of".to_string(),
+                "some-applyset-id".to_string(),
+            ),
+            ("custom-label".to_string(), "custom-value".to_string()),
+        ]));
+
+        let labels = kanidm.generate_labels();
+
+        assert!(
+            !labels.contains_key("applyset.kubernetes.io/part-of"),
+            "applyset.kubernetes.io/part-of label should be filtered out"
+        );
+        assert_eq!(
+            labels.get("custom-label").map(String::as_str),
+            Some("custom-value"),
+            "other labels should be preserved"
+        );
     }
 }

--- a/libs/operator/src/kanidm/reconcile/secret.rs
+++ b/libs/operator/src/kanidm/reconcile/secret.rs
@@ -65,7 +65,12 @@ impl SecretExt for Kanidm {
                     self.generate_resource_labels()
                         .clone()
                         .into_iter()
-                        .chain(self.labels().clone())
+                        .chain(
+                            self.labels()
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| key != "applyset.kubernetes.io/part-of"),
+                        )
                         .chain(std::iter::once((
                             SECRET_TYPE_LABEL.to_string(),
                             serde_plain::to_string(&SecretType::AdminPasswords).unwrap(),
@@ -138,7 +143,12 @@ impl Kanidm {
                     self.generate_resource_labels()
                         .clone()
                         .into_iter()
-                        .chain(self.labels().clone())
+                        .chain(
+                            self.labels()
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| key != "applyset.kubernetes.io/part-of"),
+                        )
                         .chain([
                             (REPLICA_LABEL.to_string(), pod_name.to_string()),
                             (

--- a/libs/operator/src/kanidm/reconcile/service.rs
+++ b/libs/operator/src/kanidm/reconcile/service.rs
@@ -115,7 +115,12 @@ impl ServiceExt for Kanidm {
                     self.generate_resource_labels()
                         .clone()
                         .into_iter()
-                        .chain(self.labels().clone())
+                        .chain(
+                            self.labels()
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| key != "applyset.kubernetes.io/part-of"),
+                        )
                         .chain([
                             (REPLICA_GROUP_LABEL.to_string(), rg.name.to_string()),
                             (REPLICA_LABEL.to_string(), self.pod_name(&rg.name, i)),

--- a/libs/operator/src/kanidm/reconcile/statefulset.rs
+++ b/libs/operator/src/kanidm/reconcile/statefulset.rs
@@ -210,6 +210,7 @@ impl Kanidm {
         self.labels()
             .clone()
             .into_iter()
+            .filter(|(key, _)| key != "applyset.kubernetes.io/part-of")
             .chain(pod_labels.clone())
             .collect()
     }
@@ -730,8 +731,12 @@ fn replication_type(
 
 #[cfg(test)]
 mod tests {
-    use crate::kanidm::crd::{Kanidm, KanidmSpec, KanidmStorage, PersistentVolumeClaimTemplate};
+    use crate::kanidm::crd::{
+        Kanidm, KanidmSpec, KanidmStorage, PersistentVolumeClaimTemplate, ReplicaGroup,
+    };
     use k8s_openapi::api::core::v1::{EmptyDirVolumeSource, EphemeralVolumeSource, Volume};
+    use kube::Resource;
+    use std::collections::BTreeMap;
 
     fn create_kanidm_with_storage(storage: Option<KanidmStorage>) -> Kanidm {
         Kanidm {
@@ -912,6 +917,42 @@ mod tests {
                 .any(|v| v.name == "kanidm-data" && v.empty_dir.is_some())
         );
         assert!(volume_claim_template.is_none());
+    }
+
+    #[test]
+    fn test_generate_sts_labels_filters_applyset_label() {
+        let mut kanidm = Kanidm {
+            spec: KanidmSpec {
+                domain: "idm.example.com".to_string(),
+                replica_groups: vec![ReplicaGroup {
+                    name: "default".to_string(),
+                    replicas: 1,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        kanidm.meta_mut().labels = Some(BTreeMap::from([
+            (
+                "applyset.kubernetes.io/part-of".to_string(),
+                "some-applyset-id".to_string(),
+            ),
+            ("custom-label".to_string(), "custom-value".to_string()),
+        ]));
+
+        let pod_labels = kanidm.generate_pod_labels(&kanidm.spec.replica_groups[0].clone());
+        let labels = kanidm.generate_sts_labels(&pod_labels);
+
+        assert!(
+            !labels.contains_key("applyset.kubernetes.io/part-of"),
+            "applyset.kubernetes.io/part-of label should be filtered out"
+        );
+        assert_eq!(
+            labels.get("custom-label").map(String::as_str),
+            Some("custom-value"),
+            "other labels should be preserved"
+        );
     }
 }
 


### PR DESCRIPTION
Applysets can be used to manage Kubernetes resources with kubectl, and uses labels to keep track of which resources to prune. The consequence of propagating labels unconditionally is that the operator and the applyset tooling will fight over what should/shouldn't be deleted.

Ideally this would be fleshed out a bit more, where the CRDs has an explicit filter of what labels to propagate, but this is a pragmatic middle-ground.

https://kubernetes.io/blog/2023/05/09/introducing-kubectl-applyset-pruning/

Fixes: #723