### PR TITLE
release: Version 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.4](https://github.com/pando85/kaniop/tree/v0.7.4) - 2026-05-24
+
+### Added
+
+- Add release skill for opencode ([6350dcf](https://github.com/pando85/kaniop/commit/6350dcf6aaccaafc4370e471b6ac89b072c731a0))
+
+### Fixed
+
+- kanidm: Renew replication certificates in parallel ([b9d0e9a](https://github.com/pando85/kaniop/commit/b9d0e9a50b2f2bbe2ba62844e863252aad06abfb))
+- Wait for pod readiness before exec operations ([208b3e0](https://github.com/pando85/kaniop/commit/208b3e022e8053b8733167bca437f5ed2deb5617))
+- Increase stack size for e2e tests to prevent stack overflow ([9aa5413](https://github.com/pando85/kaniop/commit/9aa54132e25e489e85709caf4009235e74479a83))
+- Use explicit stack size for service_account_api_tokens_lifecycle test ([56e6715](https://github.com/pando85/kaniop/commit/56e6715b0e41dc68bffe0dbc4243762ce6861c21))
+- Increase stack size for group_lifecycle test to 16MB ([d2ffe38](https://github.com/pando85/kaniop/commit/d2ffe38ae05ffc3d4587d77b216b2fe7a658d631))
+- Use e2e_test! macro for all e2e tests to prevent stack overflow ([a01f293](https://github.com/pando85/kaniop/commit/a01f29332a4d869c163cbcf092c42ef87bcf884d))
+- Add missing pods RBAC permission and revert unnecessary boxing ([4c21b38](https://github.com/pando85/kaniop/commit/4c21b38df29590d4cc9313ad9add956d1981dd34))
+- Improve pod readiness check reliability and performance ([a493a94](https://github.com/pando85/kaniop/commit/a493a94ac7659418b8ba48457a81a346660c52b4))
+- Restart replicas after certificate renewal ([f41d331](https://github.com/pando85/kaniop/commit/f41d33192da84b76bd062a0dc68afd0698bc7597))
+- Certificate renewal reliability and unnecessary pod restarts ([76d7353](https://github.com/pando85/kaniop/commit/76d7353aa00bc48f1aed14cc1095e2639c8bbc0e))
+
+### Build
+
+- deps: Update Rust crate serde_json to v1.0.150 ([5a70536](https://github.com/pando85/kaniop/commit/5a70536ba0ab7962ebbd8b2388f75c78aed3800d))
+
 ## [v0.7.3](https://github.com/pando85/kaniop/tree/v0.7.3) - 2026-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-crdgen"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "kaniop-group",
  "kaniop-oauth2",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-e2e-tests"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "backon",
  "futures",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-examples"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "gateway-api",
  "k8s-openapi",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-group"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "futures",
  "k8s-openapi",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-k8s-util"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "futures",
  "hex",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-oauth2"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "futures",
  "hex",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-operator"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "axum",
  "backon",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-person"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "futures",
  "k8s-openapi",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-service-account"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "futures",
  "k8s-openapi",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "kaniop-webhook"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Pando85 <pando855@gmail.com>"]
 rust-version = "1.85"
 edition = "2024"
@@ -25,12 +25,12 @@ homepage = "https://github.com/pando85/kanidm-operator"
 readme = "README.md"
 
 [workspace.dependencies]
-kaniop-group = { path = "libs/group", version = "0.7.3" }
-kaniop-k8s-util = { path = "libs/k8s-util", version = "0.7.3" }
-kaniop-oauth2 = { path = "libs/oauth2", version = "0.7.3" }
-kaniop-operator = { path = "libs/operator", version = "0.7.3" }
-kaniop-person = { path = "libs/person", version = "0.7.3" }
-kaniop-service-account = { path = "libs/service-account", version = "0.7.3" }
+kaniop-group = { path = "libs/group", version = "0.7.4" }
+kaniop-k8s-util = { path = "libs/k8s-util", version = "0.7.4" }
+kaniop-oauth2 = { path = "libs/oauth2", version = "0.7.4" }
+kaniop-operator = { path = "libs/operator", version = "0.7.4" }
+kaniop-person = { path = "libs/person", version = "0.7.4" }
+kaniop-service-account = { path = "libs/service-account", version = "0.7.4" }
 jiff = "0.2.18"
 clap = { version = "4.5", features = ["std", "derive"] }
 futures = "0.3"

--- a/charts/kaniop/Chart.yaml
+++ b/charts/kaniop/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kaniop
 description: Kanidm Operator chart
 type: application
-version: "0.7.3"
-appVersion: "0.7.3"
+version: "0.7.4"
+appVersion: "0.7.4"
 icon: https://raw.githubusercontent.com/pando85/kaniop/master/artwork/logo.png
 annotations:
   # Artifact Hub metadata: https://artifacthub.io/docs/topics/annotations/
@@ -31,10 +31,10 @@ annotations:
       url: https://kanidm.com
   artifacthub.io/images: |
     - name: kaniop
-      image: ghcr.io/pando85/kaniop:0.7.3
+      image: ghcr.io/pando85/kaniop:0.7.4
       description: Kanidm Operator (Kaniop) container image
     - name: kaniop-webhook
-      image: ghcr.io/pando85/kaniop-webhook:0.7.3
+      image: ghcr.io/pando85/kaniop-webhook:0.7.4
       description: Kanidm Operator (Kaniop) webhook container image
   artifacthub.io/crds: |
     - kind: Kanidm
@@ -74,7 +74,7 @@ annotations:
     url: https://github.com/pando85.gpg
   artifacthub.io/changes: |
     - kind: changed
-      description: Kaniop application updated to v0.7.3.
+      description: Kaniop application updated to v0.7.4.
       links:
         - name: GitHub Release
-          url: https://github.com/pando85/kaniop/releases/tag/v0.7.3
+          url: https://github.com/pando85/kaniop/releases/tag/v0.7.4


### PR DESCRIPTION
## Release v0.7.4

### Added
- Add release skill for opencode

### Fixed
- Certificate renewal reliability and unnecessary pod restarts
- Renew replication certificates in parallel
- Restart replicas after certificate renewal
- Improve pod readiness check reliability and performance
- Add missing pods RBAC permission
- Use e2e_test! macro for all e2e tests to prevent stack overflow
- Wait for pod readiness before exec operations

### Build
- deps: Update Rust crate serde_json to v1.0.150

**Checklist:**
- [x] Version bumped in `Cargo.toml`
- [x] `make update-version` ran
- [x] `make update-changelog` ran
- [x] Commit message follows `release: Version X.Y.Z`