### PR TITLE
fix(operator): recreate only on immutable update errors

### DIFF
--- a/libs/operator/src/controller/context.rs
+++ b/libs/operator/src/controller/context.rs
@@ -25,7 +25,7 @@ use kube::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Duration;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 // Context for our reconciler
 #[derive(Clone)]
@@ -382,7 +382,7 @@ where
     async fn kube_patch(
         &self,
         client: Client,
-        metrics: &ControllerMetrics,
+        _metrics: &ControllerMetrics,
         obj: K,
         operator_name: &str,
     ) -> Result<K> {
@@ -394,7 +394,7 @@ where
             resource.name = &name,
             resource.namespace = &namespace
         );
-        let resource_api = Api::<K>::namespaced(client.clone(), &namespace);
+        let resource_api = Api::<K>::namespaced(client, &namespace);
 
         let result = resource_api
             .patch(
@@ -403,45 +403,28 @@ where
                 &Patch::Apply(&obj),
             )
             .await;
-        match result {
-            Ok(resource) => Ok(resource),
-            Err(e) => match e {
-                kube::Error::Api(ae) if ae.code == 422 => {
-                    info!(
-                        msg = format!(
-                            "recreating {} because the update operation was not possible",
-                            short_type_name::<K>().unwrap_or("Unknown")
-                        ),
-                        reason = ae.reason
-                    );
-                    trace!(msg = "operation was not possible because of 422", ?ae);
-                    self.kube_delete(client.clone(), metrics, &obj).await?;
-                    metrics.reconcile_deploy_delete_create_inc();
-                    resource_api
-                        .patch(
-                            &name,
-                            &PatchParams::apply(operator_name).force(),
-                            &Patch::Apply(&obj),
-                        )
-                        .await
-                        .map_err(|e| {
-                            Error::KubeError(
-                                format!(
-                                    "failed to re-try patch {} {namespace}/{name}",
-                                    short_type_name::<K>().unwrap_or("Unknown")
-                                ),
-                                Box::new(e),
-                            )
-                        })
-                }
-                _ => Err(Error::KubeError(
-                    format!(
-                        "failed to patch {} {namespace}/{name}",
-                        short_type_name::<K>().unwrap_or("Unknown")
-                    ),
-                    Box::new(e),
-                )),
-            },
+
+        if let Err(kube::Error::Api(ae)) = &result
+            && ae.code == 422
+        {
+            debug!(
+                msg = "server-side apply rejected resource; preserving the existing resource",
+                resource.kind = short_type_name::<K>().unwrap_or("Unknown"),
+                resource.name = &name,
+                resource.namespace = &namespace,
+                reason = %ae.reason,
+                message = %ae.message,
+            );
         }
+
+        result.map_err(|e| {
+            Error::KubeError(
+                format!(
+                    "failed to patch {} {namespace}/{name}",
+                    short_type_name::<K>().unwrap_or("Unknown")
+                ),
+                Box::new(e),
+            )
+        })
     }
 }

--- a/libs/operator/src/controller/context.rs
+++ b/libs/operator/src/controller/context.rs
@@ -25,7 +25,7 @@ use kube::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Duration;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 // Context for our reconciler
 #[derive(Clone)]
@@ -305,6 +305,16 @@ where
     }
 }
 
+fn is_immutable_update_message(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+
+    message.contains("field is immutable")
+        || message.contains("may not change once set")
+        || message.contains("may not be changed once set")
+        || (message.contains("updates to statefulset spec for fields other than")
+            && message.contains("are forbidden"))
+}
+
 #[allow(async_fn_in_trait)]
 pub trait KubeOperations<T, K>
 where
@@ -382,7 +392,7 @@ where
     async fn kube_patch(
         &self,
         client: Client,
-        _metrics: &ControllerMetrics,
+        metrics: &ControllerMetrics,
         obj: K,
         operator_name: &str,
     ) -> Result<K> {
@@ -394,7 +404,7 @@ where
             resource.name = &name,
             resource.namespace = &namespace
         );
-        let resource_api = Api::<K>::namespaced(client, &namespace);
+        let resource_api = Api::<K>::namespaced(client.clone(), &namespace);
 
         let result = resource_api
             .patch(
@@ -404,27 +414,92 @@ where
             )
             .await;
 
