### PR TITLE
fix: remove leading zeros from weight values to fix Jekyll sort error

### DIFF
--- a/Documentation/src/concepts.md
+++ b/Documentation/src/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-weight: 011000
+weight: 11000
 indent: true
 ---
 

--- a/Documentation/src/contributing.md
+++ b/Documentation/src/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-weight: 060000
+weight: 60000
 ---
 
 # Contributing

--- a/Documentation/src/getting-started.md
+++ b/Documentation/src/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-weight: 01000
+weight: 1000
 ---
 
 # Getting Started

--- a/Documentation/src/index.md
+++ b/Documentation/src/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-weight: 000
+weight: 0
 ---
 
 # Introduction

--- a/Documentation/src/installation.md
+++ b/Documentation/src/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-weight: 020000
+weight: 20000
 ---
 
 This guide covers installing Kaniop in your Kubernetes cluster using various methods.

--- a/Documentation/src/llm-guide.md
+++ b/Documentation/src/llm-guide.md
@@ -1,6 +1,6 @@
 ---
 title: LLM Operations Guide
-weight: 090
+weight: 90
 ---
 
 # LLM Operations Guide

--- a/Documentation/src/quickstart.md
+++ b/Documentation/src/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-weight: 012000
+weight: 12000
 indent: true
 ---
 

--- a/Documentation/src/troubleshooting.md
+++ b/Documentation/src/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-weight: 050000
+weight: 50000
 ---
 
 # Troubleshooting

--- a/Documentation/src/usage.md
+++ b/Documentation/src/usage.md
@@ -1,6 +1,6 @@
 ---
 title: Usage
-weight: 030000
+weight: 30000
 ---
 
 # Usage

--- a/Documentation/src/usage/group.md
+++ b/Documentation/src/usage/group.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Groups
-weight: 034000
+weight: 34000
 indent: true
 ---
 

--- a/Documentation/src/usage/kanidm.md
+++ b/Documentation/src/usage/kanidm.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Kanidm Clusters
-weight: 030000
+weight: 30000
 ---
 
 # Managing Kanidm Clusters

--- a/Documentation/src/usage/oauth2.md
+++ b/Documentation/src/usage/oauth2.md
@@ -1,6 +1,6 @@
 ---
 title: OAuth2 Client Management
-weight: 031000
+weight: 31000
 indent: true
 ---
 

--- a/Documentation/src/usage/person.md
+++ b/Documentation/src/usage/person.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Persons
-weight: 032000
+weight: 32000
 indent: true
 ---
 

--- a/Documentation/src/usage/service.md
+++ b/Documentation/src/usage/service.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Service Accounts
-weight: 033000
+weight: 33000
 indent: true
 ---
 

--- a/Documentation/src/webhook.md
+++ b/Documentation/src/webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Webhook Validation
-weight: 040000
+weight: 40000
 ---
 
 # Webhook Validation for Kanidm Custom Resources


### PR DESCRIPTION
## Problem

The `weight` values in documentation front matter had leading zeros (e.g., `weight: 090`, `weight: 01000`). In YAML, numbers with leading zeros are interpreted as **octal**, but `090` contains `9` which is invalid octal.

This caused:
- Valid octal values (`000`, `01000`) → parsed as integers
- Invalid octal values (`090`) → parsed as strings
- The Liquid `sort` filter failed with `comparison of Array with Array failed`
- Jekyll builds failed silently → GitHub Pages served stale content showing v0.7 as latest instead of v0.10

## Solution

Removed leading zeros from all weight values in `Documentation/src/` markdown files so they are parsed consistently as decimal integers.

## Verification

- Local Jekyll build succeeds ✓
- Generated HTML shows correct versions: v0.10, v0.9, v0.8, v0.7... ✓

## Related

Also fixed the deployed docs in pando85/pando85.github.io directly to unblock GitHub Pages immediately.