### PR TITLE
Prevent implicit adoption of externally replicated Kanidm entities

### DIFF
--- a/Documentation/src/webhook.md
+++ b/Documentation/src/webhook.md
@@ -7,17 +7,33 @@ weight: 40000
 
 The Kaniop validating webhook prevents the creation of Kanidm custom resources (CRs) that would
 conflict with existing objects in the same Kanidm cluster. It ensures that no two resources with the
-same name point to the same Kanidm cluster (`kanidmRef.name` + `kanidmRef.namespace`), avoiding
-duplicate entries managed by different Kubernetes namespaces or CRs that could otherwise collide
-inside Kanidm.
+same effective Kanidm entity name point to the same Kanidm cluster (`kanidmRef.name` +
+`kanidmRef.namespace`), avoiding duplicate entries managed by different Kubernetes namespaces or
+CRs that could otherwise collide inside Kanidm.
+
+When the referenced `Kanidm` resource has external replication configured, the webhook also checks
+Kanidm directly before accepting a new CR. This prevents a CR from implicitly adopting an entity
+that was created in, or replicated from, another Kanidm cluster.
 
 ## How It Works
 
-- **Scope:** Applies to Kanidm custom resources (e.g., Group, Person, OAuth2).
-- **Action:** Rejects `CREATE` requests if another resource with the same name already references
-  the same Kanidm cluster.
-- **Purpose:** Prevents duplicate or conflicting entries in Kanidm, ensuring data consistency and
-  integrity.
+- **Scope:** Applies to Kanidm Group, Person, OAuth2 Client, and Service Account custom resources.
+- **Kubernetes duplicate check:** Rejects `CREATE` requests if another CR with the same effective
+  Kanidm entity name already references the same Kanidm cluster.
+- **External replication check:** If `spec.externalReplicationNodes` is configured on the referenced
+  `Kanidm`, performs an exact live lookup for the entity before allowing creation.
+- **Effective entity name:** Uses `spec.kanidmName` when configured, otherwise the Kubernetes object
+  name.
+- **Failure behavior:** Once external replication is known to be enabled, inability to verify the
+  entity against Kanidm rejects the request so a transient failure cannot turn into accidental
+  ownership of an externally managed entity.
+- **Apply ordering:** If the referenced `Kanidm` resource does not exist yet, the webhook preserves
+  the existing behavior and allows the dependent CR to be applied first.
+
+The webhook intentionally does not maintain a periodically refreshed inventory of Kanidm entities.
+A cache miss could become stale immediately in a replicated deployment, so external entity checks
+are performed against Kanidm at admission time. Authenticated Kanidm clients are reused between
+requests to avoid repeating login setup for every validation.
 
 ## Deployment
 
@@ -69,11 +85,17 @@ webhook:
 - The webhook server always uses HTTPS.
 - TLS certificates are managed automatically (via Helm job or cert-manager).
 - RBAC and service account resources are created as needed for secure operation.
+- External-replication validation uses the operator-managed Kanidm credentials and TLS trust
+  configuration.
 
 ## Troubleshooting
 
-- If webhook requests are being rejected unexpectedly, check for existing CRs with the same name and
-  Kanidm reference.
+- If webhook requests are being rejected unexpectedly, check for existing CRs with the same
+  effective `kanidmName` and Kanidm reference.
+- For Kanidm clusters using external replication, check whether an entity with that name already
+  exists directly in Kanidm.
+- If validation reports that it cannot verify an externally replicated entity, check Kanidm
+  availability, the admin password Secret, and the configured TLS Secret.
 - Review webhook logs for detailed error messages (`logging.level: debug`).
 - Ensure the webhook service is reachable and the certificate is valid.
 

--- a/cmd/webhook/src/handlers.rs
+++ b/cmd/webhook/src/handlers.rs
@@ -1,6 +1,6 @@
 use crate::admission::{AdmissionResponse, AdmissionReview};
 use crate::state::WebhookState;
-use crate::validator::{HasKanidmRef, check_duplicate};
+use crate::validator::{HasKanidmRef, KanidmEntityKind, check_duplicate, check_external_duplicate};
 
 use axum::extract::State;
 use axum::response::Json;
