### PR TITLE
fix(ci): make workspace crate publishing resilient to registry propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,37 @@ update-changelog:	## automatically update changelog based on commits
 
 .PHONY: publish
 publish:	## publish crates
-	cargo publish --workspace --exclude kaniop-e2e-tests
+	@set -eo pipefail; \
+	crates=$$(cargo metadata --format-version 1 --no-deps \
+		| jq -r '.packages[] | select(.publish == null) | .name'); \
+	declare -a remaining=(); \
+	for c in $$crates; do remaining+=("$$c"); done; \
+	for pass in $$(seq 1 12); do \
+		if [ $${#remaining[@]} -eq 0 ]; then break; fi; \
+		echo "==> Publish pass $$pass: $${remaining[*]}"; \
+		declare -a failed=(); \
+		for crate in "$${remaining[@]}"; do \
+			log=$$(mktemp); \
+			if cargo publish --no-verify -p "$$crate" >"$$log" 2>&1; then \
+				echo "   published $$crate"; \
+			elif grep -qiE 'already (exists|uploaded|been published)' "$$log"; then \
+				echo "   $$crate already published, skipping"; \
+			else \
+				echo "   deferred $$crate:"; \
+				sed -n '1,4p' "$$log" | sed 's/^/      /'; \
+				failed+=("$$crate"); \
+			fi; \
+			rm -f "$$log"; \
+		done; \
+		remaining=("$${failed[@]}"); \
+		if [ $${#remaining[@]} -eq 0 ]; then break; fi; \
+		echo "   waiting 20s for registry propagation before next pass..."; \
+		sleep 20; \
+	done; \
+	if [ $${#remaining[@]} -gt 0 ]; then \
+		echo "ERROR: failed to publish after all passes: $${remaining[*]}"; \
+		exit 1; \
+	fi
 
 IMAGE_ARCHITECTURES := amd64 arm64
 IMAGE_COMPONENTS := kaniop kaniop-webhook


### PR DESCRIPTION
## Problem

The `Publish crates` job failed in the v0.9.0 release run ([run 27738545913](https://github.com/pando85/kaniop/actions/runs/27738545913/job/82064040231)):

```
error: no packages ready to publish but 3 packages remain in plan with 1 awaiting confirmation: kaniop v0.9.0, kaniop-crdgen v0.9.0, and kaniop-webhook v0.9.0
note: this is an unexpected cargo internal error
```

The 6 library crates published fine, but `cargo publish --workspace` then hit a cargo planner bug: `kaniop-service-account` was uploaded but not yet confirmed in the crates.io index (`1 awaiting confirmation`), so its 3 dependent binaries could not be published and cargo aborted instead of waiting. As a result the v0.9.0 release on crates.io is incomplete — the 3 binaries were never published.

## Fix

Replace the single `cargo publish --workspace` with a per-crate, multi-pass publisher in `Makefile`:

- Enumerates publishable crates from `cargo metadata` (auto-excludes `publish = false` crates: `kaniop-e2e-tests`, `kaniop-examples`).
- Publishes each crate with `cargo publish -p <crate> --no-verify` — build / clippy / test jobs already gate the release, so the verification build is redundant and skipping it makes retries cheap.
- Retries deferred crates across up to 12 passes with 20s sleeps, so crates.io index-propagation delay and dependency ordering are handled regardless of processing order.
- Treats `already exists` responses as success, making the target **idempotent** — re-running it completes a partially-published release (e.g. it will finish v0.9.0 by skipping the 6 published libs and publishing the 3 missing binaries).

Both behaviors were validated with mocked simulations (fresh publish with deps in arbitrary order; idempotent re-run).