### PR TITLE
fix: specify container for 'exec' commands to allow sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Specify target container of 'exec' commands, enabling sidecar containers ([unreleased])
 - Admin Secret not generated when OpenTelemetry tracing is enabled ([574c6c9](https://github.com/pando85/kaniop/commit/574c6c9970dd6c74aba9a8beebf6e940f5eeb22e))
 - Prevent potential panics and propagate statefulset restart errors ([b975559](https://github.com/pando85/kaniop/commit/b975559e25edebc11bbddc16d545a34e95294d9a))
 - Handle replication transition and remove invalid group mail test ([ebae166](https://github.com/pando85/kaniop/commit/ebae166cc8c5ae2d404081e1ab9c9379ce7c1185))

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -658,7 +658,11 @@ impl Kanidm {
         );
         let pod = Api::<Pod>::namespaced(ctx.kaniop_ctx.client.clone(), namespace);
         let attached = pod
-            .exec(pod_name, command, &AttachParams::default())
+            .exec(
+                pod_name,
+                command,
+                &AttachParams::default().container("kanidm"),
+            )
             .await
             .map_err(|e| {
                 Error::KubeError(


### PR DESCRIPTION
When using a sidecar container within the Kanidm StatefulSet, as shown in this abbreviated example:
```yaml
---
apiVersion: kaniop.rs/v1beta1
kind: Kanidm
metadata:
  name: my-kanidm-instance
spec:
  domain: idm.example.com
  image: kanidm/server:1.9.2
  containers:
    - name: kanidm
    - name: backup-database
``` 

The kaniop operator fails when attempting to exec `kanidmd domain upgrade-check`, because the `exec` requires that the target container be named, if more than one container is present within the Pod.

This PR resolves this issue by targeting the kanidm container specifically.