@@ -9,10 +9,11 @@ use tracing::{debug, error};
 
 /// Generic validation handler
 pub async fn validate_resource<T>(
-    _state: &WebhookState,
+    state: &WebhookState,
     store: &kube::runtime::reflector::Store<T>,
     review: AdmissionReview<T>,
     resource_name: &str,
+    entity_kind: KanidmEntityKind,
 ) -> Json<AdmissionReview<()>>
 where
     T: Resource + ResourceExt + Clone + HasKanidmRef,
@@ -32,7 +33,7 @@ where
     let uid = request.uid.clone();
     let operation = &request.operation;
 
-    // Only validate CREATE operations (kanidmRef is immutable)
+    // Only validate CREATE operations (kanidmRef and kanidmName are immutable)
     if operation != "CREATE" {
         debug!(
             "Skipping validation for {} operation on {}",
@@ -52,28 +53,35 @@ where
         }
     };
 
-    // Check for duplicates
-    match check_duplicate(object, resource_name, store) {
-        Ok(_) => {
-            debug!(
-                "Validation passed for {} {}/{}",
-                resource_name,
-                object.namespace().unwrap_or_else(|| "default".to_string()),
-                object.name_any()
-            );
-            Json(review.response(AdmissionResponse::allow(uid)))
-        }
-        Err(err) => {
-            debug!(
-                "Validation failed for {} {}/{}: {}",
-                resource_name,
-                object.namespace().unwrap_or_else(|| "default".to_string()),
-                object.name_any(),
-                err
-            );
-            Json(review.response(AdmissionResponse::deny(uid, err)))
-        }
+    if let Err(err) = check_duplicate(object, resource_name, store) {
+        debug!(
+            "Validation failed for {} {}/{}: {}",
+            resource_name,
+            object.namespace().unwrap_or_else(|| "default".to_string()),
+            object.name_any(),
+            err
+        );
+        return Json(review.response(AdmissionResponse::deny(uid, err)));
     }
+
+    if let Err(err) = check_external_duplicate(state, object, resource_name, entity_kind).await {
+        debug!(
+            "External entity validation failed for {} {}/{}: {}",
+            resource_name,
+            object.namespace().unwrap_or_else(|| "default".to_string()),
+            object.name_any(),
+            err
+        );
+        return Json(review.response(AdmissionResponse::deny(uid, err)));
+    }
+
+    debug!(
+        "Validation passed for {} {}/{}",
+        resource_name,
+        object.namespace().unwrap_or_else(|| "default".to_string()),
+        object.name_any()
+    );
+    Json(review.response(AdmissionResponse::allow(uid)))
 }
 
 // Concrete handlers for each resource type
@@ -81,21 +89,42 @@ pub async fn validate_kanidm_group(
     State(state): State<WebhookState>,
     Json(review): Json<AdmissionReview<kaniop_group::crd::KanidmGroup>>,
 ) -> Json<AdmissionReview<()>> {
-    validate_resource(&state, &state.group_store, review, "KanidmGroup").await
+    validate_resource(
+        &state,
+        &state.group_store,
+        review,
+        "KanidmGroup",
+        KanidmEntityKind::Group,
+    )
+    .await
 }
 
 pub async fn validate_kanidm_person(
     State(state): State<WebhookState>,
     Json(review): Json<AdmissionReview<kaniop_person::crd::KanidmPersonAccount>>,
 ) -> Json<AdmissionReview<()>> {
-    validate_resource(&state, &state.person_store, review, "KanidmPersonAccount").await
+    validate_resource(
+        &state,
+        &state.person_store,
+        review,
+        "KanidmPersonAccount",
+        KanidmEntityKind::Person,
+    )
+    .await
 }
 
 pub async fn validate_kanidm_oauth2(
     State(state): State<WebhookState>,
     Json(review): Json<AdmissionReview<kaniop_oauth2::crd::KanidmOAuth2Client>>,
 ) -> Json<AdmissionReview<()>> {
-    validate_resource(&state, &state.oauth2_store, review, "KanidmOAuth2Client").await
+    validate_resource(
+        &state,
+        &state.oauth2_store,
+        review,
+        "KanidmOAuth2Client",
+        KanidmEntityKind::OAuth2Client,
+    )
+    .await
 }
 
 pub async fn validate_kanidm_service_account(
@@ -107,6 +136,7 @@ pub async fn validate_kanidm_service_account(
         &state.service_account_store,
         review,
         "KanidmServiceAccount",
+        KanidmEntityKind::ServiceAccount,
     )
     .await
 }

