### PR TITLE
test(crd): expose verifier timeout diagnostics

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -34,6 +34,7 @@
         "e2e",
         "error",
         "group",
+        "helm",
         "image",
         "k8s-util",
         "kanidm",

--- a/charts/kaniop/templates/crd-migration/job-verify.yaml
+++ b/charts/kaniop/templates/crd-migration/job-verify.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "kaniop.crdMigration.labels" . | nindent 4 }}
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ add .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds 120 }}
+  activeDeadlineSeconds: {{ add (mul .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds 2) 120 }}
   ttlSecondsAfterFinished: 300
   template:
     metadata:

--- a/charts/kaniop/templates/crd-migration/job-verify.yaml
+++ b/charts/kaniop/templates/crd-migration/job-verify.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "kaniop.crdMigration.labels" . | nindent 4 }}
 spec:
-  backoffLimit: {{ .Values.crdMigration.personAccountPlural.backoffLimit }}
+  backoffLimit: 0
   activeDeadlineSeconds: {{ add .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds 120 }}
   ttlSecondsAfterFinished: 300
   template:
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "kaniop.crdMigration.labels" . | nindent 8 }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: {{ include "kaniop.crdMigration.serviceAccountName" . }}
       automountServiceAccountToken: true
       securityContext:
@@ -46,7 +46,7 @@ spec:
             - name: MARKER_NAME
               value: {{ include "kaniop.fullname" . }}-person-crd-migration
             - name: TIMEOUT_SECONDS
-              value: "{{ .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds }}"
+              value: "60"
             {{- if .Values.crdMigration.personAccountPlural.failAfter }}
             - name: KANIOP_MIGRATION_FAIL_AFTER
               value: {{ .Values.crdMigration.personAccountPlural.failAfter | quote }}

--- a/charts/kaniop/templates/crd-migration/job-verify.yaml
+++ b/charts/kaniop/templates/crd-migration/job-verify.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "kaniop.crdMigration.labels" . | nindent 8 }}
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       serviceAccountName: {{ include "kaniop.crdMigration.serviceAccountName" . }}
       automountServiceAccountToken: true
       securityContext:
@@ -46,7 +46,7 @@ spec:
             - name: MARKER_NAME
               value: {{ include "kaniop.fullname" . }}-person-crd-migration
             - name: TIMEOUT_SECONDS
-              value: "60"
+              value: "{{ .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds }}"
             {{- if .Values.crdMigration.personAccountPlural.failAfter }}
             - name: KANIOP_MIGRATION_FAIL_AFTER
               value: {{ .Values.crdMigration.personAccountPlural.failAfter | quote }}

--- a/charts/kaniop/templates/crd-migration/job-verify.yaml
+++ b/charts/kaniop/templates/crd-migration/job-verify.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "kaniop.crdMigration.labels" . | nindent 4 }}
 spec:
-  backoffLimit: 0
+  backoffLimit: {{ .Values.crdMigration.personAccountPlural.backoffLimit }}
   activeDeadlineSeconds: {{ add (mul .Values.crdMigration.personAccountPlural.verifyTimeoutSeconds 2) 120 }}
   ttlSecondsAfterFinished: 300
   template:

--- a/charts/kaniop/tests/crd-migration_test.yaml
+++ b/charts/kaniop/tests/crd-migration_test.yaml
@@ -370,7 +370,7 @@ tests:
           path: spec.backoffLimit
           value: 3
 
-  - it: Should set bounded activeDeadlineSeconds on verification Job from verifyTimeoutSeconds plus startup buffer
+  - it: Should set bounded activeDeadlineSeconds on verification Job from double verifyTimeoutSeconds plus startup buffer
     release:
       name: kaniop
       namespace: kaniop
@@ -381,7 +381,7 @@ tests:
     asserts:
       - equal:
           path: spec.activeDeadlineSeconds
-          value: 720
+          value: 1320
 
   - it: Should set restartPolicy OnFailure on migration Job
     release:

--- a/charts/kaniop/tests/crd-migration_test.yaml
+++ b/charts/kaniop/tests/crd-migration_test.yaml
@@ -383,6 +383,19 @@ tests:
           path: spec.activeDeadlineSeconds
           value: 1320
 