-        if let Err(kube::Error::Api(ae)) = &result
-            && ae.code == 422
-        {
-            debug!(
-                msg = "server-side apply rejected resource; preserving the existing resource",
-                resource.kind = short_type_name::<K>().unwrap_or("Unknown"),
-                resource.name = &name,
-                resource.namespace = &namespace,
-                reason = %ae.reason,
-                message = %ae.message,
-            );
-        }
-
-        result.map_err(|e| {
-            Error::KubeError(
+        match result {
+            Ok(resource) => Ok(resource),
+            Err(kube::Error::Api(ae))
+                if ae.code == 422 && is_immutable_update_message(&ae.message) =>
+            {
+                info!(
+                    msg = format!(
+                        "recreating {} because an immutable field changed",
+                        short_type_name::<K>().unwrap_or("Unknown")
+                    ),
+                    resource.name = &name,
+                    resource.namespace = &namespace,
+                    reason = %ae.reason,
+                    message = %ae.message,
+                );
+                self.kube_delete(client.clone(), metrics, &obj).await?;
+                metrics.reconcile_deploy_delete_create_inc();
+                resource_api
+                    .patch(
+                        &name,
+                        &PatchParams::apply(operator_name).force(),
+                        &Patch::Apply(&obj),
+                    )
+                    .await
+                    .map_err(|e| {
+                        Error::KubeError(
+                            format!(
+                                "failed to re-try patch {} {namespace}/{name}",
+                                short_type_name::<K>().unwrap_or("Unknown")
+                            ),
+                            Box::new(e),
+                        )
+                    })
+            }
+            Err(kube::Error::Api(ae)) if ae.code == 422 => {
+                debug!(
+                    msg = "server-side apply rejected resource with a non-immutable 422; preserving the existing resource",
+                    resource.kind = short_type_name::<K>().unwrap_or("Unknown"),
+                    resource.name = &name,
+                    resource.namespace = &namespace,
+                    reason = %ae.reason,
+                    message = %ae.message,
+                );
+                Err(Error::KubeError(
+                    format!(
+                        "failed to patch {} {namespace}/{name}",
+                        short_type_name::<K>().unwrap_or("Unknown")
+                    ),
+                    Box::new(kube::Error::Api(ae)),
+                ))
+            }
+            Err(e) => Err(Error::KubeError(
                 format!(
                     "failed to patch {} {namespace}/{name}",
                     short_type_name::<K>().unwrap_or("Unknown")
                 ),
                 Box::new(e),
-            )
-        })
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_immutable_update_message;
+
+    #[test]
+    fn immutable_update_messages_are_classified() {
+        assert!(is_immutable_update_message(
+            "Deployment.apps \"example\" is invalid: spec.selector: Invalid value: v1.LabelSelector{}: field is immutable"
+        ));
+        assert!(is_immutable_update_message(
+            "Service \"example\" is invalid: spec.clusterIPs[0]: Invalid value: \"10.0.0.1\": may not change once set"
+        ));
+        assert!(is_immutable_update_message(
+            "StatefulSet.apps \"example\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden"
+        ));
+    }
+
+    #[test]
+    fn ordinary_validation_messages_are_not_classified_as_immutable() {
+        assert!(!is_immutable_update_message(
+            "StatefulSet.apps \"example\" is invalid: spec.minReadySeconds: Invalid value: -1: must be greater than or equal to 0"
+        ));
+        assert!(!is_immutable_update_message(
+            "StatefulSet.apps \"example\" is invalid: spec.template.spec.containers[0].image: Required value"
+        ));
     }
 }

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -499,7 +499,16 @@ fn previous_tls_secret_hash(
         })
 }
 