--- a/cmd/webhook/src/main.rs
+++ b/cmd/webhook/src/main.rs
@@ -223,7 +223,13 @@ async fn main() -> anyhow::Result<()> {
         .reflect_shared(sa_writer)
         .for_each(|_| async {});
 
-    let state = WebhookState::new(group_store, person_store, oauth2_store, sa_store);
+    let state = WebhookState::new(
+        group_store,
+        person_store,
+        oauth2_store,
+        sa_store,
+        client.clone(),
+    );
 
     // Create router
     let app = Router::new()

--- a/cmd/webhook/src/state.rs
+++ b/cmd/webhook/src/state.rs
@@ -1,9 +1,14 @@
 use kaniop_group::crd::KanidmGroup;
 use kaniop_oauth2::crd::KanidmOAuth2Client;
+use kaniop_operator::controller::kanidm::KanidmClients;
 use kaniop_person::crd::KanidmPersonAccount;
 use kaniop_service_account::crd::KanidmServiceAccount;
 
+use std::sync::Arc;
+
+use kube::Client;
 use kube::runtime::reflector::Store;
+use tokio::sync::RwLock;
 
 #[derive(Clone)]
 pub struct WebhookState {
@@ -11,6 +16,8 @@ pub struct WebhookState {
     pub person_store: Store<KanidmPersonAccount>,
     pub oauth2_store: Store<KanidmOAuth2Client>,
     pub service_account_store: Store<KanidmServiceAccount>,
+    pub kube_client: Client,
+    pub kanidm_clients: Arc<RwLock<KanidmClients>>,
 }
 
 impl WebhookState {
@@ -19,12 +26,15 @@ impl WebhookState {
         person_store: Store<KanidmPersonAccount>,
         oauth2_store: Store<KanidmOAuth2Client>,
         service_account_store: Store<KanidmServiceAccount>,
+        kube_client: Client,
     ) -> Self {
         Self {
             group_store,
             person_store,
             oauth2_store,
             service_account_store,
+            kube_client,
+            kanidm_clients: Arc::new(RwLock::new(KanidmClients::default())),
         }
     }
 }

--- a/cmd/webhook/src/validator.rs
+++ b/cmd/webhook/src/validator.rs
@@ -1,7 +1,19 @@
+use crate::state::WebhookState;
+
+use kaniop_operator::controller::kanidm::{KanidmClients, KanidmKey, KanidmUser};
 use kaniop_operator::crd::KanidmRef;
+use kaniop_operator::kanidm::crd::Kanidm;
 
 use kube::runtime::reflector::Store;
-use kube::{Resource, ResourceExt};
+use kube::{Api, Resource, ResourceExt};
+
+#[derive(Clone, Copy, Debug)]
+pub enum KanidmEntityKind {
+    Group,
+    Person,
+    OAuth2Client,
+    ServiceAccount,
+}
 
 /// Normalize KanidmRef by filling in missing namespace with object's namespace
 pub fn normalize_kanidm_ref(kanidm_ref: &KanidmRef, object_namespace: &str) -> (String, String) {
@@ -48,6 +60,107 @@ where
             ))
         })
         .unwrap_or(Ok(()))
