### PR TITLE
fix(crd): make migration hooks resume safely

### DIFF
--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -17,10 +17,8 @@ path = "src/main.rs"
 [dependencies]
 kaniop-crd-migration = { workspace = true }
 clap = { workspace = true, features = ["cargo", "env"] }
-k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
-serde_json = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 kaniop-crd-migration = { workspace = true }
 clap = { workspace = true, features = ["cargo", "env"] }
+k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true, features = ["cargo", "env"] }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,7 +1,10 @@
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
 use kaniop_crd_migration::{
     migration::{MigrationConfig, run_postsync, run_presync},
-    runtime::{enforce_sticky_fail_injection, restore_operator_for_postsync},
+    runtime::{
+        enforce_sticky_fail_injection, persist_original_operator_replicas_for_presync,
+        restore_operator_for_postsync,
+    },
 };
 use rustls::crypto::aws_lc_rs::default_provider;
 
@@ -66,6 +69,7 @@ async fn main() -> anyhow::Result<()> {
 
     match args.command {
         Command::MigratePersonAccount => {
+            persist_original_operator_replicas_for_presync(&client, &config).await?;
             enforce_sticky_fail_injection(&client, &config).await?;
             run_presync(&client, &config).await?;
         }

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,18 +1,9 @@
-use std::{env, time::Duration};
-
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
-use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
 use kaniop_crd_migration::{
-    MigrationError,
     migration::{MigrationConfig, run_postsync, run_presync},
-    state::{Phase, get_marker},
+    runtime::{enforce_sticky_fail_injection, restore_operator_for_postsync},
 };
-use kube::{Api, api::{Patch, PatchParams}};
 use rustls::crypto::aws_lc_rs::default_provider;
-use tokio::time::sleep;
-
-const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
-const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Parser, Debug)]
 #[command(
@@ -48,138 +39,6 @@ struct Args {
 enum Command {
     MigratePersonAccount,
     VerifyPersonAccount,
-}
-
-async fn enforce_sticky_fail_injection(
-    client: &kube::Client,
-    config: &MigrationConfig,
-) -> anyhow::Result<()> {
-    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
-        .ok()
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(());
-    };
-
-    let fail_phase: Phase = fail_after.parse()?;
-    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
-    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
-        return Ok(());
-    };
-
-    if marker.phase == fail_phase {
-        return Err(MigrationError::InjectedFailure(fail_phase.to_string()).into());
-    }
-
-    Ok(())
-}
-
-async fn restore_operator_for_postsync(
-    client: &kube::Client,
-    config: &MigrationConfig,
-) -> anyhow::Result<()> {
-    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
-    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
-        return Ok(());
-    };
-
-    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
-        return Ok(());
-    }
-
-    let Some(original_replicas) = marker.original_replicas else {
-        return Ok(());
-    };
-
-    let deployment_api: Api<Deployment> =
-        Api::namespaced(client.clone(), &config.operator_namespace);
-    let deployment = deployment_api
-        .get(&config.operator_deployment)
-        .await
-        .map_err(|error| {
-            MigrationError::Kube(
-                format!("get deployment {} for PostSync restore", config.operator_deployment),
-                Box::new(error),
-            )
-        })?;
-    let current_replicas = deployment
-        .spec
-        .as_ref()
-        .and_then(|spec| spec.replicas)
-        .unwrap_or(1);
-
-    if current_replicas != original_replicas {
-        tracing::info!(
-            deployment = %config.operator_deployment,
-            replicas = original_replicas,
-            "restoring operator replicas before PostSync adoption verification"
-        );
-        let patch = serde_json::json!({
-            "spec": {
-                "replicas": original_replicas
-            }
-        });
-        deployment_api
-            .patch(
-                &config.operator_deployment,
-                &PatchParams::default(),
-                &Patch::Merge(&patch),
-            )
-            .await
-            .map_err(|error| {
-                MigrationError::Kube(
-                    format!(
-                        "restore deployment {} to {original_replicas} replicas",
-                        config.operator_deployment
-                    ),
-                    Box::new(error),
-                )
-            })?;
-    }
-
-    if original_replicas == 0 {
-        return Ok(());
-    }
-
-    let start = std::time::Instant::now();
-    loop {
-        let deployment = deployment_api
-            .get(&config.operator_deployment)
-            .await
-            .map_err(|error| {
-                MigrationError::Kube(
-                    format!(
-                        "get deployment {} while waiting for PostSync restore",
-                        config.operator_deployment
-                    ),
-                    Box::new(error),
-                )
-            })?;
-        let status = deployment.status.as_ref();
-        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
-        let available = status
-            .and_then(|status| status.available_replicas)
-            .unwrap_or(0);
-
-        if ready >= original_replicas && available >= original_replicas {
-            tracing::info!(
-                deployment = %config.operator_deployment,
-                replicas = original_replicas,
-                "operator restored for PostSync adoption verification"
-            );
-            return Ok(());
-        }
-
-        if start.elapsed() > config.timeout {
-            return Err(MigrationError::Timeout(format!(
-                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
-                config.operator_deployment
-            ))
-            .into());
-        }
-
-        sleep(POLL_INTERVAL).await;
-    }
 }
 
 #[tokio::main]

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,6 +1,18 @@
+use std::{env, time::Duration};
+
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
-use kaniop_crd_migration::migration::{MigrationConfig, run_postsync, run_presync};
+use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use kaniop_crd_migration::{
+    MigrationError,
+    migration::{MigrationConfig, run_postsync, run_presync},
+    state::{Phase, get_marker},
+};
+use kube::{Api, api::{Patch, PatchParams}};
 use rustls::crypto::aws_lc_rs::default_provider;
