### PR TITLE
fix(kanidm): roll statefulsets when the TLS secret is renewed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_plain = "1.0"
 serde_yaml = "0.9"
+sha2 = "0.10"
 tempfile = "3.10"
 thiserror = "2.0"
 tokio = { version = "1.38", features = ["macros", "rt-multi-thread"] }

--- a/Documentation/src/usage/kanidm.md
+++ b/Documentation/src/usage/kanidm.md
@@ -43,7 +43,9 @@ Notice that this configuration requires a TLS certificate with the name `my-idm-
 The operator tracks the content of this TLS secret: a hash of it is injected into the pod
 template, so a certificate renewal (e.g. performed by cert-manager) automatically triggers a
 rolling restart of the Kanidm pods. This is required because kanidmd only reads its TLS
-material at startup.
+material at startup. For the renewal to be detected immediately, the secret must be of type
+`kubernetes.io/tls` (the default for cert-manager and `kubectl create secret tls`); other
+secret types are only picked up on the next periodic reconciliation.
 
 ## Security Context Configuration
 

--- a/Documentation/src/usage/kanidm.md
+++ b/Documentation/src/usage/kanidm.md
@@ -40,6 +40,11 @@ spec:
 
 Notice that this configuration requires a TLS certificate with the name `my-idm-tls`.
 
+The operator tracks the content of this TLS secret: a hash of it is injected into the pod
+template, so a certificate renewal (e.g. performed by cert-manager) automatically triggers a
+rolling restart of the Kanidm pods. This is required because kanidmd only reads its TLS
+material at startup.
+
 ## Security Context Configuration
 
 For production deployments, it's recommended to configure security contexts to comply with

--- a/libs/k8s-util/Cargo.toml
+++ b/libs/k8s-util/Cargo.toml
@@ -40,7 +40,7 @@ url-escape = "0.1.1"
 hostname = "0.4"
 url = { workspace = true }
 openssl = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2"] }
 
 [build-dependencies]

--- a/libs/k8s-util/src/resources.rs
+++ b/libs/k8s-util/src/resources.rs
@@ -1,5 +1,6 @@
 use json_patch::merge;
-use k8s_openapi::api::core::v1::Container;
+use k8s_openapi::api::core::v1::{Container, Secret};
+use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
 
@@ -47,11 +48,69 @@ pub fn get_image_tag(image: &str) -> Option<String> {
     image.split_once(':').map(|(_, tag)| tag.to_string())
 }
 
+/// Compute a deterministic SHA-256 hex digest of a secret's data.
+///
+/// Entries are hashed in key order (`BTreeMap` iteration) with a NUL separator
+/// between keys and values so shifting bytes between them changes the digest.
+pub fn hash_secret_data(secret: &Secret) -> String {
+    let mut hasher = Sha256::new();
+    for (key, value) in secret.data.iter().flatten() {
+        hasher.update(key.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(&value.0);
+        hasher.update([0u8]);
+    }
+    hex::encode(hasher.finalize())
+}
+
 #[cfg(test)]
 mod test {
-    use super::{Container, merge_containers};
+    use super::{Container, Secret, hash_secret_data, merge_containers};
+
+    use std::collections::BTreeMap;
+
+    use k8s_openapi::ByteString;
 
     const CONTAINER_NAME: &str = "kanidm";
+
+    fn secret_with_data(entries: &[(&str, &[u8])]) -> Secret {
+        Secret {
+            data: Some(
+                entries
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), ByteString(v.to_vec())))
+                    .collect::<BTreeMap<_, _>>(),
+            ),
+            ..Secret::default()
+        }
+    }
+
+    #[test]
+    fn test_hash_secret_data_is_deterministic() {
+        let secret = secret_with_data(&[("tls.crt", b"cert"), ("tls.key", b"key")]);
+        assert_eq!(hash_secret_data(&secret), hash_secret_data(&secret));
+    }
+
+    #[test]
+    fn test_hash_secret_data_changes_with_content() {
+        let secret = secret_with_data(&[("tls.crt", b"cert"), ("tls.key", b"key")]);
+        let renewed = secret_with_data(&[("tls.crt", b"renewed"), ("tls.key", b"key")]);
+        assert_ne!(hash_secret_data(&secret), hash_secret_data(&renewed));
+    }
+
+    #[test]
+    fn test_hash_secret_data_separates_keys_and_values() {
+        let secret = secret_with_data(&[("ab", b"c")]);
+        let shifted = secret_with_data(&[("a", b"bc")]);
+        assert_ne!(hash_secret_data(&secret), hash_secret_data(&shifted));
+    }
+
+    #[test]
+    fn test_hash_secret_data_empty() {
+        let no_data = Secret::default();
+        let empty_data = secret_with_data(&[]);
+        assert_eq!(hash_secret_data(&no_data), hash_secret_data(&empty_data));
+    }
 
     #[test]
     fn test_generate_containers_with_existing_kanidm() {

--- a/libs/operator/src/kanidm/controller/mod.rs
+++ b/libs/operator/src/kanidm/controller/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use futures::StreamExt;
+use futures::TryStreamExt;
 use futures::channel::mpsc;
 use futures::future::BoxFuture;
 use gateway_api::apis::standard::backendtlspolicies::BackendTLSPolicy;
@@ -26,13 +27,13 @@ use k8s_openapi::api::apps::v1::{Deployment, StatefulSet};
 use k8s_openapi::api::core::v1::{ConfigMap, Namespace, Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::ResourceExt;
-use kube::api::Api;
+use kube::api::{Api, PartialObjectMeta};
 use kube::client::Client;
 use kube::runtime::controller::{self, Controller};
 use kube::runtime::reflector::ObjectRef;
 use kube::runtime::reflector::store::Writer;
 use kube::runtime::reflector::{ReflectHandle, Store};
-use kube::runtime::{WatchStreamExt, watcher};
+use kube::runtime::{WatchStreamExt, metadata_watcher, watcher};
 use tokio::time::Duration;
 use tracing::{debug, error, info, trace};
 
@@ -92,6 +93,26 @@ fn create_replica_cert_watcher(
     .boxed()
 }
 
+/// Map a TLS secret event to the Kanidm objects that mount it.
+///
+/// The TLS secret is user-provided (e.g. created by cert-manager), so it
+/// carries neither kaniop labels nor owner references pointing to the Kanidm:
+/// match by namespace and effective TLS secret name against the Kanidm store.
+fn map_tls_secret_to_kanidms(
+    kanidm_store: &Store<Kanidm>,
+    secret: &PartialObjectMeta<Secret>,
+) -> Vec<ObjectRef<Kanidm>> {
+    kanidm_store
+        .state()
+        .into_iter()
+        .filter(|kanidm| {
+            kanidm.namespace() == secret.namespace()
+                && kanidm.effective_tls_secret_name() == secret.name_any()
+        })
+        .map(|kanidm| ObjectRef::from(kanidm.as_ref()))
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_controller(
     kanidm_watcher: impl futures::Stream<Item = Result<Kanidm, watcher::Error>> + Send + 'static,
@@ -101,6 +122,9 @@ fn run_controller(
     ingress_subscriber: ReflectHandle<Ingress>,
     secret_subscriber: ReflectHandle<Secret>,
     replica_cert_secret_subscriber: ReflectHandle<Secret>,
+    tls_secret_trigger: impl futures::Stream<Item = Result<PartialObjectMeta<Secret>, watcher::Error>>
+    + Send
+    + 'static,
     http_route_subscriber: Option<ReflectHandle<HTTPRoute>>,
     backend_tls_policy_subscriber: Option<ReflectHandle<BackendTLSPolicy>>,
     deployment_subscriber: ReflectHandle<Deployment>,
@@ -108,6 +132,7 @@ fn run_controller(
     reload_rx: mpsc::Receiver<()>,
     ctx: Arc<Context>,
 ) -> BoxFuture<'static, ()> {
+    let kanidm_store_for_tls = kanidm_store.clone();
     let mut controller = Controller::for_stream(kanidm_watcher, kanidm_store)
         .with_config(controller::Config::default().debounce(Duration::from_millis(500)))
         .owns_shared_stream(statefulset_subscriber)
@@ -116,7 +141,10 @@ fn run_controller(
         .owns_shared_stream(secret_subscriber)
         .owns_shared_stream(replica_cert_secret_subscriber)
         .owns_shared_stream(deployment_subscriber)
-        .owns_shared_stream(config_map_subscriber);
+        .owns_shared_stream(config_map_subscriber)
+        .watches_stream(tls_secret_trigger, move |secret| {
+            map_tls_secret_to_kanidms(&kanidm_store_for_tls, &secret)
+        });
 
     if let Some(subscriber) = http_route_subscriber {
         controller = controller.owns_shared_stream(subscriber);
@@ -241,7 +269,19 @@ pub async fn run(
     );
 
     let replica_cert_secrets_watcher =
-        create_replica_cert_watcher(secret, replica_cert_secret_r.writer, ctx.clone());
+        create_replica_cert_watcher(secret.clone(), replica_cert_secret_r.writer, ctx.clone());
+
+    // TLS secrets are user-provided (e.g. created by cert-manager) and carry no
+    // kaniop label to filter on: watch metadata of all secrets and let the
+    // mapper match them by name against the Kanidm store.
+    let tls_secret_metrics_ctx = kaniop_ctx.clone();
+    let tls_secret_trigger = metadata_watcher(secret, watcher::Config::default().any_semantic())
+        .default_backoff()
+        .touched_objects()
+        .inspect_err(move |e| {
+            error!(msg = "unexpected error when watching TLS secrets", %e);
+            tls_secret_metrics_ctx.metrics.watch_operations_failed_inc();
+        });
 
     let namespace_watcher = watcher(namespace_api, watcher::Config::default().any_semantic())
         .default_backoff()
@@ -298,6 +338,7 @@ pub async fn run(
         ingress_r.subscriber,
         secret_r.subscriber,
         replica_cert_secret_r.subscriber,
+        tls_secret_trigger,
         http_route_subscriber,
         backend_tls_policy_subscriber,
         deployment_r.subscriber,
@@ -319,5 +360,71 @@ pub async fn run(
         _ = replica_cert_secrets_watcher => {},
         _ = deployment_watcher => {},
         _ = config_map_watcher => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_tls_secret_to_kanidms;
+    use crate::kanidm::crd::{Kanidm, KanidmSpec};
+
+    use k8s_openapi::api::core::v1::Secret;
+    use kube::api::{ObjectMeta, PartialObjectMeta};
+    use kube::runtime::reflector;
+    use kube::runtime::watcher;
+
+    fn kanidm(name: &str, namespace: &str, tls_secret_name: Option<&str>) -> Kanidm {
+        Kanidm {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            spec: KanidmSpec {
+                domain: "idm.example.com".to_string(),
+                tls_secret_name: tls_secret_name.map(str::to_string),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn secret_meta(name: &str, namespace: &str) -> PartialObjectMeta<Secret> {
+        PartialObjectMeta {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_map_tls_secret_to_kanidms() {
+        let (store, mut writer) = reflector::store();
+        writer.apply_watcher_event(&watcher::Event::Apply(kanidm("a", "ns1", None)));
+        writer.apply_watcher_event(&watcher::Event::Apply(kanidm(
+            "b",
+            "ns1",
+            Some("custom-tls"),
+        )));
+        writer.apply_watcher_event(&watcher::Event::Apply(kanidm("c", "ns2", None)));
+
+        // default secret name `{name}-tls`
+        let refs = map_tls_secret_to_kanidms(&store, &secret_meta("a-tls", "ns1"));
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "a");
+
+        // explicit `tlsSecretName`
+        let refs = map_tls_secret_to_kanidms(&store, &secret_meta("custom-tls", "ns1"));
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "b");
+
+        // same name in another namespace does not match
+        assert!(map_tls_secret_to_kanidms(&store, &secret_meta("a-tls", "ns2")).is_empty());
+
+        // unrelated secret matches nothing
+        assert!(map_tls_secret_to_kanidms(&store, &secret_meta("other", "ns1")).is_empty());
     }
 }

--- a/libs/operator/src/kanidm/controller/mod.rs
+++ b/libs/operator/src/kanidm/controller/mod.rs
@@ -272,16 +272,21 @@ pub async fn run(
         create_replica_cert_watcher(secret.clone(), replica_cert_secret_r.writer, ctx.clone());
 
     // TLS secrets are user-provided (e.g. created by cert-manager) and carry no
-    // kaniop label to filter on: watch metadata of all secrets and let the
-    // mapper match them by name against the Kanidm store.
+    // kaniop label to filter on: watch metadata of `kubernetes.io/tls` secrets
+    // and let the mapper match them by name against the Kanidm store.
     let tls_secret_metrics_ctx = kaniop_ctx.clone();
-    let tls_secret_trigger = metadata_watcher(secret, watcher::Config::default().any_semantic())
-        .default_backoff()
-        .touched_objects()
-        .inspect_err(move |e| {
-            error!(msg = "unexpected error when watching TLS secrets", %e);
-            tls_secret_metrics_ctx.metrics.watch_operations_failed_inc();
-        });
+    let tls_secret_trigger = metadata_watcher(
+        secret,
+        watcher::Config::default()
+            .fields("type=kubernetes.io/tls")
+            .any_semantic(),
+    )
+    .default_backoff()
+    .touched_objects()
+    .inspect_err(move |e| {
+        error!(msg = "unexpected error when watching TLS secrets", %e);
+        tls_secret_metrics_ctx.metrics.watch_operations_failed_inc();
+    });
 
     let namespace_watcher = watcher(namespace_api, watcher::Config::default().any_semantic())
         .default_backoff()

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -1232,7 +1232,7 @@ mod test {
         CreateWithTwoReplicas(Kanidm),
         CreateWithIngress(Kanidm),
         CreateWithIngressWithTwoReplicas(Kanidm),
-        CreateWithTlsSecret(Kanidm, Secret),
+        CreateWithTlsSecret(Kanidm, Box<Secret>),
     }
 
     pub async fn timeout_after_1s(handle: tokio::task::JoinHandle<()>) {
@@ -1335,7 +1335,7 @@ mod test {
                             .handle_kanidm_status_patch(kanidm.clone())
                             .await
                             .unwrap()
-                            .handle_tls_secret_get(kanidm.clone(), secret)
+                            .handle_tls_secret_get(kanidm.clone(), *secret)
                             .await
                             .unwrap()
                             .handle_statefulset_patch(kanidm.clone(), Some(expected_hash))
@@ -1673,7 +1673,10 @@ mod test {
             ])),
             ..Default::default()
         };
-        let mocksrv = fakeserver.run(Scenario::CreateWithTlsSecret(kanidm.clone(), secret));
+        let mocksrv = fakeserver.run(Scenario::CreateWithTlsSecret(
+            kanidm.clone(),
+            Box::new(secret),
+        ));
         reconcile_kanidm(Arc::new(kanidm), testctx)
             .await
             .expect("reconciler");

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -32,7 +32,7 @@ use crate::telemetry;
 use kaniop_k8s_util::client::get_output;
 use kaniop_k8s_util::error::{Error, Result};
 use kaniop_k8s_util::parse::parse_semver;
-use kaniop_k8s_util::resources::get_image_tag;
+use kaniop_k8s_util::resources::{get_image_tag, hash_secret_data};
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
@@ -43,7 +43,7 @@ use futures::stream::{self, StreamExt};
 use futures::try_join;
 use k8s_openapi::NamespaceResourceScope;
 use k8s_openapi::api::apps::v1::StatefulSet;
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::api::core::v1::{Pod, Secret};
 use kube::Resource;
 use kube::ResourceExt;
 use kube::api::{Api, AttachParams, Patch, PatchParams};
@@ -454,6 +454,20 @@ pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<
     })
 }
 
+/// Hash of the TLS secret content, injected as a pod template annotation so
+/// certificate renewals roll the statefulsets. `None` if the secret does not
+/// exist yet.
+async fn get_tls_secret_hash(kanidm: &Kanidm, ctx: &Arc<Context>) -> Result<Option<String>> {
+    let secret_name = kanidm.effective_tls_secret_name();
+    let secret_api =
+        Api::<Secret>::namespaced(ctx.kaniop_ctx.client.clone(), &kanidm.get_namespace());
+    let secret = secret_api
+        .get_opt(&secret_name)
+        .await
+        .map_err(|e| Error::kube_error("get", "Secret", kanidm.get_namespace(), &secret_name, e))?;
+    Ok(secret.as_ref().map(hash_secret_data))
+}
+
 async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus) -> Result<Action> {
     let admin_secret_future = reconcile_admins_secret(kanidm.clone(), ctx.clone(), &status);
     let replication_secret_futures =
@@ -487,15 +501,18 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
         .collect::<TryJoinAll<_>>();
 
     let sts_futures = match kanidm.is_updatable(&status) {
-        true => kanidm
-            .spec
-            .replica_groups
-            .iter()
-            .map(|rg| {
-                let sts = kanidm.create_statefulset(rg)?;
-                Ok(kanidm.patch(&ctx, sts))
-            })
-            .collect::<Result<TryJoinAll<_>, _>>()?,
+        true => {
+            let tls_secret_hash = get_tls_secret_hash(&kanidm, &ctx).await?;
+            kanidm
+                .spec
+                .replica_groups
+                .iter()
+                .map(|rg| {
+                    let sts = kanidm.create_statefulset(rg, tls_secret_hash.as_deref())?;
+                    Ok(kanidm.patch(&ctx, sts))
+                })
+                .collect::<Result<TryJoinAll<_>, _>>()?
+        }
         false => {
             let note = match status.version.as_ref() {
                 Some(v) if v.compatibility_result == VersionCompatibilityResult::Incompatible => {
@@ -912,6 +929,18 @@ impl Kanidm {
         format!("{}-tls", self.name_any())
     }
 
+    /// TLS secret name mounted by the statefulsets: explicit `tlsSecretName`,
+    /// falling back to the ingress TLS secret and then to the default name.
+    pub(crate) fn effective_tls_secret_name(&self) -> String {
+        self.spec.tls_secret_name.clone().unwrap_or_else(|| {
+            self.spec
+                .ingress
+                .as_ref()
+                .and_then(|i| i.tls_secret_name.clone())
+                .unwrap_or_else(|| self.get_tls_secret_name())
+        })
+    }
+
     #[inline]
     fn get_namespace(&self) -> String {
         // safe unwrap: Kanidm is namespaced scoped
@@ -1086,7 +1115,7 @@ impl Kanidm {
 
 #[cfg(test)]
 mod test {
-    use super::statefulset::StatefulSetExt;
+    use super::statefulset::{StatefulSetExt, TLS_SECRET_HASH_ANNOTATION};
     use super::{Kanidm, reconcile_kanidm};
 
     use crate::controller::State;
@@ -1094,13 +1123,17 @@ mod test {
     use crate::kanidm::crd::KanidmStatus;
 
     use kaniop_k8s_util::error::Result;
+    use kaniop_k8s_util::resources::hash_secret_data;
 
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use http::{Request, Response};
+    use k8s_openapi::ByteString;
     use k8s_openapi::api::apps::v1::StatefulSet;
-    use k8s_openapi::api::core::v1::Service;
+    use k8s_openapi::api::core::v1::{Secret, Service};
     use k8s_openapi::api::networking::v1::Ingress;
+    use kube::api::ObjectMeta;
     use kube::runtime::reflector::store::Writer;
     use kube::{Client, Resource, ResourceExt, client::Body};
     use opentelemetry::metrics::MeterProvider;
@@ -1166,6 +1199,7 @@ mod test {
         CreateWithTwoReplicas(Kanidm),
         CreateWithIngress(Kanidm),
         CreateWithIngressWithTwoReplicas(Kanidm),
+        CreateWithTlsSecret(Kanidm, Secret),
     }
 
     pub async fn timeout_after_1s(handle: tokio::task::JoinHandle<()>) {
@@ -1197,7 +1231,10 @@ mod test {
                             .handle_kanidm_status_patch(kanidm.clone())
                             .await
                             .unwrap()
-                            .handle_statefulset_patch(kanidm.clone())
+                            .handle_tls_secret_get_not_found(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_statefulset_patch(kanidm.clone(), None)
                             .await
                             .unwrap()
                             .handle_service_patch(kanidm.clone())
@@ -1210,7 +1247,10 @@ mod test {
                             .handle_kanidm_status_patch(kanidm.clone())
                             .await
                             .unwrap()
-                            .handle_statefulset_patch(kanidm.clone())
+                            .handle_tls_secret_get_not_found(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_statefulset_patch(kanidm.clone(), None)
                             .await
                             .unwrap()
                             .handle_service_patch(kanidm.clone())
@@ -1223,7 +1263,10 @@ mod test {
                             .handle_kanidm_status_patch(kanidm.clone())
                             .await
                             .unwrap()
-                            .handle_statefulset_patch(kanidm.clone())
+                            .handle_tls_secret_get_not_found(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_statefulset_patch(kanidm.clone(), None)
                             .await
                             .unwrap()
                             .handle_service_patch(kanidm.clone())
@@ -1239,13 +1282,33 @@ mod test {
                             .handle_kanidm_status_patch(kanidm.clone())
                             .await
                             .unwrap()
-                            .handle_statefulset_patch(kanidm.clone())
+                            .handle_tls_secret_get_not_found(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_statefulset_patch(kanidm.clone(), None)
                             .await
                             .unwrap()
                             .handle_service_patch(kanidm.clone())
                             .await
                             .unwrap()
                             .handle_ingress_patch(kanidm.clone())
+                            .await
+                    }
+                    Scenario::CreateWithTlsSecret(kanidm, secret) => {
+                        let expected_hash = hash_secret_data(&secret);
+                        self.handle_kanidm_get(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_kanidm_status_patch(kanidm.clone())
+                            .await
+                            .unwrap()
+                            .handle_tls_secret_get(kanidm.clone(), secret)
+                            .await
+                            .unwrap()
+                            .handle_statefulset_patch(kanidm.clone(), Some(expected_hash))
+                            .await
+                            .unwrap()
+                            .handle_service_patch(kanidm.clone())
                             .await
                     }
                 }
@@ -1296,7 +1359,58 @@ mod test {
             Ok(self)
         }
 
-        async fn handle_statefulset_patch(mut self, kanidm: Kanidm) -> Result<Self> {
+        async fn handle_tls_secret_get_not_found(mut self, kanidm: Kanidm) -> Result<Self> {
+            let (request, send) = self.0.next_request().await.expect("service not called");
+            assert_eq!(request.method(), http::Method::GET);
+            let expected_uri_prefix = format!(
+                "/api/v1/namespaces/default/secrets/{}",
+                kanidm.effective_tls_secret_name()
+            );
+            let uri = request.uri().to_string();
+            assert!(
+                uri.starts_with(&expected_uri_prefix),
+                "expected uri to start with {expected_uri_prefix}, got {uri}"
+            );
+            let status = serde_json::json!({
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {},
+                "status": "Failure",
+                "message": "secret not found",
+                "reason": "NotFound",
+                "code": 404
+            });
+            send.send_response(
+                Response::builder()
+                    .status(404)
+                    .body(Body::from(serde_json::to_vec(&status).unwrap()))
+                    .unwrap(),
+            );
+            Ok(self)
+        }
+
+        async fn handle_tls_secret_get(mut self, kanidm: Kanidm, secret: Secret) -> Result<Self> {
+            let (request, send) = self.0.next_request().await.expect("service not called");
+            assert_eq!(request.method(), http::Method::GET);
+            let expected_uri_prefix = format!(
+                "/api/v1/namespaces/default/secrets/{}",
+                kanidm.effective_tls_secret_name()
+            );
+            let uri = request.uri().to_string();
+            assert!(
+                uri.starts_with(&expected_uri_prefix),
+                "expected uri to start with {expected_uri_prefix}, got {uri}"
+            );
+            let response = serde_json::to_vec(&secret).unwrap();
+            send.send_response(Response::builder().body(Body::from(response)).unwrap());
+            Ok(self)
+        }
+
+        async fn handle_statefulset_patch(
+            mut self,
+            kanidm: Kanidm,
+            expected_tls_hash: Option<String>,
+        ) -> Result<Self> {
             for rg in kanidm.spec.replica_groups.iter() {
                 let (request, send) = self.0.next_request().await.expect("service not called");
                 assert_eq!(request.method(), http::Method::PATCH);
@@ -1316,6 +1430,19 @@ mod test {
                     statefulset.clone().spec.unwrap().replicas.unwrap(),
                     rg.replicas
                 );
+                let tls_hash_annotation = statefulset
+                    .spec
+                    .as_ref()
+                    .unwrap()
+                    .template
+                    .metadata
+                    .as_ref()
+                    .unwrap()
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get(TLS_SECRET_HASH_ANNOTATION))
+                    .cloned();
+                assert_eq!(tls_hash_annotation, expected_tls_hash);
                 let response = serde_json::to_vec(&statefulset).unwrap();
                 // pass through kanidm "patch accepted"
                 send.send_response(Response::builder().body(Body::from(response)).unwrap());
@@ -1438,6 +1565,29 @@ mod test {
         let (testctx, fakeserver) = get_test_context();
         let kanidm = Kanidm::test().with_ingress().with_replicas(2);
         let mocksrv = fakeserver.run(Scenario::CreateWithIngressWithTwoReplicas(kanidm.clone()));
+        reconcile_kanidm(Arc::new(kanidm), testctx)
+            .await
+            .expect("reconciler");
+        timeout_after_1s(mocksrv).await;
+    }
+
+    #[tokio::test]
+    async fn kanidm_create_with_tls_secret() {
+        let (testctx, fakeserver) = get_test_context();
+        let kanidm = Kanidm::test();
+        let secret = Secret {
+            metadata: ObjectMeta {
+                name: Some(kanidm.effective_tls_secret_name()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            data: Some(BTreeMap::from([
+                ("tls.crt".to_string(), ByteString(b"cert".to_vec())),
+                ("tls.key".to_string(), ByteString(b"key".to_vec())),
+            ])),
+            ..Default::default()
+        };
+        let mocksrv = fakeserver.run(Scenario::CreateWithTlsSecret(kanidm.clone(), secret));
         reconcile_kanidm(Arc::new(kanidm), testctx)
             .await
             .expect("reconciler");

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -533,10 +533,9 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
 
     let sts_futures = match kanidm.is_updatable(&status) {
         true => {
-            let tls_secret_hash = match get_tls_secret_hash(&kanidm, &ctx).await? {
-                Some(hash) => Some(hash),
-                None => previous_tls_secret_hash(&kanidm, ctx.stores.stateful_set_store.state()),
-            };
+            let tls_secret_hash = get_tls_secret_hash(&kanidm, &ctx).await?.or_else(|| {
+                previous_tls_secret_hash(&kanidm, ctx.stores.stateful_set_store.state())
+            });
             kanidm
                 .spec
                 .replica_groups

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -26,7 +26,7 @@ use crate::controller::{INSTANCE_LABEL, MANAGED_BY_LABEL, NAME_LABEL};
 use crate::kanidm::crd::{
     Kanidm, KanidmReplicaState, KanidmStatus, KanidmUpgradeCheckResult, VersionCompatibilityResult,
 };
-use crate::kanidm::reconcile::statefulset::REPLICA_LABEL;
+use crate::kanidm::reconcile::statefulset::{REPLICA_LABEL, TLS_SECRET_HASH_ANNOTATION};
 use crate::telemetry;
 
 use kaniop_k8s_util::client::get_output;
@@ -468,6 +468,37 @@ async fn get_tls_secret_hash(kanidm: &Kanidm, ctx: &Arc<Context>) -> Result<Opti
     Ok(secret.as_ref().map(hash_secret_data))
 }
 
+/// Previous TLS secret hash annotation from the existing statefulsets.
+///
+/// Used when the TLS secret is missing: dropping the annotation would roll
+/// the pods onto a missing volume and leave them stuck in ContainerCreating.
+fn previous_tls_secret_hash(
+    kanidm: &Kanidm,
+    stateful_sets: impl IntoIterator<Item = Arc<StatefulSet>>,
+) -> Option<String> {
+    stateful_sets
+        .into_iter()
+        .filter(|sts| {
+            sts.namespace() == kanidm.namespace()
+                && sts
+                    .metadata
+                    .labels
+                    .as_ref()
+                    .is_some_and(|l| l.get(CLUSTER_LABEL) == Some(&kanidm.name_any()))
+        })
+        .find_map(|sts| {
+            sts.spec
+                .as_ref()?
+                .template
+                .metadata
+                .as_ref()?
+                .annotations
+                .as_ref()?
+                .get(TLS_SECRET_HASH_ANNOTATION)
+                .cloned()
+        })
+}
+
 async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus) -> Result<Action> {
     let admin_secret_future = reconcile_admins_secret(kanidm.clone(), ctx.clone(), &status);
     let replication_secret_futures =
@@ -502,7 +533,10 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
 
     let sts_futures = match kanidm.is_updatable(&status) {
         true => {
-            let tls_secret_hash = get_tls_secret_hash(&kanidm, &ctx).await?;
+            let tls_secret_hash = match get_tls_secret_hash(&kanidm, &ctx).await? {
+                Some(hash) => Some(hash),
+                None => previous_tls_secret_hash(&kanidm, ctx.stores.stateful_set_store.state()),
+            };
             kanidm
                 .spec
                 .replica_groups
@@ -1116,7 +1150,7 @@ impl Kanidm {
 #[cfg(test)]
 mod test {
     use super::statefulset::{StatefulSetExt, TLS_SECRET_HASH_ANNOTATION};
-    use super::{Kanidm, reconcile_kanidm};
+    use super::{CLUSTER_LABEL, Kanidm, previous_tls_secret_hash, reconcile_kanidm};
 
     use crate::controller::State;
     use crate::kanidm::controller::context::{Context, Stores};
@@ -1130,8 +1164,8 @@ mod test {
 
     use http::{Request, Response};
     use k8s_openapi::ByteString;
-    use k8s_openapi::api::apps::v1::StatefulSet;
-    use k8s_openapi::api::core::v1::{Secret, Service};
+    use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec};
+    use k8s_openapi::api::core::v1::{PodTemplateSpec, Secret, Service};
     use k8s_openapi::api::networking::v1::Ingress;
     use kube::api::ObjectMeta;
     use kube::runtime::reflector::store::Writer;
@@ -1569,6 +1603,59 @@ mod test {
             .await
             .expect("reconciler");
         timeout_after_1s(mocksrv).await;
+    }
+
+    fn statefulset_of(cluster: &str, namespace: &str, tls_hash: Option<&str>) -> Arc<StatefulSet> {
+        Arc::new(StatefulSet {
+            metadata: ObjectMeta {
+                name: Some(format!("{cluster}-default")),
+                namespace: Some(namespace.to_string()),
+                labels: Some(BTreeMap::from([(
+                    CLUSTER_LABEL.to_string(),
+                    cluster.to_string(),
+                )])),
+                ..Default::default()
+            },
+            spec: Some(StatefulSetSpec {
+                template: PodTemplateSpec {
+                    metadata: Some(ObjectMeta {
+                        annotations: tls_hash.map(|h| {
+                            BTreeMap::from([(
+                                TLS_SECRET_HASH_ANNOTATION.to_string(),
+                                h.to_string(),
+                            )])
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_previous_tls_secret_hash() {
+        let kanidm = Kanidm::test();
+
+        // annotation carried over from an existing statefulset
+        let stss = vec![statefulset_of("test", "default", Some("abc123"))];
+        assert_eq!(
+            previous_tls_secret_hash(&kanidm, stss),
+            Some("abc123".to_string())
+        );
+
+        // no annotation on the existing statefulset
+        let stss = vec![statefulset_of("test", "default", None)];
+        assert_eq!(previous_tls_secret_hash(&kanidm, stss), None);
+
+        // statefulsets from another cluster or namespace are ignored
+        let stss = vec![
+            statefulset_of("other", "default", Some("abc123")),
+            statefulset_of("test", "other-ns", Some("abc123")),
+        ];
+        assert_eq!(previous_tls_secret_hash(&kanidm, stss), None);
     }
 
     #[tokio::test]

--- a/libs/operator/src/kanidm/reconcile/statefulset.rs
+++ b/libs/operator/src/kanidm/reconcile/statefulset.rs
@@ -22,6 +22,7 @@ use kube::api::{ObjectMeta, Resource};
 
 pub const REPLICA_GROUP_LABEL: &str = "kanidm.kaniop.rs/replica-group";
 pub const REPLICA_LABEL: &str = "kanidm.kaniop.rs/replica";
+pub const TLS_SECRET_HASH_ANNOTATION: &str = "kanidm.kaniop.rs/tls-secret-hash";
 pub const CONTAINER_REPLICATION_PORT: i32 = 8444;
 pub const CONTAINER_REPLICATION_PORT_NAME: &str = "replication";
 
@@ -101,7 +102,11 @@ pub trait StatefulSetExt {
     fn pod_name(&self, rg_name: &str, i: i32) -> String;
     fn pod_env_prefix(&self, pod_name: &str) -> String;
 
-    fn create_statefulset(&self, replica_group: &ReplicaGroup) -> Result<StatefulSet>;
+    fn create_statefulset(
+        &self,
+        replica_group: &ReplicaGroup,
+        tls_secret_hash: Option<&str>,
+    ) -> Result<StatefulSet>;
 }
 
 impl StatefulSetExt for Kanidm {
@@ -120,7 +125,11 @@ impl StatefulSetExt for Kanidm {
         pod_name.to_uppercase().replace("-", "_")
     }
 
-    fn create_statefulset(&self, replica_group: &ReplicaGroup) -> Result<StatefulSet> {
+    fn create_statefulset(
+        &self,
+        replica_group: &ReplicaGroup,
+        tls_secret_hash: Option<&str>,
+    ) -> Result<StatefulSet> {
         let pod_labels = self.generate_pod_labels(replica_group);
         let labels = self.generate_sts_labels(&pod_labels);
         let env = self.generate_env_vars(replica_group);
@@ -148,6 +157,15 @@ impl StatefulSetExt for Kanidm {
                 template: PodTemplateSpec {
                     metadata: Some(ObjectMeta {
                         labels: Some(pod_labels),
+                        // kanidmd only reads its TLS material at startup: hash the TLS
+                        // secret content into the pod template so a renewed certificate
+                        // triggers a rolling restart.
+                        annotations: tls_secret_hash.map(|hash| {
+                            BTreeMap::from([(
+                                TLS_SECRET_HASH_ANNOTATION.to_string(),
+                                hash.to_string(),
+                            )])
+                        }),
                         ..ObjectMeta::default()
                     }),
                     spec: Some(PodSpec {
@@ -558,13 +576,7 @@ impl Kanidm {
     }
 
     fn generate_volumes(&self) -> (Vec<Volume>, Option<Vec<PersistentVolumeClaim>>) {
-        let secret_name = self.spec.tls_secret_name.clone().unwrap_or_else(|| {
-            self.spec
-                .ingress
-                .as_ref()
-                .and_then(|i| i.tls_secret_name.clone())
-                .unwrap_or_else(|| self.get_tls_secret_name())
-        });
+        let secret_name = self.effective_tls_secret_name();
 
         self.expand_storage(
             self.spec
@@ -700,8 +712,12 @@ fn replication_type(
 
 #[cfg(test)]
 mod tests {
-    use crate::kanidm::crd::{Kanidm, KanidmSpec, KanidmStorage, PersistentVolumeClaimTemplate};
+    use super::{StatefulSetExt, TLS_SECRET_HASH_ANNOTATION};
+    use crate::kanidm::crd::{
+        Kanidm, KanidmSpec, KanidmStorage, PersistentVolumeClaimTemplate, ReplicaGroup,
+    };
     use k8s_openapi::api::core::v1::{EmptyDirVolumeSource, EphemeralVolumeSource, Volume};
+    use kube::api::ObjectMeta;
 
     fn create_kanidm_with_storage(storage: Option<KanidmStorage>) -> Kanidm {
         Kanidm {
@@ -711,6 +727,58 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+
+    fn create_kanidm_with_replica_group() -> (Kanidm, ReplicaGroup) {
+        let replica_group = ReplicaGroup {
+            name: "default".to_string(),
+            replicas: 1,
+            ..Default::default()
+        };
+        let kanidm = Kanidm {
+            metadata: ObjectMeta {
+                name: Some("test".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: KanidmSpec {
+                domain: "idm.example.com".to_string(),
+                replica_groups: vec![replica_group.clone()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        (kanidm, replica_group)
+    }
+
+    #[test]
+    fn test_create_statefulset_with_tls_secret_hash_annotation() {
+        let (kanidm, replica_group) = create_kanidm_with_replica_group();
+        let sts = kanidm
+            .create_statefulset(&replica_group, Some("abc123"))
+            .unwrap();
+
+        let annotations = sts
+            .spec
+            .unwrap()
+            .template
+            .metadata
+            .unwrap()
+            .annotations
+            .unwrap();
+        assert_eq!(
+            annotations.get(TLS_SECRET_HASH_ANNOTATION),
+            Some(&"abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_create_statefulset_without_tls_secret_hash_annotation() {
+        let (kanidm, replica_group) = create_kanidm_with_replica_group();
+        let sts = kanidm.create_statefulset(&replica_group, None).unwrap();
+
+        let annotations = sts.spec.unwrap().template.metadata.unwrap().annotations;
+        assert!(annotations.is_none());
     }
 
     #[test]

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use kaniop_operator::kanidm::crd::Kanidm;
 use kaniop_operator::kanidm::reconcile::secret::SecretExt;
-use kaniop_operator::kanidm::reconcile::statefulset::StatefulSetExt;
+use kaniop_operator::kanidm::reconcile::statefulset::{StatefulSetExt, TLS_SECRET_HASH_ANNOTATION};
 
 use futures::future::JoinAll;
 use futures::join;
@@ -713,6 +713,60 @@ e2e_test!(
         wait_for_replication_success_with_timeout(&pod_api, &pod_names).await;
     }
 );
+
+fn tls_hash_annotation(sts: &StatefulSet) -> Option<String> {
+    sts.spec
+        .as_ref()?
+        .template
+        .metadata
+        .as_ref()?
+        .annotations
+        .as_ref()?
+        .get(TLS_SECRET_HASH_ANNOTATION)
+        .cloned()
+}
+
+e2e_test!(kanidm_tls_secret_renewal, {
+    let name = "test-tls-secret-renewal";
+    let s = setup(name, None).await;
+
+    let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+    let sts = s.statefulset_api.get(&sts_name).await.unwrap();
+    let initial_hash = tls_hash_annotation(&sts).expect("TLS hash annotation on pod template");
+
+    // Simulate a cert-manager renewal: change the TLS secret content. The
+    // appended newline keeps the PEM parseable so pods restart cleanly.
+    let secret_name = format!("{name}-tls");
+    let mut secret = s.secret_api.get(&secret_name).await.unwrap();
+    secret
+        .data
+        .as_mut()
+        .unwrap()
+        .insert("tls.crt".to_string(), ByteString([CERT, b"\n"].concat()));
+    secret.metadata.managed_fields = None;
+    s.secret_api
+        .patch(
+            &secret_name,
+            &PatchParams::apply("e2e-test").force(),
+            &Patch::Apply(&secret),
+        )
+        .await
+        .unwrap();
+
+    // the operator must roll the statefulset with a fresh hash
+    wait_for(
+        s.statefulset_api.clone(),
+        &sts_name,
+        move |obj: Option<&StatefulSet>| {
+            obj.and_then(tls_hash_annotation)
+                .is_some_and(|h| h != initial_hash)
+        },
+    )
+    .await;
+
+    wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+    wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
+});
 
 e2e_test!(kanidm_block_incompatible_version_upgrade, {
     use kaniop_operator::kanidm::crd::VersionCompatibilityResult;


### PR DESCRIPTION
## Problem

kanidmd only reads its TLS material at startup. When the TLS secret referenced by a Kanidm (`tlsSecretName`, the ingress fallback, or the default `{name}-tls`) is renewed — typically by cert-manager — nothing rolls the statefulsets: the pods keep serving the stale certificate until someone runs a manual `kubectl rollout restart`. With a verified TLS backend (e.g. Traefik ServersTransport pinning the CA), this breaks the whole IdM endpoint with `x509: certificate signed by unknown authority`.

The secret is user-provided: it carries neither kaniop labels nor owner references, so no existing watcher covers it, and the pod template carries no fingerprint of its content.

## Fix (prometheus-operator pattern)

1. **Pod template hash annotation** — the reconciler fetches the TLS secret and injects `kanidm.kaniop.rs/tls-secret-hash` (SHA-256 of the secret data) into the pod template, so any content change rolls the statefulsets.
2. **Watcher** — a metadata-only watcher on `kubernetes.io/tls` secrets, wired through `watches_stream` with a mapper that matches events by namespace + effective TLS secret name against the Kanidm store, triggers reconciliation on renewal (instead of waiting for the periodic 24h requeue). `owns_shared_stream` was not usable here because the secret's owner is not the Kanidm (e.g. a cert-manager Certificate).
3. **Missing-secret safety** — if the secret disappears, the previous annotation is carried over from the live statefulsets so pods are not rolled onto a missing volume and stuck in `ContainerCreating`.

## Notes

- The watch is scoped with a field selector to `type=kubernetes.io/tls` to avoid watching every secret in the cluster; other secret types still work but are only picked up by the periodic reconciliation (documented).
- `sha2` was moved to `[workspace.dependencies]` while adding the hash helper to `kaniop-k8s-util`.

## Testing

- Unit tests: hash determinism and key/value separation; annotation present/absent in `create_statefulset`; watcher mapper (default name, explicit `tlsSecretName`, namespace isolation); carry-over on missing secret; mock API server scenario asserting the annotation matches the hash of the served secret.
- e2e: `kanidm_tls_secret_renewal` renews the TLS secret content and asserts the statefulset is rolled with a fresh hash.
- Full CI (lint, unit/integration, e2e on Kind) is green on the fork: https://github.com/chriskaya/kaniop/pull/1
- Docs updated (`Documentation/src/usage/kanidm.md`).