+}
+
+/// Reject creation when an entity with the same effective Kanidm name already exists in a
+/// Kanidm cluster configured for external replication.
+///
+/// This deliberately performs an exact live lookup instead of treating a periodically refreshed
+/// cache miss as proof that an entity does not exist. If the referenced Kanidm resource has not
+/// been created yet, validation keeps the existing apply-order behavior and lets the request
+/// through. Once external replication is known to be enabled, lookup/client errors fail closed.
+pub async fn check_external_duplicate<T>(
+    state: &WebhookState,
+    object: &T,
+    object_name: &str,
+    entity_kind: KanidmEntityKind,
+) -> Result<(), String>
+where
+    T: Resource + ResourceExt + HasKanidmRef,
+{
+    let object_namespace = object.namespace().unwrap_or_else(|| "default".to_string());
+    let (kanidm_name, kanidm_namespace) =
+        normalize_kanidm_ref(object.kanidm_ref_spec(), &object_namespace);
+
+    let kanidm_api = Api::<Kanidm>::namespaced(state.kube_client.clone(), &kanidm_namespace);
+    let kanidm = match kanidm_api.get(&kanidm_name).await {
+        Ok(kanidm) => kanidm,
+        // Preserve the existing ability to apply dependent CRs before the Kanidm CR itself.
+        Err(kube::Error::Api(response)) if response.code == 404 => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "failed to verify {object_name} against Kanidm {kanidm_namespace}/{kanidm_name}: {error}"
+            ));
+        }
+    };
+
+    if kanidm.spec.external_replication_nodes.is_empty() {
+        return Ok(());
+    }
+
+    let key = KanidmKey {
+        namespace: kanidm_namespace.clone(),
+        name: kanidm_name.clone(),
+    };
+
+    let cached_client = state.kanidm_clients.read().await.get(&key).cloned();
+    let client = match cached_client {
+        Some(client) if client.auth_valid().await.is_ok() => client,
+        _ => {
+            let client = KanidmClients::create_client(
+                &kanidm_namespace,
+                &kanidm_name,
+                KanidmUser::IdmAdmin,
+                state.kube_client.clone(),
+            )
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to connect to externally replicated Kanidm {kanidm_namespace}/{kanidm_name} while validating {object_name}: {error:?}"
+                )
+            })?;
+
+            state
+                .kanidm_clients
+                .write()
+                .await
+                .insert(key, client.clone());
+            client
+        }
+    };
+
+    let entity_name = object.kanidm_entity_name();
+    let entity_exists = match entity_kind {
+        KanidmEntityKind::Group => client
+            .idm_group_get(&entity_name)
+            .await
+            .map(|entry| entry.is_some()),
+        KanidmEntityKind::Person => client
+            .idm_person_account_get(&entity_name)
+            .await
+            .map(|entry| entry.is_some()),
+        KanidmEntityKind::OAuth2Client => client
+            .idm_oauth2_rs_get(&entity_name)
+            .await
+            .map(|entry| entry.is_some()),
+        KanidmEntityKind::ServiceAccount => client
+            .idm_service_account_get(&entity_name)
+            .await
+            .map(|entry| entry.is_some()),
+    }
+    .map_err(|error| {
+        format!(
+            "failed to verify whether Kanidm entity '{entity_name}' exists in externally replicated Kanidm {kanidm_namespace}/{kanidm_name}: {error:?}"
+        )
+    })?;
+
+    if entity_exists {
+        Err(format!(
+            "{object_name} cannot manage Kanidm entity '{entity_name}' because it already exists in externally replicated Kanidm {kanidm_namespace}/{kanidm_name}"
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 /// Trait to abstract access to kanidm_ref and kanidm_entity_name across different resource types

--- a/libs/operator/src/kanidm/reconcile/mail_sender.rs
+++ b/libs/operator/src/kanidm/reconcile/mail_sender.rs
@@ -101,14 +101,16 @@ pub async fn reconcile_mail_sender(
         )?;
         kanidm.patch(&ctx, deployment).await?;
 
-        let deployment_ref =
-            kube::runtime::reflector::ObjectRef::<Deployment>::new(&deployment_name)
-                .within(&namespace);
-        let ready = ctx
-            .stores
-            .deployment_store
-            .get(&deployment_ref)
-            .and_then(|d| d.status.clone())
+        let deployment_api: Api<Deployment> =
+            Api::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
+        let deployment_status = deployment_api
+            .get(&deployment_name)
+            .await
+            .map_err(|e| Error::kube_error("get", "deployment", &namespace, &deployment_name, e))?;
+
+        let ready = deployment_status
+            .status
+            .as_ref()
             .is_some_and(|s| s.ready_replicas.unwrap_or(0) >= 1);
 
         Ok(Some(MailSenderStatus {

--- a/tests/e2e/test/mail_sender.rs
+++ b/tests/e2e/test/mail_sender.rs
@@ -15,8 +15,6 @@ use kube::runtime::{conditions, wait::Condition};
 use kube::{Api, Client, ResourceExt};
 use serde_json::json;
 
-use crate::kanidm::get_dependency_version;
-
 fn is_mail_sender_ready() -> impl Condition<Kanidm> {
     move |obj: Option<&Kanidm>| {
         obj.and_then(|kanidm| kanidm.status.as_ref())
@@ -478,7 +476,10 @@ e2e_test!(mail_sender_custom_image, {
     let smtp_secret_name = format!("{name}-smtp-credentials");
     create_smtp_secret(&s.client, &smtp_secret_name, "smtp-user", "smtp-password").await;
 
-    let custom_image = format!("kanidm/tools:{}", get_dependency_version().unwrap());
+    let custom_image = format!(
+        "kanidm/tools:{}",
+        crate::kanidm::get_dependency_version().unwrap()
+    );
     let kanidm_api = Api::<Kanidm>::namespaced(s.client.clone(), "default");
     let mut kanidm = kanidm_api.get(name).await.unwrap();
     kanidm.spec.mail_sender = Some(MailSenderSpec {
@@ -488,7 +489,7 @@ e2e_test!(mail_sender_custom_image, {
             ..Default::default()
         },
         from_address: "kanidm@example.com".to_string(),
-        image: Some(custom_image.to_string()),
+        image: Some(custom_image.clone()),
         ..Default::default()
     });
     kanidm.metadata.managed_fields = None;


### PR DESCRIPTION
## Summary

Supersedes #491 with a smaller and stronger consistency model.

When a `KanidmGroup`, `KanidmPersonAccount`, `KanidmOAuth2Client`, or `KanidmServiceAccount` is created against a `Kanidm` resource that has `spec.externalReplicationNodes` configured, the webhook performs an exact live lookup in Kanidm before allowing the CREATE.

If the target entity already exists at admission time, the webhook rejects the CR instead of allowing Kaniop to implicitly adopt, mutate, and potentially delete an externally replicated entity.

## Why replace #491

#491 periodically inventories all Kanidm entities into a webhook-local cache and treats a cache miss as proof that an entity does not exist. That introduces correctness gaps around startup, partial refresh failures, stale snapshots, repeated sync workers, and the refresh interval itself.

This PR keeps only the useful client-reuse idea and removes the entity inventory entirely:

- no background Kanidm watcher
- no periodic entity synchronization
- no negative entity cache
- no cache warm-up/readiness dependency
- no per-Kanidm sync worker lifecycle

Admission instead verifies only the exact entity being created, at the point where the answer matters.

## Behavior

1. Keep the existing CRD-vs-CRD duplicate validation.
2. Resolve the effective Kanidm entity name (`spec.kanidmName` when set, otherwise the Kubernetes object name).
3. Fetch the referenced `Kanidm` resource.
4. If external replication is not configured, keep the existing behavior.
5. If external replication is configured, reuse or create an authenticated `idm_admin` client and perform an exact typed lookup.
6. Existing entity -> reject CREATE.
7. Missing entity -> allow CREATE.
8. Kanidm/client/lookup failure after external replication is known to be enabled -> fail closed.

A missing referenced `Kanidm` CR still allows the request so dependent resources can be applied before the Kanidm resource, preserving the existing GitOps/apply-order behavior.

## Implementation notes

- Reuses `KanidmClients::create_client`, including the operator's current TLS trust handling, instead of copying the older client-construction code from #491.
- Caches authenticated clients, not entity existence.
- Uses `kanidm_entity_name()` for external checks, so `spec.kanidmName` cannot bypass validation.
- Covers groups, persons, OAuth2 clients, and service accounts.
- Updates webhook documentation with external-replication and failure semantics.

## Consistency boundary

Kanidm replication is asynchronous, so neither this PR nor #491 can provide a distributed uniqueness guarantee across clusters: an entity may be created remotely after admission succeeds but before it is visible locally. This PR removes the much larger stale-cache window from #491 and checks the freshest state available from the target Kanidm at admission time.

A future ownership-state change in the controllers could add defense in depth against the remaining admission-to-reconcile race, but that changes reconciliation/adoption semantics and is intentionally kept separate from this replacement.

## Validation

CI runs formatting, Rust tests/checks, examples, and Helm checks on this branch.

## Follow-up

A broader change that makes adoption of *any* pre-existing Kanidm entity explicit would be valuable, but it changes existing Kaniop semantics and is intentionally kept out of this PR.