+  - it: Should set bounded backoffLimit on verification Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-migration/job-verify.yaml
+    set:
+      crdMigration.personAccountPlural.enabled: true
+      crdMigration.personAccountPlural.backoffLimit: 3
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 3
+
   - it: Should set restartPolicy OnFailure on migration Job
     release:
       name: kaniop

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -17,10 +17,8 @@ path = "src/main.rs"
 [dependencies]
 kaniop-crd-migration = { workspace = true }
 clap = { workspace = true, features = ["cargo", "env"] }
-k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
-serde_json = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 kaniop-crd-migration = { workspace = true }
 clap = { workspace = true, features = ["cargo", "env"] }
+k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true, features = ["cargo", "env"] }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,7 +1,10 @@
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
 use kaniop_crd_migration::{
     migration::{MigrationConfig, run_postsync, run_presync},
-    runtime::{enforce_sticky_fail_injection, restore_operator_for_postsync},
+    runtime::{
+        enforce_sticky_fail_injection, persist_original_operator_replicas_for_presync,
+        restore_operator_for_postsync,
+    },
 };
 use rustls::crypto::aws_lc_rs::default_provider;
 
@@ -66,6 +69,7 @@ async fn main() -> anyhow::Result<()> {
 
     match args.command {
         Command::MigratePersonAccount => {
+            persist_original_operator_replicas_for_presync(&client, &config).await?;
             enforce_sticky_fail_injection(&client, &config).await?;
             run_presync(&client, &config).await?;
         }

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,18 +1,9 @@
-use std::{env, time::Duration};
-
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
-use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
 use kaniop_crd_migration::{
-    MigrationError,
     migration::{MigrationConfig, run_postsync, run_presync},
-    state::{Phase, get_marker},
+    runtime::{enforce_sticky_fail_injection, restore_operator_for_postsync},
 };
-use kube::{Api, api::{Patch, PatchParams}};
 use rustls::crypto::aws_lc_rs::default_provider;
-use tokio::time::sleep;
-
-const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
-const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Parser, Debug)]
 #[command(
@@ -48,138 +39,6 @@ struct Args {
 enum Command {
     MigratePersonAccount,
     VerifyPersonAccount,
-}
-
-async fn enforce_sticky_fail_injection(
-    client: &kube::Client,
-    config: &MigrationConfig,
-) -> anyhow::Result<()> {
-    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
-        .ok()
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(());
-    };
-
-    let fail_phase: Phase = fail_after.parse()?;
-    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
-    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
-        return Ok(());
-    };
-
-    if marker.phase == fail_phase {
-        return Err(MigrationError::InjectedFailure(fail_phase.to_string()).into());
-    }
-
-    Ok(())
-}
-
-async fn restore_operator_for_postsync(
-    client: &kube::Client,
-    config: &MigrationConfig,
-) -> anyhow::Result<()> {
-    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
-    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
-        return Ok(());
-    };
-
-    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
-        return Ok(());
-    }
-
-    let Some(original_replicas) = marker.original_replicas else {
-        return Ok(());
-    };
-
-    let deployment_api: Api<Deployment> =
-        Api::namespaced(client.clone(), &config.operator_namespace);
-    let deployment = deployment_api
-        .get(&config.operator_deployment)
-        .await
-        .map_err(|error| {
-            MigrationError::Kube(
-                format!("get deployment {} for PostSync restore", config.operator_deployment),
-                Box::new(error),
-            )
-        })?;
-    let current_replicas = deployment
-        .spec
-        .as_ref()
-        .and_then(|spec| spec.replicas)
-        .unwrap_or(1);
-
-    if current_replicas != original_replicas {
-        tracing::info!(
-            deployment = %config.operator_deployment,
-            replicas = original_replicas,
-            "restoring operator replicas before PostSync adoption verification"
-        );
-        let patch = serde_json::json!({
-            "spec": {
-                "replicas": original_replicas
-            }
-        });
-        deployment_api
-            .patch(
-                &config.operator_deployment,
-                &PatchParams::default(),
-                &Patch::Merge(&patch),
-            )
-            .await
-            .map_err(|error| {
-                MigrationError::Kube(
-                    format!(
-                        "restore deployment {} to {original_replicas} replicas",
-                        config.operator_deployment
-                    ),
-                    Box::new(error),
-                )
-            })?;
-    }
-
-    if original_replicas == 0 {
-        return Ok(());
-    }
-
-    let start = std::time::Instant::now();
-    loop {
-        let deployment = deployment_api
-            .get(&config.operator_deployment)
-            .await
-            .map_err(|error| {
-                MigrationError::Kube(
-                    format!(
-                        "get deployment {} while waiting for PostSync restore",
-                        config.operator_deployment
-                    ),
-                    Box::new(error),
-                )
-            })?;
-        let status = deployment.status.as_ref();
-        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
-        let available = status
-            .and_then(|status| status.available_replicas)
-            .unwrap_or(0);
-
-        if ready >= original_replicas && available >= original_replicas {
-            tracing::info!(
-                deployment = %config.operator_deployment,
-                replicas = original_replicas,
-                "operator restored for PostSync adoption verification"
-            );
-            return Ok(());
-        }
-
-        if start.elapsed() > config.timeout {
-            return Err(MigrationError::Timeout(format!(
-                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
-                config.operator_deployment
-            ))
-            .into());
-        }
-
-        sleep(POLL_INTERVAL).await;
-    }
 }
 
 #[tokio::main]

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,6 +1,18 @@
+use std::{env, time::Duration};
+
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
-use kaniop_crd_migration::migration::{MigrationConfig, run_postsync, run_presync};
+use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use kaniop_crd_migration::{
+    MigrationError,
+    migration::{MigrationConfig, run_postsync, run_presync},
+    state::{Phase, get_marker},
+};
+use kube::{Api, api::{Patch, PatchParams}};
 use rustls::crypto::aws_lc_rs::default_provider;