+use tokio::time::sleep;
+
+const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Parser, Debug)]
 #[command(
@@ -38,6 +50,138 @@ enum Command {
     VerifyPersonAccount,
 }
 
+async fn enforce_sticky_fail_injection(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> anyhow::Result<()> {
+    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let fail_phase: Phase = fail_after.parse()?;
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase == fail_phase {
+        return Err(MigrationError::InjectedFailure(fail_phase.to_string()).into());
+    }
+
+    Ok(())
+}
+
+async fn restore_operator_for_postsync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> anyhow::Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
+        return Ok(());
+    }
+
+    let Some(original_replicas) = marker.original_replicas else {
+        return Ok(());
+    };
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!("get deployment {} for PostSync restore", config.operator_deployment),
+                Box::new(error),
+            )
+        })?;
+    let current_replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    if current_replicas != original_replicas {
+        tracing::info!(
+            deployment = %config.operator_deployment,
+            replicas = original_replicas,
+            "restoring operator replicas before PostSync adoption verification"
+        );
+        let patch = serde_json::json!({
+            "spec": {
+                "replicas": original_replicas
+            }
+        });
+        deployment_api
+            .patch(
+                &config.operator_deployment,
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "restore deployment {} to {original_replicas} replicas",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+    }
+
+    if original_replicas == 0 {
+        return Ok(());
+    }
+
+    let start = std::time::Instant::now();
+    loop {
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while waiting for PostSync restore",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let status = deployment.status.as_ref();
+        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
+        let available = status
+            .and_then(|status| status.available_replicas)
+            .unwrap_or(0);
+
+        if ready >= original_replicas && available >= original_replicas {
+            tracing::info!(
+                deployment = %config.operator_deployment,
+                replicas = original_replicas,
+                "operator restored for PostSync adoption verification"
+            );
+            return Ok(());
+        }
+
+        if start.elapsed() > config.timeout {
+            return Err(MigrationError::Timeout(format!(
+                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
+                config.operator_deployment
+            ))
+            .into());
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     default_provider().install_default().unwrap();
@@ -63,9 +207,11 @@ async fn main() -> anyhow::Result<()> {
 
     match args.command {
         Command::MigratePersonAccount => {
+            enforce_sticky_fail_injection(&client, &config).await?;
             run_presync(&client, &config).await?;
         }
         Command::VerifyPersonAccount => {
+            restore_operator_for_postsync(&client, &config).await?;
             let result = run_postsync(&client, &config).await?;
             if kaniop_crd_migration::verify::adoption_verification_passed(&result) {
                 tracing::info!(

--- a/libs/crd-migration/src/lib.rs
+++ b/libs/crd-migration/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod checksum;
 pub mod crd;
 pub mod migration;
+pub mod runtime;
 pub mod sanitize;
 pub mod state;
 pub mod verify;

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,0 +1,159 @@
+use std::{env, time::Duration};
+
+use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use kube::{Api, api::{Patch, PatchParams}};
+use tokio::time::sleep;
+use tracing::info;
+
+use crate::{
+    MigrationError, Result,
+    migration::MigrationConfig,
+    state::{Phase, get_marker},
+};
+
+const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Keep failure injection active when Kubernetes restarts a failed migration container.
+///
+/// The migration state machine persists the completed phase before injecting the failure. Without
+/// this check, a restarted container resumes from that marker and advances past the requested
+/// failure point.
+pub async fn enforce_sticky_fail_injection(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let fail_phase: Phase = fail_after.parse()?;
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase == fail_phase {
+        return Err(MigrationError::InjectedFailure(fail_phase.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Restore the operator replica count recorded by PreSync before verifying adoption.
+///
+/// PreSync intentionally scales the operator to zero while replacing the CRD. Helm and Argo CD do
+/// not necessarily restore that live replica drift before the PostSync hook runs, so adoption can
+/// never complete unless the migrator restores the recorded replica count itself.
+pub async fn restore_operator_for_postsync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
+        return Ok(());
+    }
+
+    let Some(original_replicas) = marker.original_replicas else {
+        return Ok(());
+    };
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!(
+                    "get deployment {} for PostSync restore",
+                    config.operator_deployment
+                ),
+                Box::new(error),
+            )
+        })?;
+    let current_replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    if current_replicas != original_replicas {
+        info!(
+            deployment = %config.operator_deployment,
+            replicas = original_replicas,
+            "restoring operator replicas before PostSync adoption verification"
+        );
+        let patch = serde_json::json!({
+            "spec": {
+                "replicas": original_replicas
+            }
+        });
+        deployment_api
+            .patch(
+                &config.operator_deployment,
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "restore deployment {} to {original_replicas} replicas",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+    }
+
+    if original_replicas == 0 {
+        return Ok(());
+    }
+
+    let start = std::time::Instant::now();
+    loop {
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while waiting for PostSync restore",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let status = deployment.status.as_ref();
+        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
+        let available = status
+            .and_then(|status| status.available_replicas)
+            .unwrap_or(0);
+
+        if ready >= original_replicas && available >= original_replicas {
+            info!(
+                deployment = %config.operator_deployment,
+                replicas = original_replicas,
+                "operator restored for PostSync adoption verification"
+            );
+            return Ok(());
+        }
+
+        if start.elapsed() > config.timeout {
+            return Err(MigrationError::Timeout(format!(
+                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
+                config.operator_deployment
+            )));
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -176,12 +176,20 @@ pub async fn restore_operator_for_postsync(
         return Ok(());
     }
 
-    let original_replicas = marker.original_replicas.ok_or_else(|| {
-        MigrationError::State(format!(
+    let Some(original_replicas) = marker.original_replicas else {
+        // Fresh installs create a Verified zero-source marker without ever stopping the operator,
+        // so there is intentionally no replica count to restore. Destructive migrations are
+        // required to persist a restore target before their first checkpoint.
+        if marker.source_count == 0 && marker.restored_count == 0 {
+            info!("PostSync has a zero-source marker; no operator restore is required");
+            return Ok(());
+        }
+
+        return Err(MigrationError::State(format!(
             "migration marker at phase {} is missing originalReplicas; refusing to wait for PostSync adoption without a restore target",
             marker.phase
-        ))
-    })?;
+        )));
+    };
 
     let deployment_api: Api<Deployment> =
         Api::namespaced(client.clone(), &config.operator_namespace);

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,4 +1,4 @@
-use std::{env, time::Duration};
+use std::env;
 
 use jiff::Timestamp;
 use k8s_openapi::{
@@ -9,7 +9,6 @@ use kube::{
     Api,
     api::{Patch, PatchParams},
 };
-use tokio::time::sleep;
 use tracing::info;
 
 use crate::{
@@ -20,7 +19,6 @@ use crate::{
 };
 
 const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
-const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Persist the operator's desired replica count before PreSync can reach a failure checkpoint.
 ///
@@ -169,7 +167,9 @@ pub async fn enforce_sticky_fail_injection(
 ///
 /// PreSync intentionally scales the operator to zero while replacing the CRD. Helm and Argo CD do
 /// not necessarily restore that live replica drift before the PostSync hook runs, so adoption can
-/// never complete unless the migrator restores the recorded replica count itself.
+/// never complete unless the migrator restores the recorded replica count itself. Readiness is
+/// deliberately left to the adoption verification that follows so the hook has one timeout budget
+/// instead of spending the full migration timeout twice.
 pub async fn restore_operator_for_postsync(
     client: &kube::Client,
     config: &MigrationConfig,
@@ -247,46 +247,5 @@ pub async fn restore_operator_for_postsync(
             })?;
     }
 
-    if original_replicas == 0 {
-        return Ok(());
-    }
-
-    let start = std::time::Instant::now();
-    loop {
-        let deployment = deployment_api
-            .get(&config.operator_deployment)
-            .await
-            .map_err(|error| {
-                MigrationError::Kube(
-                    format!(
-                        "get deployment {} while waiting for PostSync restore",
-                        config.operator_deployment
-                    ),
-                    Box::new(error),
-                )
-            })?;
-        let status = deployment.status.as_ref();
-        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
-        let available = status
-            .and_then(|status| status.available_replicas)
-            .unwrap_or(0);
-
-        if ready >= original_replicas && available >= original_replicas {
-            info!(
-                deployment = %config.operator_deployment,
-                replicas = original_replicas,
-                "operator restored for PostSync adoption verification"
-            );
-            return Ok(());
-        }
-
-        if start.elapsed() > config.timeout {
-            return Err(MigrationError::Timeout(format!(
-                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
-                config.operator_deployment
-            )));
-        }
-
-        sleep(POLL_INTERVAL).await;
-    }
+    Ok(())
 }

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -39,6 +39,15 @@ pub async fn persist_original_operator_replicas_for_presync(
             return Ok(());
         }
 
+        // Fresh installs never stop the operator, so their Verified/Completed zero-source marker
+        // legitimately has no restore target. Subsequent upgrades must keep that state a no-op.
+        if marker.phase >= Phase::Verified
+            && marker.source_count == 0
+            && marker.restored_count == 0
+        {
+            return Ok(());
+        }
+
         if marker.phase > Phase::BackedUp {
             return Err(MigrationError::State(format!(
                 "migration marker is at phase {} without originalReplicas; cannot safely restore operator",

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -41,9 +41,7 @@ pub async fn persist_original_operator_replicas_for_presync(
 
         // Fresh installs never stop the operator, so their Verified/Completed zero-source marker
         // legitimately has no restore target. Subsequent upgrades must keep that state a no-op.
-        if marker.phase >= Phase::Verified
-            && marker.source_count == 0
-            && marker.restored_count == 0
+        if marker.phase >= Phase::Verified && marker.source_count == 0 && marker.restored_count == 0
         {
             return Ok(());
         }

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,6 +1,10 @@
 use std::{env, time::Duration};
 
-use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use jiff::Timestamp;
+use k8s_openapi::{
+    api::{apps::v1::Deployment, core::v1::ConfigMap},
+    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+};
 use kube::{
     Api,
     api::{Patch, PatchParams},
@@ -9,13 +13,132 @@ use tokio::time::sleep;
 use tracing::info;
 
 use crate::{
-    MigrationError, Result,
+    CORRECTED_CRD_NAME, LEGACY_CRD_NAME, MigrationError, Result,
+    crd::get_crd,
     migration::MigrationConfig,
-    state::{Phase, get_marker},
+    state::{MigrationMarker, Phase, create_or_update_marker, get_marker},
 };
 
 const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Persist the operator's desired replica count before PreSync can reach a failure checkpoint.
+///
+/// A migration retry must know how many operator replicas to restore after replacing the CRD. The
+/// destructive state machine used to record this only while scaling the Deployment down, after the
+/// `BackedUp` checkpoint. A failure at that checkpoint therefore left no restore target and
+/// PostSync could wait forever for adoption while the operator remained stopped.
+pub async fn persist_original_operator_replicas_for_presync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+
+    if let Some(mut marker) = get_marker(&marker_api, &config.marker_name).await? {
+        if marker.original_replicas.is_some() {
+            return Ok(());
+        }
+
+        if marker.phase > Phase::BackedUp {
+            return Err(MigrationError::State(format!(
+                "migration marker is at phase {} without originalReplicas; cannot safely restore operator",
+                marker.phase
+            )));
+        }
+
+        let deployment_api: Api<Deployment> =
+            Api::namespaced(client.clone(), &config.operator_namespace);
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while repairing migration marker",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let replicas = deployment
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.replicas)
+            .unwrap_or(1);
+
+        if marker.phase == Phase::BackedUp && replicas == 0 {
+            return Err(MigrationError::State(format!(
+                "migration marker is at BackedUp without originalReplicas and deployment {} is already scaled to zero; original replica count is ambiguous",
+                config.operator_deployment
+            )));
+        }
+
+        marker.original_replicas = Some(replicas);
+        marker.updated_at = Timestamp::now().to_string();
+        create_or_update_marker(
+            &marker_api,
+            &marker,
+            &config.marker_name,
+            &config.namespace,
+        )
+        .await?;
+        info!(
+            deployment = %config.operator_deployment,
+            replicas,
+            phase = %marker.phase,
+            "persisted missing original operator replica count"
+        );
+        return Ok(());
+    }
+
+    // Do not create migration state on fresh installs or already-migrated clusters. Creating a
+    // marker here is only valid for the legacy-only state, where run_presync would otherwise start
+    // a new migration immediately afterwards.
+    let crd_api: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let legacy_crd = get_crd(&crd_api, LEGACY_CRD_NAME).await?;
+    let corrected_crd = get_crd(&crd_api, CORRECTED_CRD_NAME).await?;
+    if legacy_crd.is_none() || corrected_crd.is_some() {
+        return Ok(());
+    }
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!(
+                    "get deployment {} before starting migration",
+                    config.operator_deployment
+                ),
+                Box::new(error),
+            )
+        })?;
+    let replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    let now = Timestamp::now().to_string();
+    let mut marker = MigrationMarker::new(&now);
+    marker.original_replicas = Some(replicas);
+    create_or_update_marker(
+        &marker_api,
+        &marker,
+        &config.marker_name,
+        &config.namespace,
+    )
+    .await?;
+    info!(
+        deployment = %config.operator_deployment,
+        replicas,
+        "persisted original operator replica count before migration"
+    );
+
+    Ok(())
+}
 
 /// Keep failure injection active when Kubernetes restarts a failed migration container.
 ///
@@ -64,9 +187,12 @@ pub async fn restore_operator_for_postsync(
         return Ok(());
     }
 
-    let Some(original_replicas) = marker.original_replicas else {
-        return Ok(());
-    };
+    let original_replicas = marker.original_replicas.ok_or_else(|| {
+        MigrationError::State(format!(
+            "migration marker at phase {} is missing originalReplicas; refusing to wait for PostSync adoption without a restore target",
+            marker.phase
+        ))
+    })?;
 
     let deployment_api: Api<Deployment> =
         Api::namespaced(client.clone(), &config.operator_namespace);

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -75,13 +75,8 @@ pub async fn persist_original_operator_replicas_for_presync(
 
         marker.original_replicas = Some(replicas);
         marker.updated_at = Timestamp::now().to_string();
-        create_or_update_marker(
-            &marker_api,
-            &marker,
-            &config.marker_name,
-            &config.namespace,
-        )
-        .await?;
+        create_or_update_marker(&marker_api, &marker, &config.marker_name, &config.namespace)
+            .await?;
         info!(
             deployment = %config.operator_deployment,
             replicas,
@@ -124,13 +119,7 @@ pub async fn persist_original_operator_replicas_for_presync(
     let now = Timestamp::now().to_string();
     let mut marker = MigrationMarker::new(&now);
     marker.original_replicas = Some(replicas);
-    create_or_update_marker(
-        &marker_api,
-        &marker,
-        &config.marker_name,
-        &config.namespace,
-    )
-    .await?;
+    create_or_update_marker(&marker_api, &marker, &config.marker_name, &config.namespace).await?;
     info!(
         deployment = %config.operator_deployment,
         replicas,

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,7 +1,10 @@
 use std::{env, time::Duration};
 
 use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
-use kube::{Api, api::{Patch, PatchParams}};
+use kube::{
+    Api,
+    api::{Patch, PatchParams},
+};
 use tokio::time::sleep;
 use tracing::info;
 

--- a/tests/e2e/scripts/crd-migration-argocd.sh
+++ b/tests/e2e/scripts/crd-migration-argocd.sh
@@ -351,9 +351,24 @@ setup_kanidm_and_persons() {
     local tls_dir
     tls_dir=$(mktemp -d)
     openssl req -x509 -nodes -newkey rsa:2048 \
-        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.crt" \
-        -days 1 -subj "/CN=test-migration.localhost" \
-        -addext "subjectAltName=DNS:test-migration.localhost" >/dev/null 2>&1
+        -keyout "${tls_dir}/ca.key" -out "${tls_dir}/ca.crt" \
+        -days 1 -subj "/CN=Kaniop CRD migration test CA" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1
+    openssl req -nodes -newkey rsa:2048 \
+        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.csr" \
+        -subj "/CN=test-migration.localhost" >/dev/null 2>&1
+    cat >"${tls_dir}/tls.ext" <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:test-migration.localhost
+EOF
+    openssl x509 -req -in "${tls_dir}/tls.csr" \
+        -CA "${tls_dir}/ca.crt" -CAkey "${tls_dir}/ca.key" -CAcreateserial \
+        -out "${tls_dir}/tls-leaf.crt" -days 1 \
+        -extfile "${tls_dir}/tls.ext" >/dev/null 2>&1
+    cat "${tls_dir}/tls-leaf.crt" "${tls_dir}/ca.crt" >"${tls_dir}/tls.crt"
     kubectl -n default create secret tls test-migration-tls \
         --cert="${tls_dir}/tls.crt" --key="${tls_dir}/tls.key"
     rm -rf "${tls_dir}"

--- a/tests/e2e/scripts/crd-migration-failures.sh
+++ b/tests/e2e/scripts/crd-migration-failures.sh
@@ -172,9 +172,24 @@ setup_legacy_state() {
     local tls_dir
     tls_dir=$(mktemp -d)
     openssl req -x509 -nodes -newkey rsa:2048 \
-        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.crt" \
-        -days 1 -subj "/CN=test-failure.localhost" \
-        -addext "subjectAltName=DNS:test-failure.localhost" >/dev/null 2>&1
+        -keyout "${tls_dir}/ca.key" -out "${tls_dir}/ca.crt" \
+        -days 1 -subj "/CN=Kaniop CRD migration failure test CA" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1
+    openssl req -nodes -newkey rsa:2048 \
+        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.csr" \
+        -subj "/CN=test-failure.localhost" >/dev/null 2>&1
+    cat >"${tls_dir}/tls.ext" <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:test-failure.localhost
+EOF
+    openssl x509 -req -in "${tls_dir}/tls.csr" \
+        -CA "${tls_dir}/ca.crt" -CAkey "${tls_dir}/ca.key" -CAcreateserial \
+        -out "${tls_dir}/tls-leaf.crt" -days 1 \
+        -extfile "${tls_dir}/tls.ext" >/dev/null 2>&1
+    cat "${tls_dir}/tls-leaf.crt" "${tls_dir}/ca.crt" >"${tls_dir}/tls.crt"
     kubectl -n default create secret tls test-failure-tls \
         --cert="${tls_dir}/tls.crt" --key="${tls_dir}/tls.key"
     rm -rf "${tls_dir}"

--- a/tests/e2e/scripts/crd-migration-helm.sh
+++ b/tests/e2e/scripts/crd-migration-helm.sh
@@ -158,9 +158,24 @@ setup_kanidm() {
     local tls_dir
     tls_dir=$(mktemp -d)
     openssl req -x509 -nodes -newkey rsa:2048 \
-        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.crt" \
-        -days 1 -subj "/CN=test-migration.localhost" \
-        -addext "subjectAltName=DNS:test-migration.localhost" >/dev/null 2>&1
+        -keyout "${tls_dir}/ca.key" -out "${tls_dir}/ca.crt" \
+        -days 1 -subj "/CN=Kaniop CRD migration test CA" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1
+    openssl req -nodes -newkey rsa:2048 \
+        -keyout "${tls_dir}/tls.key" -out "${tls_dir}/tls.csr" \
+        -subj "/CN=test-migration.localhost" >/dev/null 2>&1
+    cat >"${tls_dir}/tls.ext" <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:test-migration.localhost
+EOF
+    openssl x509 -req -in "${tls_dir}/tls.csr" \
+        -CA "${tls_dir}/ca.crt" -CAkey "${tls_dir}/ca.key" -CAcreateserial \
+        -out "${tls_dir}/tls-leaf.crt" -days 1 \
+        -extfile "${tls_dir}/tls.ext" >/dev/null 2>&1
+    cat "${tls_dir}/tls-leaf.crt" "${tls_dir}/ca.crt" >"${tls_dir}/tls.crt"
     kubectl -n default create secret tls test-migration-tls \
         --cert="${tls_dir}/tls.crt" --key="${tls_dir}/tls.key"
     rm -rf "${tls_dir}"


### PR DESCRIPTION
## Summary

- make CRD migration failure injection sticky across Kubernetes Job container retries
- restore the operator Deployment to the replica count recorded during PreSync before PostSync adoption verification
- wait for the restored operator to become ready before checking migrated person adoption

## Why

This follows up #932. Its required PR checks passed and auto-merge completed, but the merged head exposed failures in the dedicated CRD Migration E2E workflow:

- failure-injection retries resumed past the injected checkpoint because the marker had already advanced
- Helm and Argo CD PostSync verification waited for operator adoption while the operator was still scaled to zero by PreSync

The migration marker already records `originalReplicas`; this change uses that recorded state to restore the operator before adoption verification, while keeping the migration data and CRD schemas unchanged.

Refs #932
Refs https://github.com/pando85/kaniop/discussions/931