### PR TITLE
test: add e2e test for HA cluster upgrade from previous minor version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
+ "indexmap 2.13.0",
  "log",
  "publicsuffix",
  "serde",
@@ -3364,6 +3365,7 @@ dependencies = [
  "time",
  "tokio",
  "toml 0.8.23",
+ "ureq",
  "uuid",
 ]
 
@@ -5860,7 +5862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6510,24 +6512,29 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
+ "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -6568,6 +6575,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6849,6 +6862,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 backon = "1.3"
+ureq = { version = "3", features = ["json"] }
 serial_test = "3"
 jiff = { workspace = true }
 time = "0.3"

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -1,5 +1,6 @@
 mod domain_appearance;
 mod replication;
+mod upgrade;
 
 use crate::kanidm::get_dependency_version;
 use crate::test::{init_crypto_provider, wait_for};

--- a/tests/e2e/test/kanidm/upgrade.rs
+++ b/tests/e2e/test/kanidm/upgrade.rs
@@ -11,14 +11,80 @@ use json_patch::merge;
 use k8s_openapi::api::apps::v1::StatefulSet;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::{Api, Patch, PatchParams};
+use serde::Deserialize;
 use serde_json::json;
+
+#[derive(Deserialize)]
+struct CratesVersionsResponse {
+    versions: Vec<CrateVersion>,
+}
+
+#[derive(Deserialize)]
+struct CrateVersion {
+    num: String,
+    yanked: bool,
+}
+
+fn parse_semver(version: &str) -> Option<(u64, u64, u64)> {
+    let parts: Vec<&str> = version.split('.').collect();
+    if parts.len() >= 3 {
+        let major = parts[0].parse().ok()?;
+        let minor = parts[1].parse().ok()?;
+        let patch = parts[2].split('-').next()?.parse().ok()?;
+        Some((major, minor, patch))
+    } else {
+        None
+    }
+}
+
+fn fetch_previous_minor_from_crates_io(current_major: u64, current_minor: u64) -> Option<String> {
+    let response: CratesVersionsResponse =
+        ureq::get("https://crates.io/api/v1/crates/kanidm_client/versions?per_page=100")
+            .header("User-Agent", "kaniop-e2e-test")
+            .call()
+            .ok()?
+            .body_mut()
+            .read_json()
+            .ok()?;
+
+    let mut best: Option<(u64, u64, u64)> = None;
+    for v in &response.versions {
+        if v.yanked {
+            continue;
+        }
+        let Some((major, minor, patch)) = parse_semver(&v.num) else {
+            continue;
+        };
+        if major == current_major && minor == current_minor {
+            continue;
+        }
+        let is_previous_minor = if current_minor > 0 {
+            major == current_major && minor == current_minor - 1
+        } else {
+            major == current_major - 1
+        };
+        if !is_previous_minor {
+            continue;
+        }
+        if best.is_none_or(|(b_major, b_minor, b_patch)| {
+            (major, minor, patch) > (b_major, b_minor, b_patch)
+        }) {
+            best = Some((major, minor, patch));
+        }
+    }
+    best.map(|(major, minor, patch)| format!("{major}.{minor}.{patch}"))
+}
 
 fn previous_minor_version() -> String {
     let current = get_dependency_version().unwrap();
-    let parts: Vec<&str> = current.split('.').collect();
-    let major: u64 = parts[0].parse().unwrap();
-    let minor: u64 = parts[1].parse().unwrap();
-    format!("{major}.{}.0", minor - 1)
+    let (current_major, current_minor, _) = parse_semver(&current).unwrap();
+
+    if current_minor > 0 {
+        format!("{current_major}.{}.0", current_minor - 1)
+    } else {
+        fetch_previous_minor_from_crates_io(current_major, current_minor)
+            .expect("Failed to determine previous minor version from crates.io")
+    }
 }
 
 fn get_statefulset_image(sts: &StatefulSet) -> String {

--- a/tests/e2e/test/kanidm/upgrade.rs
+++ b/tests/e2e/test/kanidm/upgrade.rs
@@ -1,0 +1,106 @@
+use serial_test::serial;
+
+use super::{
+    DEFAULT_REPLICA_GROUP_NAME, STORAGE_VOLUME_CLAIM_TEMPLATE_JSON, is_kanidm, is_kanidm_false,
+    is_statefulset_ready, setup, wait_for, wait_for_replication_success_with_timeout,
+};
+use crate::kanidm::get_dependency_version;
+use crate::test::poll_until;
+
+use json_patch::merge;
+use k8s_openapi::api::apps::v1::StatefulSet;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, Patch, PatchParams};
+use serde_json::json;
+
+fn previous_minor_version() -> String {
+    let current = get_dependency_version().unwrap();
+    let parts: Vec<&str> = current.split('.').collect();
+    let major: u64 = parts[0].parse().unwrap();
+    let minor: u64 = parts[1].parse().unwrap();
+    format!("{major}.{}.0", minor - 1)
+}
+
+fn get_statefulset_image(sts: &StatefulSet) -> String {
+    sts.spec
+        .as_ref()
+        .unwrap()
+        .template
+        .spec
+        .as_ref()
+        .unwrap()
+        .containers
+        .first()
+        .unwrap()
+        .image
+        .clone()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial(replication)]
+async fn kanidm_upgrade_ha_cluster() {
+    let name = "test-upgrade-ha-cluster";
+    let prev_version = previous_minor_version();
+    let current_version = get_dependency_version().unwrap();
+    let prev_image = format!("kanidm/server:{prev_version}");
+    let current_image = format!("kanidm/server:{current_version}");
+
+    let mut spec_patch = json!({
+        "image": prev_image,
+        "replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 2, "primaryNode": true}],
+    });
+    merge(&mut spec_patch, &STORAGE_VOLUME_CLAIM_TEMPLATE_JSON.clone());
+
+    let s = setup(name, Some(spec_patch)).await;
+
+    let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+    let sts = s.statefulset_api.get(&sts_name).await.unwrap();
+    assert_eq!(sts.spec.as_ref().unwrap().replicas.unwrap(), 2);
+    assert_eq!(get_statefulset_image(&sts), prev_image);
+
+    wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+    wait_for(s.kanidm_api.clone(), name, is_kanidm("Initialized")).await;
+    wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
+
+    let pod_api = Api::<Pod>::namespaced(s.client.clone(), "default");
+    let pod_names = (0..2)
+        .map(|i| format!("{sts_name}-{i}"))
+        .collect::<Vec<_>>();
+    wait_for_replication_success_with_timeout(&pod_api, &pod_names).await;
+
+    let mut kanidm = s.kanidm_api.get(name).await.unwrap();
+    kanidm.spec.image = current_image.clone();
+    kanidm.metadata.managed_fields = None;
+    s.kanidm_api
+        .patch(
+            name,
+            &PatchParams::apply("e2e-test").force(),
+            &Patch::Apply(&kanidm),
+        )
+        .await
+        .unwrap();
+
+    let statefulset_api = s.statefulset_api.clone();
+    let expected_image = current_image.clone();
+    poll_until("StatefulSet image updated", || async {
+        let sts = statefulset_api.get(&sts_name).await.ok()?;
+        let image = get_statefulset_image(&sts);
+        if image == expected_image {
+            Some(())
+        } else {
+            None
+        }
+    })
+    .await;
+
+    wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+    wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
+    wait_for(s.statefulset_api.clone(), &sts_name, is_statefulset_ready).await;
+
+    let upgraded_sts = s.statefulset_api.get(&sts_name).await.unwrap();
+    assert_eq!(get_statefulset_image(&upgraded_sts), current_image);
+    assert_eq!(upgraded_sts.spec.as_ref().unwrap().replicas.unwrap(), 2);
+
+    wait_for_replication_success_with_timeout(&pod_api, &pod_names).await;
+}


### PR DESCRIPTION
## Summary

- Add e2e test that creates a Kanidm cluster in HA mode (2 replicas) at the previous minor version, validates replication, then upgrades to the current version and verifies the upgrade completes successfully with replication still working
- The previous minor version is derived programmatically from the `kanidm_client` version in `Cargo.lock`, so the test stays in sync automatically