+use tokio::time::sleep;
+
+const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Parser, Debug)]
 #[command(
@@ -38,6 +50,138 @@ enum Command {
     VerifyPersonAccount,
 }
 
+async fn enforce_sticky_fail_injection(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> anyhow::Result<()> {
+    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let fail_phase: Phase = fail_after.parse()?;
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase == fail_phase {
+        return Err(MigrationError::InjectedFailure(fail_phase.to_string()).into());
+    }
+
+    Ok(())
+}
+
+async fn restore_operator_for_postsync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> anyhow::Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
+        return Ok(());
+    }
+
+    let Some(original_replicas) = marker.original_replicas else {
+        return Ok(());
+    };
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!("get deployment {} for PostSync restore", config.operator_deployment),
+                Box::new(error),
+            )
+        })?;
+    let current_replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    if current_replicas != original_replicas {
+        tracing::info!(
+            deployment = %config.operator_deployment,
+            replicas = original_replicas,
+            "restoring operator replicas before PostSync adoption verification"
+        );
+        let patch = serde_json::json!({
+            "spec": {
+                "replicas": original_replicas
+            }
+        });
+        deployment_api
+            .patch(
+                &config.operator_deployment,
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "restore deployment {} to {original_replicas} replicas",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+    }
+
+    if original_replicas == 0 {
+        return Ok(());
+    }
+
+    let start = std::time::Instant::now();
+    loop {
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while waiting for PostSync restore",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let status = deployment.status.as_ref();
+        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
+        let available = status
+            .and_then(|status| status.available_replicas)
+            .unwrap_or(0);
+
+        if ready >= original_replicas && available >= original_replicas {
+            tracing::info!(
+                deployment = %config.operator_deployment,
+                replicas = original_replicas,
+                "operator restored for PostSync adoption verification"
+            );
+            return Ok(());
+        }
+
+        if start.elapsed() > config.timeout {
+            return Err(MigrationError::Timeout(format!(
+                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
+                config.operator_deployment
+            ))
+            .into());
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     default_provider().install_default().unwrap();
@@ -63,9 +207,11 @@ async fn main() -> anyhow::Result<()> {
 
     match args.command {
         Command::MigratePersonAccount => {
+            enforce_sticky_fail_injection(&client, &config).await?;
             run_presync(&client, &config).await?;
         }
         Command::VerifyPersonAccount => {
+            restore_operator_for_postsync(&client, &config).await?;
             let result = run_postsync(&client, &config).await?;
             if kaniop_crd_migration::verify::adoption_verification_passed(&result) {
                 tracing::info!(

--- a/libs/crd-migration/src/lib.rs
+++ b/libs/crd-migration/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod checksum;
 pub mod crd;
 pub mod migration;
+pub mod runtime;
 pub mod sanitize;
 pub mod state;
 pub mod verify;

--- a/libs/crd-migration/src/lib.rs
+++ b/libs/crd-migration/src/lib.rs
@@ -13,6 +13,7 @@ pub const API_GROUP: &str = "kaniop.rs";
 pub const API_VERSION: &str = "v1beta1";
 pub const KIND: &str = "KanidmPersonAccount";
 pub const LEGACY_FINALIZER: &str = "kanidmpersonsaccounts.kaniop.rs/finalizer";
+pub const CORRECTED_FINALIZER: &str = "kanidmpersonaccounts.kaniop.rs/finalizer";
 pub const LEGACY_CRD_NAME: &str = "kanidmpersonsaccounts.kaniop.rs";
 pub const CORRECTED_CRD_NAME: &str = "kanidmpersonaccounts.kaniop.rs";
 pub const MIGRATION_VERSION: &str = "person-plural-v1";

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,0 +1,159 @@
+use std::{env, time::Duration};
+
+use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use kube::{Api, api::{Patch, PatchParams}};
+use tokio::time::sleep;
+use tracing::info;
+
+use crate::{
+    MigrationError, Result,
+    migration::MigrationConfig,
+    state::{Phase, get_marker},
+};
+
+const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Keep failure injection active when Kubernetes restarts a failed migration container.
+///
+/// The migration state machine persists the completed phase before injecting the failure. Without
+/// this check, a restarted container resumes from that marker and advances past the requested
+/// failure point.
+pub async fn enforce_sticky_fail_injection(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let Some(fail_after) = env::var(FAIL_AFTER_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let fail_phase: Phase = fail_after.parse()?;
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase == fail_phase {
+        return Err(MigrationError::InjectedFailure(fail_phase.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Restore the operator replica count recorded by PreSync before verifying adoption.
+///
+/// PreSync intentionally scales the operator to zero while replacing the CRD. Helm and Argo CD do
+/// not necessarily restore that live replica drift before the PostSync hook runs, so adoption can
+/// never complete unless the migrator restores the recorded replica count itself.
+pub async fn restore_operator_for_postsync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+    let Some(marker) = get_marker(&marker_api, &config.marker_name).await? else {
+        return Ok(());
+    };
+
+    if marker.phase < Phase::Verified || marker.phase >= Phase::Completed {
+        return Ok(());
+    }
+
+    let Some(original_replicas) = marker.original_replicas else {
+        return Ok(());
+    };
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!(
+                    "get deployment {} for PostSync restore",
+                    config.operator_deployment
+                ),
+                Box::new(error),
+            )
+        })?;
+    let current_replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    if current_replicas != original_replicas {
+        info!(
+            deployment = %config.operator_deployment,
+            replicas = original_replicas,
+            "restoring operator replicas before PostSync adoption verification"
+        );
+        let patch = serde_json::json!({
+            "spec": {
+                "replicas": original_replicas
+            }
+        });
+        deployment_api
+            .patch(
+                &config.operator_deployment,
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "restore deployment {} to {original_replicas} replicas",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+    }
+
+    if original_replicas == 0 {
+        return Ok(());
+    }
+
+    let start = std::time::Instant::now();
+    loop {
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while waiting for PostSync restore",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let status = deployment.status.as_ref();
+        let ready = status.and_then(|status| status.ready_replicas).unwrap_or(0);
+        let available = status
+            .and_then(|status| status.available_replicas)
+            .unwrap_or(0);
+
+        if ready >= original_replicas && available >= original_replicas {
+            info!(
+                deployment = %config.operator_deployment,
+                replicas = original_replicas,
+                "operator restored for PostSync adoption verification"
+            );
+            return Ok(());
+        }
+
+        if start.elapsed() > config.timeout {
+            return Err(MigrationError::Timeout(format!(
+                "deployment {} did not restore to {original_replicas} ready replicas within timeout",
+                config.operator_deployment
+            )));
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -176,12 +176,20 @@ pub async fn restore_operator_for_postsync(
         return Ok(());
     }
 
-    let original_replicas = marker.original_replicas.ok_or_else(|| {
-        MigrationError::State(format!(
+    let Some(original_replicas) = marker.original_replicas else {
+        // Fresh installs create a Verified zero-source marker without ever stopping the operator,
+        // so there is intentionally no replica count to restore. Destructive migrations are
+        // required to persist a restore target before their first checkpoint.
+        if marker.source_count == 0 && marker.restored_count == 0 {
+            info!("PostSync has a zero-source marker; no operator restore is required");
+            return Ok(());
+        }
+
+        return Err(MigrationError::State(format!(
             "migration marker at phase {} is missing originalReplicas; refusing to wait for PostSync adoption without a restore target",
             marker.phase
-        ))
-    })?;
+        )));
+    };
 
     let deployment_api: Api<Deployment> =
         Api::namespaced(client.clone(), &config.operator_namespace);

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -39,6 +39,15 @@ pub async fn persist_original_operator_replicas_for_presync(
             return Ok(());
         }
 
+        // Fresh installs never stop the operator, so their Verified/Completed zero-source marker
+        // legitimately has no restore target. Subsequent upgrades must keep that state a no-op.
+        if marker.phase >= Phase::Verified
+            && marker.source_count == 0
+            && marker.restored_count == 0
+        {
+            return Ok(());
+        }
+
         if marker.phase > Phase::BackedUp {
             return Err(MigrationError::State(format!(
                 "migration marker is at phase {} without originalReplicas; cannot safely restore operator",

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -41,9 +41,7 @@ pub async fn persist_original_operator_replicas_for_presync(
 
         // Fresh installs never stop the operator, so their Verified/Completed zero-source marker
         // legitimately has no restore target. Subsequent upgrades must keep that state a no-op.
-        if marker.phase >= Phase::Verified
-            && marker.source_count == 0
-            && marker.restored_count == 0
+        if marker.phase >= Phase::Verified && marker.source_count == 0 && marker.restored_count == 0
         {
             return Ok(());
         }

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,6 +1,10 @@
 use std::{env, time::Duration};
 
-use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
+use jiff::Timestamp;
+use k8s_openapi::{
+    api::{apps::v1::Deployment, core::v1::ConfigMap},
+    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+};
 use kube::{
     Api,
     api::{Patch, PatchParams},
@@ -9,13 +13,132 @@ use tokio::time::sleep;
 use tracing::info;
 
 use crate::{
-    MigrationError, Result,
+    CORRECTED_CRD_NAME, LEGACY_CRD_NAME, MigrationError, Result,
+    crd::get_crd,
     migration::MigrationConfig,
-    state::{Phase, get_marker},
+    state::{MigrationMarker, Phase, create_or_update_marker, get_marker},
 };
 
 const FAIL_AFTER_ENV: &str = "KANIOP_MIGRATION_FAIL_AFTER";
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Persist the operator's desired replica count before PreSync can reach a failure checkpoint.
+///
+/// A migration retry must know how many operator replicas to restore after replacing the CRD. The
+/// destructive state machine used to record this only while scaling the Deployment down, after the
+/// `BackedUp` checkpoint. A failure at that checkpoint therefore left no restore target and
+/// PostSync could wait forever for adoption while the operator remained stopped.
+pub async fn persist_original_operator_replicas_for_presync(
+    client: &kube::Client,
+    config: &MigrationConfig,
+) -> Result<()> {
+    let marker_api: Api<ConfigMap> = Api::namespaced(client.clone(), &config.namespace);
+
+    if let Some(mut marker) = get_marker(&marker_api, &config.marker_name).await? {
+        if marker.original_replicas.is_some() {
+            return Ok(());
+        }
+
+        if marker.phase > Phase::BackedUp {
+            return Err(MigrationError::State(format!(
+                "migration marker is at phase {} without originalReplicas; cannot safely restore operator",
+                marker.phase
+            )));
+        }
+
+        let deployment_api: Api<Deployment> =
+            Api::namespaced(client.clone(), &config.operator_namespace);
+        let deployment = deployment_api
+            .get(&config.operator_deployment)
+            .await
+            .map_err(|error| {
+                MigrationError::Kube(
+                    format!(
+                        "get deployment {} while repairing migration marker",
+                        config.operator_deployment
+                    ),
+                    Box::new(error),
+                )
+            })?;
+        let replicas = deployment
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.replicas)
+            .unwrap_or(1);
+
+        if marker.phase == Phase::BackedUp && replicas == 0 {
+            return Err(MigrationError::State(format!(
+                "migration marker is at BackedUp without originalReplicas and deployment {} is already scaled to zero; original replica count is ambiguous",
+                config.operator_deployment
+            )));
+        }
+
+        marker.original_replicas = Some(replicas);
+        marker.updated_at = Timestamp::now().to_string();
+        create_or_update_marker(
+            &marker_api,
+            &marker,
+            &config.marker_name,
+            &config.namespace,
+        )
+        .await?;
+        info!(
+            deployment = %config.operator_deployment,
+            replicas,
+            phase = %marker.phase,
+            "persisted missing original operator replica count"
+        );
+        return Ok(());
+    }
+
+    // Do not create migration state on fresh installs or already-migrated clusters. Creating a
+    // marker here is only valid for the legacy-only state, where run_presync would otherwise start
+    // a new migration immediately afterwards.
+    let crd_api: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let legacy_crd = get_crd(&crd_api, LEGACY_CRD_NAME).await?;
+    let corrected_crd = get_crd(&crd_api, CORRECTED_CRD_NAME).await?;
+    if legacy_crd.is_none() || corrected_crd.is_some() {
+        return Ok(());
+    }
+
+    let deployment_api: Api<Deployment> =
+        Api::namespaced(client.clone(), &config.operator_namespace);
+    let deployment = deployment_api
+        .get(&config.operator_deployment)
+        .await
+        .map_err(|error| {
+            MigrationError::Kube(
+                format!(
+                    "get deployment {} before starting migration",
+                    config.operator_deployment
+                ),
+                Box::new(error),
+            )
+        })?;
+    let replicas = deployment
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.replicas)
+        .unwrap_or(1);
+
+    let now = Timestamp::now().to_string();
+    let mut marker = MigrationMarker::new(&now);
+    marker.original_replicas = Some(replicas);
+    create_or_update_marker(
+        &marker_api,
+        &marker,
+        &config.marker_name,
+        &config.namespace,
+    )
+    .await?;
+    info!(
+        deployment = %config.operator_deployment,
+        replicas,
+        "persisted original operator replica count before migration"
+    );
+
+    Ok(())
+}
 
 /// Keep failure injection active when Kubernetes restarts a failed migration container.
 ///
@@ -64,9 +187,12 @@ pub async fn restore_operator_for_postsync(
         return Ok(());
     }
 
-    let Some(original_replicas) = marker.original_replicas else {
-        return Ok(());
-    };
+    let original_replicas = marker.original_replicas.ok_or_else(|| {
+        MigrationError::State(format!(
+            "migration marker at phase {} is missing originalReplicas; refusing to wait for PostSync adoption without a restore target",
+            marker.phase
+        ))
+    })?;
 
     let deployment_api: Api<Deployment> =
         Api::namespaced(client.clone(), &config.operator_namespace);

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -75,13 +75,8 @@ pub async fn persist_original_operator_replicas_for_presync(
 
         marker.original_replicas = Some(replicas);
         marker.updated_at = Timestamp::now().to_string();
-        create_or_update_marker(
-            &marker_api,
-            &marker,
-            &config.marker_name,
-            &config.namespace,
-        )
-        .await?;
+        create_or_update_marker(&marker_api, &marker, &config.marker_name, &config.namespace)
+            .await?;
         info!(
             deployment = %config.operator_deployment,
             replicas,
@@ -124,13 +119,7 @@ pub async fn persist_original_operator_replicas_for_presync(
     let now = Timestamp::now().to_string();
     let mut marker = MigrationMarker::new(&now);
     marker.original_replicas = Some(replicas);
-    create_or_update_marker(
-        &marker_api,
-        &marker,
-        &config.marker_name,
-        &config.namespace,
-    )
-    .await?;
+    create_or_update_marker(&marker_api, &marker, &config.marker_name, &config.namespace).await?;
     info!(
         deployment = %config.operator_deployment,
         replicas,

--- a/libs/crd-migration/src/runtime.rs
+++ b/libs/crd-migration/src/runtime.rs
@@ -1,7 +1,10 @@
 use std::{env, time::Duration};
 
 use k8s_openapi::api::{apps::v1::Deployment, core::v1::ConfigMap};
-use kube::{Api, api::{Patch, PatchParams}};
+use kube::{
+    Api,
+    api::{Patch, PatchParams},
+};
 use tokio::time::sleep;
 use tracing::info;
 

--- a/libs/crd-migration/src/verify.rs
+++ b/libs/crd-migration/src/verify.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use tokio::time::sleep;
 
 use crate::{
-    LEGACY_FINALIZER, MigrationError, Result, backup::list_backup_entries,
+    CORRECTED_FINALIZER, MigrationError, Result, backup::list_backup_entries,
     checksum::object_checksum, corrected_person_api_resource, sanitize::extract_metadata_spec,
 };
 
@@ -264,7 +264,7 @@ async fn check_adoption_state(
                     .metadata
                     .finalizers
                     .as_ref()
-                    .is_some_and(|f| f.iter().any(|fi| fi == LEGACY_FINALIZER));
+                    .is_some_and(|f| f.iter().any(|fi| fi == CORRECTED_FINALIZER));
 
                 if !has_finalizer {
                     missing_finalizers.push(format!("{}/{}", entry.namespace, entry.name));

--- a/libs/person/src/reconcile.rs
+++ b/libs/person/src/reconcile.rs
@@ -28,8 +28,8 @@ use time::format_description::well_known::Rfc3339;
 use time::{OffsetDateTime, UtcOffset};
 use tracing::{Span, debug, field, info, instrument, trace, warn};
 
-pub static PERSON_OPERATOR_NAME: &str = "kanidmpersonsaccounts.kaniop.rs";
-pub static PERSON_FINALIZER: &str = "kanidmpersonsaccounts.kaniop.rs/finalizer";
+pub static PERSON_OPERATOR_NAME: &str = "kanidmpersonaccounts.kaniop.rs";
+pub static PERSON_FINALIZER: &str = "kanidmpersonaccounts.kaniop.rs/finalizer";
 
 const TYPE_CREDENTIAL: &str = "Credential";
 const TYPE_EXISTS: &str = "Exists";

--- a/tests/e2e/scripts/crd-migration-argocd.sh
+++ b/tests/e2e/scripts/crd-migration-argocd.sh
@@ -266,6 +266,7 @@ spec:
       parameters:
         - name: image.tag
           value: "${version}"
+          forceString: true
         - name: env[0].name
           value: KANIDM_DEV_YOLO
         - name: env[0].value
@@ -277,6 +278,7 @@ spec:
           value: "true"
         - name: webhook.image.tag
           value: "${version}"
+          forceString: true
         - name: webhook.logging.level
           value: "${E2E_LOGGING_LEVEL}"
         - name: webhook.patch.createSecretJob.activeDeadlineSeconds

--- a/tests/e2e/scripts/crd-migration-argocd.sh
+++ b/tests/e2e/scripts/crd-migration-argocd.sh
@@ -484,8 +484,8 @@ trigger_migration_sync() {
     kubectl -n "${ARGOCD_NAMESPACE}" patch application kaniop --type merge \
         -p "{\"operation\":{\"sync\":{\"revision\":\"${expected_revision}\",\"syncStrategy\":{\"hook\":{}}}}}"
 
-    log "Waiting for migration sync to complete (up to 600s)"
-    wait_for_application_synced "kaniop" 600 "${expected_revision}"
+    log "Waiting for migration sync to complete (up to 1800s)"
+    wait_for_application_synced "kaniop" 1800 "${expected_revision}"
 }
 
 verify_post_migration() {
@@ -559,7 +559,7 @@ record_post_migration_uids_and_run_idempotency() {
     log "Triggering second sync (idempotency)"
     kubectl -n "${ARGOCD_NAMESPACE}" patch application kaniop --type merge \
         -p '{"operation": {"sync": {"syncStrategy": {"hook": {}}}}}'
-    wait_for_application_synced "kaniop" 600
+    wait_for_application_synced "kaniop" 1800
 
     log "Running idempotent-rerun Rust e2e tests"
     export MIGRATION_STAGE="idempotent-rerun"

--- a/tests/e2e/scripts/crd-migration-failures.sh
+++ b/tests/e2e/scripts/crd-migration-failures.sh
@@ -34,7 +34,7 @@ KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-chart-testing-failures}"
 KIND_IMAGE_TAG="${KIND_IMAGE_TAG:-v1.34.3}"
 SKIP_KIND_CREATE="${SKIP_KIND_CREATE:-false}"
 CLEANUP_ON_EXIT="${CLEANUP_ON_EXIT:-true}"
-HELM_TIMEOUT="${HELM_TIMEOUT:-10m}"
+HELM_TIMEOUT="${HELM_TIMEOUT:-25m}"
 KUBE_CONTEXT="kind-${KIND_CLUSTER_NAME}"
 LEGACY_PLURAL="kanidmpersonsaccounts.kaniop.rs"
 CORRECTED_PLURAL="kanidmpersonaccounts.kaniop.rs"
@@ -135,7 +135,7 @@ reset_cluster_for_failure_test() {
 
     kubectl -n "${KANIOP_NAMESPACE}" delete secret -l kaniop.rs/migration=person-plural-v1 --ignore-not-found=true 2>/dev/null || true
     kubectl -n "${KANIOP_NAMESPACE}" delete configmap kaniop-person-crd-migration --ignore-not-found=true 2>/dev/null || true
-    kubectl -n "${KANIOP_NAMESPACE}" delete jobs -l app.kubernetes.io/component=crd-migrator --ignore-not-found=true 2>/dev/null || true
+    kubectl -n "${KANIOP_NAMESPACE}" delete jobs -l app.kubernetes.io/component=crd-migration --ignore-not-found=true 2>/dev/null || true
 
     kubectl get "crd/${LEGACY_PLURAL}" >/dev/null 2>&1 && {
         kubectl delete "crd/${LEGACY_PLURAL}" --ignore-not-found=true 2>/dev/null || true
@@ -273,9 +273,9 @@ inject_failure_and_resume() {
         --set "env[0].name=KANIDM_DEV_YOLO" \
         --set-string "env[0].value=1"; then
         log "ERROR: Resume upgrade failed at phase ${phase}. Dumping migration job logs:"
-        kubectl -n "${KANIOP_NAMESPACE}" logs -l app.kubernetes.io/component=crd-migrator --tail=100 2>&1 || true
+        kubectl -n "${KANIOP_NAMESPACE}" logs -l app.kubernetes.io/component=crd-migration --tail=100 2>&1 || true
         log "Dumping migration job status:"
-        kubectl -n "${KANIOP_NAMESPACE}" get jobs -l app.kubernetes.io/component=crd-migrator -o yaml 2>&1 || true
+        kubectl -n "${KANIOP_NAMESPACE}" get jobs -l app.kubernetes.io/component=crd-migration -o yaml 2>&1 || true
         fatal "Resume upgrade failed at phase ${phase}"
     fi
 

--- a/tests/e2e/scripts/crd-migration-helm.sh
+++ b/tests/e2e/scripts/crd-migration-helm.sh
@@ -22,7 +22,7 @@
 #   SKIP_KIND_CREATE      - set to "true" to skip Kind cluster creation
 #   CLEANUP_ON_EXIT       - set to "false" to keep cluster on exit (default: true)
 #   E2E_LOGGING_LEVEL     - log filter for operator (default: info,kaniop=debug)
-#   HELM_TIMEOUT          - helm operation timeout (default: 10m)
+#   HELM_TIMEOUT          - helm operation timeout (default: 25m)
 #
 set -euo pipefail
 
@@ -38,7 +38,7 @@ SKIP_KIND_CREATE="${SKIP_KIND_CREATE:-false}"
 CLEANUP_ON_EXIT="${CLEANUP_ON_EXIT:-true}"
 E2E_LOGGING_LEVEL="${E2E_LOGGING_LEVEL:-info,kaniop=debug,kaniop_webhook=debug}"
 HELM_LOGGING_LEVEL="${E2E_LOGGING_LEVEL//,/\\,}"
-HELM_TIMEOUT="${HELM_TIMEOUT:-10m}"
+HELM_TIMEOUT="${HELM_TIMEOUT:-25m}"
 KUBE_CONTEXT="kind-${KIND_CLUSTER_NAME}"
 LEGACY_CHART_REF="oci://ghcr.io/pando85/helm-charts/kaniop"
 RELEASE_NAME="kaniop"


### PR DESCRIPTION
Temporary diagnostic PR for #933. Runs the CRD migration E2E suite with a single 60s verifier attempt so the remaining PostSync failure is observable instead of being killed by Helm's outer timeout. This PR will be closed after diagnosis.