+fn is_headless_service(service: &Service) -> bool {
+    service
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.cluster_ip.as_deref())
+        == Some("None")
+}
+
 fn preserve_defaulted_service_fields(desired: &mut Service, current: &Service) {
+    debug_assert_eq!(is_headless_service(desired), is_headless_service(current));
     let (Some(desired_spec), Some(current_spec)) = (desired.spec.as_mut(), current.spec.as_ref())
     else {
         return;
@@ -510,6 +519,39 @@ fn preserve_defaulted_service_fields(desired: &mut Service, current: &Service) {
     if desired_spec.cluster_ips.is_none() {
         desired_spec.cluster_ips = current_spec.cluster_ips.clone();
     }
+}
+
+async fn reconcile_service(
+    kanidm: &Kanidm,
+    ctx: &Context,
+    mut desired: Service,
+) -> Result<Service> {
+    let namespace = kanidm.get_namespace();
+    let name = desired.name_any();
+    let service_api = Api::<Service>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
+    let current = service_api
+        .get_opt(&name)
+        .await
+        .map_err(|e| Error::kube_error("get", "Service", &namespace, &name, e))?;
+
+    if let Some(current) = current {
+        let current_headless = is_headless_service(&current);
+        let desired_headless = is_headless_service(&desired);
+        if current_headless != desired_headless {
+            info!(
+                msg = "recreating Service to change headless mode",
+                resource.name = &name,
+                resource.namespace = &namespace,
+                current_headless,
+                desired_headless,
+            );
+            kanidm.delete(ctx, &current).await?;
+        } else {
+            preserve_defaulted_service_fields(&mut desired, &current);
+        }
+    }
+
+    kanidm.patch(ctx, desired).await
 }
 
 fn preserve_defaulted_statefulset_fields(desired: &mut StatefulSet, current: &StatefulSet) {
@@ -636,14 +678,7 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             try_join_all([])
         }
     };
-    let mut desired_service = kanidm.create_service();
-    if let Some(current) = ctx.stores.service_store.find(|current| {
-        current.namespace() == kanidm.namespace()
-            && current.name_any() == desired_service.name_any()
-    }) {
-        preserve_defaulted_service_fields(&mut desired_service, current.as_ref());
-    }
-    let service_future = kanidm.patch(&ctx, desired_service);
+    let service_future = reconcile_service(&kanidm, &ctx, kanidm.create_service());
 
     let deprecated_rg_svcs = {
         let expected_rg_svcs_names = kanidm
@@ -1280,7 +1315,7 @@ mod test {
             self
         }
 
-        /// Modify kanidm to set a deletion timestamp
+        /// Modify a kanidm to set a deletion timestamp
         pub fn needs_delete(mut self) -> Self {
             use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
             use k8s_openapi::jiff::Timestamp;

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -532,9 +532,11 @@ async fn reconcile_service(
     let name = desired.name_any();
     let desired_headless = is_headless_service(&desired);
 
-    if let Some(cached) = ctx.stores.service_store.find(|current| {
-        current.namespace() == kanidm.namespace() && current.name_any() == name
-    }) {
+    if let Some(cached) = ctx
+        .stores
+        .service_store
+        .find(|current| current.namespace() == kanidm.namespace() && current.name_any() == name)
+    {
         if is_headless_service(cached.as_ref()) == desired_headless {
             preserve_defaulted_service_fields(&mut desired, cached.as_ref());
         } else {

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -508,7 +508,9 @@ fn is_headless_service(service: &Service) -> bool {
 }
 
 fn preserve_defaulted_service_fields(desired: &mut Service, current: &Service) {
-    debug_assert_eq!(is_headless_service(desired), is_headless_service(current));
+    if is_headless_service(desired) != is_headless_service(current) {
+        return;
+    }
     let (Some(desired_spec), Some(current_spec)) = (desired.spec.as_mut(), current.spec.as_ref())
     else {
         return;
@@ -528,26 +530,36 @@ async fn reconcile_service(
 ) -> Result<Service> {
     let namespace = kanidm.get_namespace();
     let name = desired.name_any();
-    let service_api = Api::<Service>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
-    let current = service_api
-        .get_opt(&name)
-        .await
-        .map_err(|e| Error::kube_error("get", "Service", &namespace, &name, e))?;
+    let desired_headless = is_headless_service(&desired);
 
-    if let Some(current) = current {
-        let current_headless = is_headless_service(&current);
-        let desired_headless = is_headless_service(&desired);
-        if current_headless != desired_headless {
-            info!(
-                msg = "recreating Service to change headless mode",
-                resource.name = &name,
-                resource.namespace = &namespace,
-                current_headless,
-                desired_headless,
-            );
-            kanidm.delete(ctx, &current).await?;
+    if let Some(cached) = ctx.stores.service_store.find(|current| {
+        current.namespace() == kanidm.namespace() && current.name_any() == name
+    }) {
+        if is_headless_service(cached.as_ref()) == desired_headless {
+            preserve_defaulted_service_fields(&mut desired, cached.as_ref());
         } else {
-            preserve_defaulted_service_fields(&mut desired, &current);
+            // A destructive decision must be based on live state, not a potentially stale reflector.
+            let service_api = Api::<Service>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
+            let current = service_api
+                .get_opt(&name)
+                .await
+                .map_err(|e| Error::kube_error("get", "Service", &namespace, &name, e))?;
+
+            if let Some(current) = current {
+                let current_headless = is_headless_service(&current);
+                if current_headless != desired_headless {
+                    info!(
+                        msg = "recreating Service to change headless mode",
+                        resource.name = &name,
+                        resource.namespace = &namespace,
+                        current_headless,
+                        desired_headless,
+                    );
+                    kanidm.delete(ctx, &current).await?;
+                } else {
+                    preserve_defaulted_service_fields(&mut desired, &current);
+                }
+            }
         }
     }
 
@@ -1315,7 +1327,7 @@ mod test {
             self
         }
 
-        /// Modify a kanidm to set a deletion timestamp
+        /// Modify kanidm to set a deletion timestamp
         pub fn needs_delete(mut self) -> Self {
             use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
             use k8s_openapi::jiff::Timestamp;

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -43,7 +43,7 @@ use futures::stream::{self, StreamExt};
 use futures::try_join;
 use k8s_openapi::NamespaceResourceScope;
 use k8s_openapi::api::apps::v1::StatefulSet;
-use k8s_openapi::api::core::v1::{Pod, Secret};
+use k8s_openapi::api::core::v1::{Pod, Secret, Service};
 use kube::Resource;
 use kube::ResourceExt;
 use kube::api::{Api, AttachParams, Patch, PatchParams};
@@ -499,6 +499,19 @@ fn previous_tls_secret_hash(
         })
 }
 
+fn preserve_defaulted_service_fields(desired: &mut Service, current: &Service) {
+    let (Some(desired_spec), Some(current_spec)) = (desired.spec.as_mut(), current.spec.as_ref())
+    else {
+        return;
+    };
+    if desired_spec.cluster_ip.is_none() {
+        desired_spec.cluster_ip = current_spec.cluster_ip.clone();
+    }
+    if desired_spec.cluster_ips.is_none() {
+        desired_spec.cluster_ips = current_spec.cluster_ips.clone();
+    }
+}
+
 fn preserve_defaulted_statefulset_fields(desired: &mut StatefulSet, current: &StatefulSet) {
     let Some(desired_templates) = desired
         .spec
@@ -623,7 +636,14 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             try_join_all([])
         }
     };
-    let service_future = kanidm.patch(&ctx, kanidm.create_service());
+    let mut desired_service = kanidm.create_service();
+    if let Some(current) = ctx.stores.service_store.find(|current| {
+        current.namespace() == kanidm.namespace()
+            && current.name_any() == desired_service.name_any()
+    }) {
+        preserve_defaulted_service_fields(&mut desired_service, current.as_ref());
+    }
+    let service_future = kanidm.patch(&ctx, desired_service);
 
     let deprecated_rg_svcs = {
         let expected_rg_svcs_names = kanidm
@@ -659,7 +679,16 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
         .iter()
         .filter(|rg| rg.services.is_some())
         .flat_map(|rg| {
-            (0..rg.replicas).map(|i| kanidm.patch(&ctx, kanidm.create_replica_group_service(rg, i)))
+            (0..rg.replicas).map(|i| {
+                let mut svc = kanidm.create_replica_group_service(rg, i);
+                if let Some(current) = ctx.stores.service_store.find(|current| {
+                    current.namespace() == kanidm.namespace()
+                        && current.name_any() == svc.name_any()
+                }) {
+                    preserve_defaulted_service_fields(&mut svc, current.as_ref());
+                }
+                kanidm.patch(&ctx, svc)
+            })
         })
         .collect::<TryJoinAll<_>>();
 

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -499,6 +499,45 @@ fn previous_tls_secret_hash(
         })
 }
 
+fn preserve_defaulted_statefulset_fields(desired: &mut StatefulSet, current: &StatefulSet) {
+    let Some(desired_templates) = desired
+        .spec
+        .as_mut()
+        .and_then(|spec| spec.volume_claim_templates.as_mut())
+    else {
+        return;
+    };
+    let Some(current_templates) = current
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.volume_claim_templates.as_ref())
+    else {
+        return;
+    };
+
+    for desired_template in desired_templates {
+        let Some(name) = desired_template.metadata.name.as_deref() else {
+            continue;
+        };
+        let Some(current_template) = current_templates
+            .iter()
+            .find(|template| template.metadata.name.as_deref() == Some(name))
+        else {
+            continue;
+        };
+        let (Some(desired_spec), Some(current_spec)) = (
+            desired_template.spec.as_mut(),
+            current_template.spec.as_ref(),
+        ) else {
+            continue;
+        };
+
+        if desired_spec.storage_class_name.is_none() {
+            desired_spec.storage_class_name = current_spec.storage_class_name.clone();
+        }
+    }
+}
+
 async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus) -> Result<Action> {
     let admin_secret_future = reconcile_admins_secret(kanidm.clone(), ctx.clone(), &status);
     let replication_secret_futures =
@@ -541,7 +580,13 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
                 .replica_groups
                 .iter()
                 .map(|rg| {
-                    let sts = kanidm.create_statefulset(rg, tls_secret_hash.as_deref())?;
+                    let mut sts = kanidm.create_statefulset(rg, tls_secret_hash.as_deref())?;
+                    if let Some(current) = ctx.stores.stateful_set_store.find(|current| {
+                        current.namespace() == kanidm.namespace()
+                            && current.name_any() == sts.name_any()
+                    }) {
+                        preserve_defaulted_statefulset_fields(&mut sts, current.as_ref());
+                    }
                     Ok(kanidm.patch(&ctx, sts))
                 })
                 .collect::<Result<TryJoinAll<_>, _>>()?

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -103,7 +103,6 @@ e2e_test!(kanidm_init_containers_without_replication, {
     let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
     let sts = s.statefulset_api.get(&sts_name).await.unwrap();
 
-    // Verify the init container was filtered out
     let init_containers = sts
         .spec
         .as_ref()
@@ -115,7 +114,6 @@ e2e_test!(kanidm_init_containers_without_replication, {
         .init_containers
         .as_ref();
 
-    // Either no init containers or none with the replication config name
     if let Some(containers) = init_containers {
         assert!(
             !containers
@@ -248,7 +246,6 @@ pub struct SetupKanidm {
     pub kanidm_api: Api<Kanidm>,
     pub statefulset_api: Api<StatefulSet>,
     pub secret_api: Api<Secret>,
-    // TODO: remove this silent dead_code
     #[allow(dead_code)]
     pub admin_password: String,
     pub idm_admin_password: String,
@@ -479,7 +476,6 @@ e2e_test!(kanidm_change_kanidm_replicas, {
 
     assert_eq!(check_sts.clone().spec.unwrap().replicas.unwrap(), 2);
     let sts_name = check_sts.name_any();
-    // wait for restarts
     wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
 
     let pod_api = Api::<Pod>::namespaced(s.client.clone(), "default");
@@ -585,7 +581,7 @@ e2e_test!(kanidm_statefulset_already_exists, {
 });
 
 e2e_test!(
-    kanidm_statefulset_immutable_field_conflict_is_non_destructive,
+    kanidm_statefulset_immutable_field_conflict_recreates_statefulset,
     {
         init_crypto_provider();
         let name = "test-sts-immutable-conflict";
@@ -631,7 +627,7 @@ e2e_test!(
             .unwrap();
         let original_uid = original.uid().unwrap();
 
-        let (_, kanidm_api) = create_kanidm(
+        let _ = create_kanidm(
             &client,
             name,
             Some(json!({
@@ -641,52 +637,74 @@ e2e_test!(
         .await;
         create_secret(&client, name).await;
 
-        wait_for(kanidm_api.clone(), name, |obj: Option<&Kanidm>| {
-            obj.is_some_and(|kanidm| {
-                kanidm
-                    .metadata
-                    .finalizers
-                    .as_ref()
-                    .is_some_and(|finalizers| !finalizers.is_empty())
-            })
-        })
-        .await;
-
-        // Status is updated before child resources are reconciled. Waiting for two
-        // status updates after finalizer installation proves a full reconciliation
-        // returned from the immutable-field 422 before we assert the StatefulSet UID.
-        let after_finalizer = kanidm_api.get(name).await.unwrap();
-        let generation = after_finalizer.metadata.generation.unwrap();
-        let resource_version = after_finalizer.resource_version().unwrap();
+        let expected_instance = name.to_string();
         wait_for(
-            kanidm_api.clone(),
-            name,
-            has_observed_generation_after(generation, resource_version),
+            statefulset_api.clone(),
+            &sts_name,
+            move |obj: Option<&StatefulSet>| {
+                obj.is_some_and(|sts| {
+                    sts.metadata.uid.as_deref() != Some(original_uid.as_str())
+                        && sts
+                            .spec
+                            .as_ref()
+                            .and_then(|spec| spec.selector.match_labels.as_ref())
+                            .and_then(|labels| labels.get("app.kubernetes.io/instance"))
+                            == Some(&expected_instance)
+                })
+            },
         )
         .await;
-
-        let after_first_reconcile = kanidm_api.get(name).await.unwrap();
-        let resource_version = after_first_reconcile.resource_version().unwrap();
-        wait_for(
-            kanidm_api,
-            name,
-            has_observed_generation_after(generation, resource_version),
-        )
-        .await;
-
-        let current = statefulset_api.get(&sts_name).await.unwrap();
-        assert_eq!(current.uid().as_deref(), Some(original_uid.as_str()));
-        assert_eq!(
-            current
-                .spec
-                .as_ref()
-                .and_then(|spec| spec.selector.match_labels.as_ref())
-                .and_then(|labels| labels.get("app"))
-                .map(String::as_str),
-            Some("conflicting-selector")
-        );
     }
 );
+
+e2e_test!(kanidm_statefulset_non_immutable_422_is_non_destructive, {
+    let name = "test-sts-non-immutable-422";
+    let s = setup(name, None).await;
+    let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+    let original = s.statefulset_api.get(&sts_name).await.unwrap();
+    let original_uid = original.uid().unwrap();
+
+    let mut kanidm = s.kanidm_api.get(name).await.unwrap();
+    kanidm.spec.min_ready_seconds = Some(-1);
+    kanidm.metadata.managed_fields = None;
+    let patched = s
+        .kanidm_api
+        .patch(
+            name,
+            &PatchParams::apply("e2e-test").force(),
+            &Patch::Apply(&kanidm),
+        )
+        .await
+        .unwrap();
+
+    let generation = patched.metadata.generation.unwrap();
+    let resource_version = patched.resource_version().unwrap();
+    wait_for(
+        s.kanidm_api.clone(),
+        name,
+        has_observed_generation_after(generation, resource_version),
+    )
+    .await;
+
+    let after_first_reconcile = s.kanidm_api.get(name).await.unwrap();
+    let resource_version = after_first_reconcile.resource_version().unwrap();
+    wait_for(
+        s.kanidm_api.clone(),
+        name,
+        has_observed_generation_after(generation, resource_version),
+    )
+    .await;
+
+    let current = s.statefulset_api.get(&sts_name).await.unwrap();
+    assert_eq!(current.uid().as_deref(), Some(original_uid.as_str()));
+    assert_ne!(
+        current
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.min_ready_seconds),
+        Some(-1)
+    );
+});
 
 e2e_test!(kanidm_change_domain, {
     let name = "test-change-kanidm-domain";
@@ -872,7 +890,6 @@ e2e_test!(
 
         assert_eq!(check_sts.clone().spec.unwrap().replicas.unwrap(), 2);
         let sts_name = check_sts.name_any();
-        // wait for restarts
         wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
 
         let pod_api = Api::<Pod>::namespaced(s.client.clone(), "default");
@@ -881,13 +898,11 @@ e2e_test!(
             .collect::<Vec<_>>();
         wait_for_replication_success_with_timeout(&pod_api, &pod_names).await;
 
-        // patch secret to trigger certificate renewal
         for i in 0..replicas {
             let pod_name = format!("{sts_name}-{i}");
             let secret_name = kanidm.replica_secret_name(&pod_name);
             let mut secret = s.secret_api.get(&secret_name).await.unwrap();
             let data = secret.data.as_mut().unwrap();
-            // Change secret for an expired certificate
             data.insert("tls.der.b64url".to_string(), ByteString(b"MIICAzCCAamgAwIBAgIUabYGR1vKncj22sN2DpTmWocmfuswCgYIKoZIzj0EAwIwTDEbMBkGA1UECgwSS2FuaWRtIFJlcGxpY2F0aW9uMS0wKwYDVQQDDCQyYmE4MzE2YS1lYmFhLTRiYzEtODQ5My01Zjg2ZmFmYWU1OTQwHhcNMjUxMDEyMTExOTQxWhcNMjUxMDEzMTExOTQxWjBMMRswGQYDVQQKDBJLYW5pZG0gUmVwbGljYXRpb24xLTArBgNVBAMMJDJiYTgzMTZhLWViYWEtNGJjMS04NDkzLTVmODZmYWZhZTU5NDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABKPMz0fox2HAsE8PM2hT0aWV8r7sIa3v6R6azORc4HMzs6JilLacJVfMm97Kerzcdx6VlTaQaapScFkGQNVfGv6jaTBnMB0GA1UdDgQWBBSqpOBYyTNyBhQRIAe9UvjqJZ3_nDAfBgNVHSMEGDAWgBSqpOBYyTNyBhQRIAe9UvjqJZ3_nDAPBgNVHRMBAf8EBTADAQH_MBQGA1UdEQQNMAuCCWxvY2FsaG9zdDAKBggqhkjOPQQDAgNIADBFAiEA7_2p0-7uMsT02kOX5u0Bd32u6691fo9071QfZdvcVgcCIC-noe1886tavYc3xYd_nZWIsM4HM2CM33gXggYgVwgw".to_vec()));
             secret.metadata.managed_fields = None;
             s.secret_api
@@ -927,8 +942,6 @@ e2e_test!(kanidm_tls_secret_renewal, {
     let sts = s.statefulset_api.get(&sts_name).await.unwrap();
     let initial_hash = tls_hash_annotation(&sts).expect("TLS hash annotation on pod template");
 
-    // Simulate a cert-manager renewal: change the TLS secret content. The
-    // appended newline keeps the PEM parseable so pods restart cleanly.
     let secret_name = format!("{name}-tls");
     let mut secret = s.secret_api.get(&secret_name).await.unwrap();
     secret
@@ -946,7 +959,6 @@ e2e_test!(kanidm_tls_secret_renewal, {
         .await
         .unwrap();
 
-    // the operator must roll the statefulset with a fresh hash
     wait_for(
         s.statefulset_api.clone(),
         &sts_name,
@@ -987,7 +999,6 @@ e2e_test!(kanidm_block_incompatible_version_upgrade, {
         .clone()
         .unwrap();
 
-    // Use major version 99 which will always be incompatible (client SDK uses 1.x)
     let incompatible_image = "kanidm/server:99.0.0";
     let mut kanidm = s.kanidm_api.get(name).await.unwrap();
     kanidm.spec.image = incompatible_image.to_string();
@@ -1042,7 +1053,6 @@ e2e_test!(kanidm_block_incompatible_version_initial_creation, {
     use kaniop_operator::kanidm::crd::VersionCompatibilityResult;
 
     let name = "test-block-incompatible-initial";
-    // Use major version 99 which will always be incompatible (client SDK uses 1.x)
     let incompatible_image = "kanidm/server:99.0.0";
 
     let mut kanidm_spec_json = KANIDM_DEFAULT_SPEC_JSON.clone();

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -18,7 +18,7 @@ use futures::join;
 use json_patch::merge;
 use k8s_openapi::ByteString;
 use k8s_openapi::api::apps::v1::StatefulSet;
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod, Secret};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod, Secret, Service};
 use kube::ResourceExt;
 use kube::api::{Api, LogParams, ObjectMeta, Patch, PatchParams, PostParams};
 use kube::client::Client;
@@ -146,6 +146,26 @@ pub fn is_kanidm_false(cond: &str) -> impl Condition<Kanidm> + '_ {
     check_kanidm_condition(cond, "False".to_string())
 }
 
+fn has_observed_generation_after(
+    generation: i64,
+    resource_version: String,
+) -> impl Condition<Kanidm> {
+    move |obj: Option<&Kanidm>| {
+        obj.is_some_and(|kanidm| {
+            kanidm.metadata.resource_version.as_deref() != Some(resource_version.as_str())
+                && kanidm
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.conditions.as_ref())
+                    .is_some_and(|conditions| {
+                        conditions
+                            .iter()
+                            .any(|condition| condition.observed_generation == Some(generation))
+                    })
+        })
+    }
+}
+
 fn is_statefulset_ready(obj: Option<&StatefulSet>) -> bool {
     obj.and_then(|statefulset| statefulset.status.as_ref())
         .is_some_and(|s| s.ready_replicas == Some(s.replicas))
@@ -183,7 +203,7 @@ async fn create_kanidm(
     let mut kanidm_spec_json = KANIDM_DEFAULT_SPEC_JSON.clone();
     if let Some(patch) = kanidm_spec_patch {
         merge(&mut kanidm_spec_json, &patch);
-    };
+    }
 
     let kanidm = Kanidm::new(name, serde_json::from_value(kanidm_spec_json).unwrap());
 
@@ -407,6 +427,16 @@ e2e_test!(kanidm_change_statefulset, {
 e2e_test!(kanidm_change_kanidm_replicas, {
     let name = "test-change-kanidm-replicas";
     let s = setup(name, Some(STORAGE_VOLUME_CLAIM_TEMPLATE_JSON.clone())).await;
+    let service_api = Api::<Service>::namespaced(s.client.clone(), "default");
+    let original_service = service_api.get(name).await.unwrap();
+    let original_service_uid = original_service.uid().unwrap();
+    assert_ne!(
+        original_service
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.cluster_ip.as_deref()),
+        Some("None")
+    );
 
     let mut kanidm = s.kanidm_api.get(name).await.unwrap();
     kanidm.spec.replica_groups[0].replicas = 2;
@@ -420,6 +450,18 @@ e2e_test!(kanidm_change_kanidm_replicas, {
         )
         .await
         .unwrap();
+
+    wait_for(service_api.clone(), name, move |obj: Option<&Service>| {
+        obj.is_some_and(|service| {
+            service.metadata.uid.as_deref() != Some(original_service_uid.as_str())
+                && service
+                    .spec
+                    .as_ref()
+                    .and_then(|spec| spec.cluster_ip.as_deref())
+                    == Some("None")
+        })
+    })
+    .await;
 
     wait_for(s.kanidm_api.clone(), name, |obj: Option<&Kanidm>| {
         obj.and_then(|kanidm| kanidm.status.as_ref())
@@ -589,11 +631,48 @@ e2e_test!(
             .unwrap();
         let original_uid = original.uid().unwrap();
 
-        let _ = create_kanidm(&client, name, None).await;
+        let (_, kanidm_api) = create_kanidm(
+            &client,
+            name,
+            Some(json!({
+                "disableUpgradeChecks": true
+            })),
+        )
+        .await;
         create_secret(&client, name).await;
 
-        // Give the controller enough time to observe the Kanidm and receive the immutable-field 422.
-        sleep(Duration::from_secs(5)).await;
+        wait_for(kanidm_api.clone(), name, |obj: Option<&Kanidm>| {
+            obj.is_some_and(|kanidm| {
+                kanidm
+                    .metadata
+                    .finalizers
+                    .as_ref()
+                    .is_some_and(|finalizers| !finalizers.is_empty())
+            })
+        })
+        .await;
+
+        // Status is updated before child resources are reconciled. Waiting for two
+        // status updates after finalizer installation proves a full reconciliation
+        // returned from the immutable-field 422 before we assert the StatefulSet UID.
+        let after_finalizer = kanidm_api.get(name).await.unwrap();
+        let generation = after_finalizer.metadata.generation.unwrap();
+        let resource_version = after_finalizer.resource_version().unwrap();
+        wait_for(
+            kanidm_api.clone(),
+            name,
+            has_observed_generation_after(generation, resource_version),
+        )
+        .await;
+
+        let after_first_reconcile = kanidm_api.get(name).await.unwrap();
+        let resource_version = after_first_reconcile.resource_version().unwrap();
+        wait_for(
+            kanidm_api,
+            name,
+            has_observed_generation_after(generation, resource_version),
+        )
+        .await;
 
         let current = statefulset_api.get(&sts_name).await.unwrap();
         assert_eq!(current.uid().as_deref(), Some(original_uid.as_str()));

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -505,7 +505,7 @@ e2e_test!(
             .and_then(|templates| templates.first())
             .and_then(|pvc| pvc.spec.as_ref())
             .and_then(|spec| spec.storage_class_name.as_deref());
-        assert_eq!(storage_class, Some("standard"));
+        assert_eq!(storage_class, None);
 
         let mut kanidm = s.kanidm_api.get(name).await.unwrap();
         kanidm.spec.min_ready_seconds = Some(1);

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -62,6 +62,24 @@ static STORAGE_VOLUME_CLAIM_TEMPLATE_JSON: LazyLock<serde_json::Value> = LazyLoc
     })
 });
 
+static STORAGE_VOLUME_CLAIM_TEMPLATE_DEFAULT_CLASS_JSON: LazyLock<serde_json::Value> =
+    LazyLock::new(|| {
+        json!({
+            "storage": {
+                "volumeClaimTemplate": {
+                    "spec": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": {
+                            "requests": {
+                                "storage": "1Gi"
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    });
+
 static INIT_CONTAINERS_SECURITY_CONTEXT_JSON: LazyLock<serde_json::Value> = LazyLock::new(|| {
     json!({
         "initContainers": [
@@ -429,6 +447,55 @@ e2e_test!(kanidm_change_kanidm_replicas, {
     wait_for_replication_success_with_timeout(&pod_api, &pod_names).await;
 });
 
+e2e_test!(
+    kanidm_default_storage_class_does_not_recreate_statefulset,
+    {
+        let name = "test-default-storage-class";
+        let s = setup(
+            name,
+            Some(STORAGE_VOLUME_CLAIM_TEMPLATE_DEFAULT_CLASS_JSON.clone()),
+        )
+        .await;
+
+        let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+        let original = s.statefulset_api.get(&sts_name).await.unwrap();
+        let original_uid = original.uid().unwrap();
+        let storage_class = original
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.volume_claim_templates.as_ref())
+            .and_then(|templates| templates.first())
+            .and_then(|pvc| pvc.spec.as_ref())
+            .and_then(|spec| spec.storage_class_name.as_deref());
+        assert_eq!(storage_class, Some("standard"));
+
+        let mut kanidm = s.kanidm_api.get(name).await.unwrap();
+        kanidm.spec.min_ready_seconds = Some(1);
+        kanidm.metadata.managed_fields = None;
+        s.kanidm_api
+            .patch(
+                name,
+                &PatchParams::apply("e2e-test").force(),
+                &Patch::Apply(&kanidm),
+            )
+            .await
+            .unwrap();
+
+        wait_for(
+            s.statefulset_api.clone(),
+            &sts_name,
+            |obj: Option<&StatefulSet>| {
+                obj.and_then(|sts| sts.spec.as_ref())
+                    .is_some_and(|spec| spec.min_ready_seconds == Some(1))
+            },
+        )
+        .await;
+
+        let updated = s.statefulset_api.get(&sts_name).await.unwrap();
+        assert_eq!(updated.uid().as_deref(), Some(original_uid.as_str()));
+    }
+);
+
 e2e_test!(kanidm_statefulset_already_exists, {
     init_crypto_provider();
     let name = "test-statefulset-already-exists";
@@ -475,71 +542,72 @@ e2e_test!(kanidm_statefulset_already_exists, {
     setup(name, None).await;
 });
 
-e2e_test!(kanidm_statefulset_immutable_field_conflict, {
-    init_crypto_provider();
-    let name = "test-sts-immutable-conflict";
-    let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
-    let statefulset = json!({
-        "apiVersion": "apps/v1",
-        "kind": "StatefulSet",
-        "metadata": {
-            "name": sts_name
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "app": "conflicting-selector"
-                }
+e2e_test!(
+    kanidm_statefulset_immutable_field_conflict_is_non_destructive,
+    {
+        init_crypto_provider();
+        let name = "test-sts-immutable-conflict";
+        let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+        let statefulset = json!({
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "name": sts_name
             },
-            "template": {
-                "metadata": {
-                    "labels": {
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {
                         "app": "conflicting-selector"
                     }
                 },
-                "spec": {
-                    "containers": [
-                        {
-                            "name": name,
-                            "image": "kanidm/server:latest"
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "conflicting-selector"
                         }
-                    ]
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": name,
+                                "image": "kanidm/server:latest"
+                            }
+                        ]
+                    }
                 }
             }
-        }
-    });
-    let statefulset_api =
-        Api::<StatefulSet>::namespaced(Client::try_default().await.unwrap(), "default");
-    statefulset_api
-        .create(
-            &PostParams::default(),
-            &serde_json::from_value(statefulset).unwrap(),
-        )
-        .await
-        .unwrap();
+        });
+        let client = Client::try_default().await.unwrap();
+        let statefulset_api = Api::<StatefulSet>::namespaced(client.clone(), "default");
+        let original = statefulset_api
+            .create(
+                &PostParams::default(),
+                &serde_json::from_value(statefulset).unwrap(),
+            )
+            .await
+            .unwrap();
+        let original_uid = original.uid().unwrap();
 
-    setup(name, None).await;
+        let _ = create_kanidm(&client, name, None).await;
+        create_secret(&client, name).await;
 
-    let sts = statefulset_api.get(&sts_name).await.unwrap();
-    let match_labels = sts
-        .spec
-        .as_ref()
-        .unwrap()
-        .selector
-        .match_labels
-        .as_ref()
-        .unwrap();
-    assert!(
-        match_labels.get("app").is_none()
-            || match_labels.get("app") != Some(&"conflicting-selector".to_string()),
-        "StatefulSet selector should be replaced by operator"
-    );
-    assert!(
-        match_labels.contains_key("app.kubernetes.io/instance"),
-        "StatefulSet should have operator labels"
-    );
-});
+        // Give the controller enough time to observe the Kanidm and receive the immutable-field 422.
+        sleep(Duration::from_secs(5)).await;
+
+        let current = statefulset_api.get(&sts_name).await.unwrap();
+        assert_eq!(current.uid().as_deref(), Some(original_uid.as_str()));
+        assert_eq!(
+            current
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.selector.match_labels.as_ref())
+                .and_then(|labels| labels.get("app"))
+                .map(String::as_str),
+            Some("conflicting-selector")
+        );
+    }
+);
 
 e2e_test!(kanidm_change_domain, {
     let name = "test-change-kanidm-domain";


### PR DESCRIPTION
## Summary

Make child-resource reconciliation selective and non-destructive: only known immutable-field `422 Unprocessable Entity` responses may use the delete/recreate fallback, while ordinary validation 422s preserve the existing resource. Also harden StatefulSet reconciliation against Kubernetes-defaulted PVC fields and handle Service headless transitions explicitly.

## What changed

- Refactor `KubeOperations::kube_patch` so `422` is no longer treated as a generic recreate signal.
  - Classify Kubernetes immutable-update messages (`field is immutable`, `may not change once set`, and the StatefulSet immutable-spec `Forbidden` form).
  - Only those immutable 422s trigger delete -> recreate -> retry.
  - Other 422 validation failures are propagated and the existing resource is preserved.
- Add unit coverage for immutable vs ordinary validation error classification.
- Update StatefulSet E2E coverage:
  - an immutable selector conflict must recreate the StatefulSet and change its UID;
  - a non-immutable validation 422 (`minReadySeconds: -1`) must keep the existing StatefulSet UID unchanged.
  - synchronization uses status/`observedGeneration`, not a fixed sleep.
- Preserve a server-defaulted `storageClassName` from an existing StatefulSet `volumeClaimTemplate` when the desired Kanidm spec leaves it unset.
  - This targets the default-StorageClass failure mode reported in #878.
- Handle the main Kanidm Service's ClusterIP/headless transition explicitly.
  - Preserve server-assigned `clusterIP`/`clusterIPs` only when current and desired Services have the same headless mode.
  - When replication changes require switching between normal ClusterIP and headless, confirm the transition against the live Service and perform a controlled recreate instead of swallowing the requested change.
- Extend E2E coverage for the replication transition to assert that the Service becomes headless and receives a new UID.

## Why

`422 Unprocessable Entity` covers both immutable-update failures and ordinary invalid desired state. Deleting a healthy StatefulSet for every 422 turns configuration mistakes into outages. At the same time, genuine immutable Kubernetes fields still require recreation. The reconciler now distinguishes those cases instead of making the decision from the HTTP status code alone.

Service ClusterIP/headless changes remain resource-specific because preserving server-defaulted IP fields would otherwise suppress the requested transition.

## Validation

- `cargo fmt --all -- --check`
- Clippy / pull-request Rust checks
- unit tests for 422 classification
- E2E coverage for immutable recreate vs non-immutable preservation
- normal pull-request CI provides the full repository validation

Related to #878.