### PR TITLE
feat(chart): add operator performance metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ E2E_TEST_THREADS ?= 16
 # set KANIDM_DEV_YOLO=1 to avoid Kanidm client exiting silently when dev derived profile is used
 HELM_PARAMS = --namespace $(KANIOP_NAMESPACE) \
 		--set-string image.tag=$(VERSION) \
+		--set metrics.enabled=true \
 		--set 'env[0].name=KANIDM_DEV_YOLO' \
 		--set-string 'env[0].value=1' \
 		--set logging.level=$(E2E_LOGGING_LEVEL) \

--- a/charts/kaniop/files/dashboards/kaniop.json
+++ b/charts/kaniop/files/dashboards/kaniop.json
@@ -226,7 +226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(controller) (increase(kaniop_reconcile_failures_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * kaniop_ready{controller=~\"$controller\"})",
+          "expr": "sum by(controller) (increase(kaniop_reconcile_failures_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * sum by(controller) (kaniop_ready{controller=~\"$controller\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -327,7 +327,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(controller) (increase(kaniop_status_update_errors_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * kaniop_ready{controller=~\"$controller\"})",
+          "expr": "sum by(controller) (increase(kaniop_status_update_errors_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * sum by(controller) (kaniop_ready{controller=~\"$controller\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -428,7 +428,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (controller) (increase(kaniop_watch_operations_failed_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * kaniop_ready{controller=~\"$controller\"})",
+          "expr": "sum by (controller) (increase(kaniop_watch_operations_failed_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * sum by(controller) (kaniop_ready{controller=~\"$controller\"}))",
           "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
@@ -558,7 +558,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows what’s causing reconciles",
+      "description": "Shows what's causing reconciles",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -645,7 +645,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(controller, action, triggered_by) (increase(kaniop_triggered_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * kaniop_ready{controller=~\"$controller\"})",
+          "expr": "sum by(controller, action, triggered_by) (increase(kaniop_triggered_total{controller=~\"$controller\"}[$interval])) or on(controller) (0 * sum by(controller) (kaniop_ready{controller=~\"$controller\"}))",
           "legendFormat": "{{controller}} · {{action}} · {{triggered_by}}",
           "range": true,
           "refId": "A"
@@ -655,16 +655,336 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of reconcile operations currently in flight per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (kaniop_active_reconciles{controller=~\"$controller\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Reconciles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of objects currently in error backoff state per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (kaniop_objects_in_backoff{controller=~\"$controller\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Objects in Backoff",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 34
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Reconcile outcomes",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Reconcile results by outcome type (changed, unchanged, error)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller, outcome) (increase(kaniop_reconcile_outcome_total{controller=~\"$controller\"}[$interval]))",
+          "legendFormat": "{{controller}} · {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 11,
       "panels": [],
-      "title": "Performance",
+      "title": "Reconcile latency",
       "type": "row"
     },
     {
@@ -734,7 +1054,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 4,
       "options": {
@@ -769,6 +1089,214 @@
         }
       ],
       "title": "Mean Reconcile Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Median reconcile duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(controller, le) (rate(kaniop_reconcile_duration_seconds_bucket{controller=~\"$controller\"}[$interval])))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "p50 Reconcile Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "95th percentile reconcile duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(controller, le) (rate(kaniop_reconcile_duration_seconds_bucket{controller=~\"$controller\"}[$interval])))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "p95 Reconcile Duration",
       "type": "timeseries"
     },
     {
@@ -838,7 +1366,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 52
       },
       "id": 5,
       "options": {
@@ -881,12 +1409,438 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 60
+      },
+      "id": 19,
+      "panels": [],
+      "title": "Kanidm SDK",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Kanidm SDK call rate by operation",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 61
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(operation) (rate(kaniop_kanidm_sdk_calls_total[$interval]))",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SDK Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Kanidm SDK call rate by outcome (changed, unchanged, error)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 61
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(outcome) (rate(kaniop_kanidm_sdk_calls_total[$interval]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SDK Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile Kanidm SDK call duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(kaniop_kanidm_sdk_call_duration_seconds_bucket[$interval])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SDK p99 Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
       },
       "id": 12,
       "panels": [],
-      "title": "K8s API Health",
+      "title": "Kubernetes API",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Median Kubernetes API request latency by endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by(exported_endpoint, le) (rate(kaniop_kubernetes_client_http_request_duration_seconds_bucket[$interval])))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "p50 Kubernetes API Latency",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -953,9 +1907,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 36
+        "w": 12,
+        "x": 12,
+        "y": 70
       },
       "id": 13,
       "options": {
@@ -1058,7 +2012,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 78
       },
       "id": 14,
       "options": {
@@ -1088,7 +2042,328 @@
           "refId": "A"
         }
       ],
-      "title": "API Requests by Status Code",
+      "title": "API Throughput by Status Code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Transport-level failure rate by endpoint; non-zero indicates connectivity issues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 78
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(exported_endpoint) (rate(kaniop_kubernetes_client_http_transport_failures_total[$interval]))",
+          "legendFormat": "{{exported_endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transport Failures",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Operator resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Operator pod CPU usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=\"kaniop\"}[$interval]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Operator pod memory usage (working set)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container=\"kaniop\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
       "type": "timeseries"
     }
   ],
@@ -1130,6 +2405,27 @@
         "query": {
           "qryType": 1,
           "query": "label_values(kaniop_ready,controller)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kaniop_ready,namespace)",
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kaniop_ready,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/charts/kaniop/tests/dashboard-configmap_test.yaml
+++ b/charts/kaniop/tests/dashboard-configmap_test.yaml
@@ -228,3 +228,101 @@ tests:
       - notMatchRegex:
           path: metadata.name
           pattern: "-$"
+
+  - it: Dashboard contains namespace variable for operator pod metrics
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: label_values\(kaniop_ready,namespace\)
+
+  - it: Dashboard contains active reconciles and backoff panels
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_active_reconciles
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_objects_in_backoff
+
+  - it: Dashboard contains Kanidm SDK panels
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_kanidm_sdk_calls_total
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_kanidm_sdk_call_duration_seconds_bucket
+
+  - it: Dashboard contains reconcile outcome and latency percentile panels
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_reconcile_outcome_total
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: histogram_quantile\(0\.50.*reconcile_duration_seconds_bucket
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: histogram_quantile\(0\.95.*reconcile_duration_seconds_bucket
+
+  - it: Dashboard contains Kubernetes transport failure and p50 latency panels
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: kaniop_kubernetes_client_http_transport_failures_total
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: histogram_quantile\(0\.50.*kubernetes_client_http_request_duration_seconds_bucket
+
+  - it: Dashboard contains operator resource panels using namespace variable
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: container_cpu_usage_seconds_total.*namespace
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: container_memory_working_set_bytes.*namespace
+
+  - it: Dashboard preserves schema version and uid
+    set:
+      metrics.dashboards.enabled: true
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: "schemaVersion.: 42"
+      - matchRegex:
+          path: data["kaniop.json"]
+          pattern: "uid.: .pan9z68."

--- a/cmd/operator/src/main.rs
+++ b/cmd/operator/src/main.rs
@@ -133,7 +133,9 @@ async fn main() -> anyhow::Result<()> {
 
     let exporter = kaniop_operator::prometheus_exporter::PrometheusExporter::new();
     debug!("Prometheus exporter created");
-    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter.clone()).build();
+    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter.clone())
+        .with_interval(Duration::from_secs(5))
+        .build();
     let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
         .with_reader(reader)
         .build();

--- a/libs/group/src/reconcile.rs
+++ b/libs/group/src/reconcile.rs
@@ -9,12 +9,17 @@ use kaniop_operator::controller::{
     context::{Context, IdmClientContext},
     idm_reconcile_interval,
 };
+use kaniop_operator::metrics::{
+    KANIDM_OP_ACCOUNT_POLICY, KANIDM_OP_CREATE, KANIDM_OP_DELETE, KANIDM_OP_GET,
+    KANIDM_OP_PURGE_ATTR, KANIDM_OP_SET_MAIL, KANIDM_OP_SET_MEMBERS, KANIDM_OP_UNIX_EXTEND,
+    KANIDM_OP_UPDATE, KANIDM_OUTCOME_CHANGED, KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED,
+    KANIDM_RESOURCE_GROUP, record_kanidm_sdk_call,
+};
 use kaniop_operator::telemetry;
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::TryFutureExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use k8s_openapi::jiff::Timestamp;
 use kanidm_client::{ClientError, KanidmClient};
@@ -63,7 +68,7 @@ pub async fn watched_resource(group: &KanidmGroup, ctx: Arc<Context<KanidmGroup>
 pub async fn reconcile_group(
     group: Arc<KanidmGroup>,
     ctx: Arc<Context<KanidmGroup>>,
-) -> Result<Action> {
+) -> Result<(Action, bool)> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx.metrics.reconcile_count_and_measure(&trace_id);
@@ -87,7 +92,7 @@ pub async fn reconcile_group(
             warn!(msg = "failed to publish ResourceNotWatched event", %e);
             Error::kube_error("publish", "event", group.get_namespace(), group.name_any(), e)
         })?;
-        return Ok(Action::requeue(idm_reconcile_interval()));
+        return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
 
     info!(msg = "reconciling group");
@@ -103,10 +108,26 @@ pub async fn reconcile_group(
             e
         })?;
     let groups_api: Api<KanidmGroup> = Api::namespaced(ctx.client.clone(), &namespace);
-    finalizer(&groups_api, GROUP_FINALIZER, group, |event| async {
-        match event {
-            Finalizer::Apply(g) => g.reconcile(kanidm_client, status, ctx).await,
-            Finalizer::Cleanup(g) => g.cleanup(kanidm_client, status).await,
+    let outcome = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let outcome_clone = outcome.clone();
+    let action = finalizer(&groups_api, GROUP_FINALIZER, group, move |event| {
+        let outcome = outcome_clone.clone();
+        let ctx = ctx.clone();
+        let status = status.clone();
+        let kanidm_client = kanidm_client.clone();
+        async move {
+            match event {
+                Finalizer::Apply(g) => {
+                    let (action, changed) = g.reconcile(kanidm_client, status, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+                Finalizer::Cleanup(g) => {
+                    let (action, changed) = g.cleanup(kanidm_client, status, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+            }
         }
     })
     .await
@@ -119,7 +140,9 @@ pub async fn reconcile_group(
             "failed on group finalizer".to_string(),
             Box::new(e),
         )),
-    })
+    })?;
+    let changed = outcome.load(std::sync::atomic::Ordering::Relaxed);
+    Ok((action, changed))
 }
 
 impl KanidmGroup {
@@ -135,9 +158,12 @@ impl KanidmGroup {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmGroupStatus,
         ctx: Arc<Context<KanidmGroup>>,
-    ) -> Result<Action> {
-        match self.internal_reconcile(kanidm_client, status).await {
-            Ok(action) => Ok(action),
+    ) -> Result<(Action, bool)> {
+        match self
+            .internal_reconcile(kanidm_client, status, ctx.clone())
+            .await
+        {
+            Ok(result) => Ok(result),
             Err(e) => match e {
                 Error::KanidmClientError(_, _) => {
                     ctx.recorder
@@ -174,53 +200,106 @@ impl KanidmGroup {
         &self,
         kanidm_client: Arc<KanidmClient>,
         status: KanidmGroupStatus,
-    ) -> Result<Action> {
+        ctx: Arc<Context<KanidmGroup>>,
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let metrics = &ctx.metrics;
         let mut require_status_update = false;
+        let mut changed = false;
         if is_group_false(TYPE_EXISTS, status.clone()) {
-            self.create(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                self.create(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_group_false(TYPE_MANAGED_UPDATED, status.clone()) {
-            self.update_managed_by(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_UPDATE,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_managed_by(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_group_false(TYPE_MAIL_UPDATED, status.clone()) {
-            self.update_mail(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_SET_MAIL,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_mail(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_group_false(TYPE_MEMBERS_UPDATED, status.clone()) {
-            self.update_members(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_SET_MEMBERS,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_members(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_group_false(TYPE_POSIX_UPDATED, status.clone())
             || (is_group_false(TYPE_POSIX_INITIALIZED, status.clone())
                 && is_group(TYPE_POSIX_UPDATED, status.clone()))
         {
-            self.update_posix_attributes(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_UNIX_EXTEND,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_posix_attributes(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         // Account policy reconciliation: enable first if needed, then update settings
         if is_group_false(TYPE_ACCOUNT_POLICY_ENABLED, status.clone()) {
-            self.enable_account_policy(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                self.enable_account_policy(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_group_false(TYPE_ACCOUNT_POLICY_UPDATED, status.clone()) {
-            self.update_account_policy(&kanidm_client, name).await?;
+            self.update_account_policy(&kanidm_client, name, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if require_status_update {
             trace!(msg = "status update required, requeueing in 500ms");
-            Ok(Action::requeue(Duration::from_millis(500)))
+            Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
-            Ok(Action::requeue(idm_reconcile_interval()))
+            Ok((Action::requeue(idm_reconcile_interval()), changed))
         }
     }
 
@@ -376,7 +455,12 @@ impl KanidmGroup {
         Ok(())
     }
 
-    async fn update_account_policy(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn update_account_policy(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = "update account policy");
         let policy =
             self.spec.account_policy.as_ref().ok_or_else(|| {
@@ -386,250 +470,332 @@ impl KanidmGroup {
 
         // Update or reset auth session expiry
         if let Some(expiry) = policy.auth_session_expiry {
-            kanidm_client
-                .group_account_policy_authsession_expiry_set(name, expiry)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "auth session expiry",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_authsession_expiry_set(name, expiry),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "auth session expiry",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_authsession_expiry_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "auth session expiry",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_authsession_expiry_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "auth session expiry",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset credential type minimum
         if let Some(ref cred_type) = policy.credential_type_minimum {
-            kanidm_client
-                .group_account_policy_credential_type_minimum_set(name, &cred_type.to_string())
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        ATTR_CREDENTIAL_TYPE_MINIMUM,
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client
+                    .group_account_policy_credential_type_minimum_set(name, &cred_type.to_string()),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    ATTR_CREDENTIAL_TYPE_MINIMUM,
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .idm_group_purge_attr(name, ATTR_CREDENTIAL_TYPE_MINIMUM)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        ATTR_CREDENTIAL_TYPE_MINIMUM,
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_PURGE_ATTR,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_group_purge_attr(name, ATTR_CREDENTIAL_TYPE_MINIMUM),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    ATTR_CREDENTIAL_TYPE_MINIMUM,
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset password minimum length
         if let Some(length) = policy.password_minimum_length {
-            kanidm_client
-                .group_account_policy_password_minimum_length_set(name, length)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "password minimum length",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_password_minimum_length_set(name, length),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "password minimum length",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_password_minimum_length_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "password minimum length",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_password_minimum_length_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "password minimum length",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset privilege expiry
         if let Some(expiry) = policy.privilege_expiry {
-            kanidm_client
-                .group_account_policy_privilege_expiry_set(name, expiry)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "privilege expiry",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_privilege_expiry_set(name, expiry),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "privilege expiry",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_privilege_expiry_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "privilege expiry",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_privilege_expiry_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "privilege expiry",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset webauthn attestation CA list
         if let Some(ref ca_list) = policy.webauthn_attestation_ca_list {
-            kanidm_client
-                .group_account_policy_webauthn_attestation_set(name, ca_list)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "webauthn attestation CA list",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_webauthn_attestation_set(name, ca_list),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "webauthn attestation CA list",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_webauthn_attestation_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "webauthn attestation CA list",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_webauthn_attestation_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "webauthn attestation CA list",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset allow primary cred fallback
         if let Some(allow) = policy.allow_primary_cred_fallback {
-            kanidm_client
-                .group_account_policy_allow_primary_cred_fallback(name, allow)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        ATTR_ALLOW_PRIMARY_CRED_FALLBACK,
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_allow_primary_cred_fallback(name, allow),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    ATTR_ALLOW_PRIMARY_CRED_FALLBACK,
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .idm_group_purge_attr(name, ATTR_ALLOW_PRIMARY_CRED_FALLBACK)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        ATTR_ALLOW_PRIMARY_CRED_FALLBACK,
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_PURGE_ATTR,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_group_purge_attr(name, ATTR_ALLOW_PRIMARY_CRED_FALLBACK),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    ATTR_ALLOW_PRIMARY_CRED_FALLBACK,
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset limit search max results
         if let Some(max_results) = policy.limit_search_max_results {
-            kanidm_client
-                .group_account_policy_limit_search_max_results(name, max_results)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "limit search max results",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_limit_search_max_results(name, max_results),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "limit search max results",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_limit_search_max_results_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "limit search max results",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_limit_search_max_results_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "limit search max results",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         // Update or reset limit search max filter test
         if let Some(max_filter_test) = policy.limit_search_max_filter_test {
-            kanidm_client
-                .group_account_policy_limit_search_max_filter_test(name, max_filter_test)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "set",
-                        "limit search max filter test",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client
+                    .group_account_policy_limit_search_max_filter_test(name, max_filter_test),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "set",
+                    "limit search max filter test",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         } else {
-            kanidm_client
-                .group_account_policy_limit_search_max_filter_test_reset(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error_attr(
-                        "reset",
-                        "limit search max filter test",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_ACCOUNT_POLICY,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.group_account_policy_limit_search_max_filter_test_reset(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error_attr(
+                    "reset",
+                    "limit search max filter test",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
 
         Ok(())
@@ -639,21 +805,44 @@ impl KanidmGroup {
         &self,
         kanidm_client: Arc<KanidmClient>,
         status: KanidmGroupStatus,
-    ) -> Result<Action> {
+        ctx: Arc<Context<KanidmGroup>>,
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let mut changed = false;
 
         if is_group(TYPE_EXISTS, status.clone()) {
             debug!(msg = "delete");
+            let start = tokio::time::Instant::now();
             let result = kanidm_client.idm_group_delete(name).await;
             match result {
-                Ok(()) => {}
+                Ok(()) => {
+                    ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_GROUP,
+                        KANIDM_OP_DELETE,
+                        KANIDM_OUTCOME_CHANGED,
+                        start.elapsed(),
+                    );
+                    changed = true;
+                }
                 Err(ClientError::Http(status, _, _)) if status == 403 => {
                     debug!(
                         msg =
                             "group cannot be deleted (likely a built-in group), skipping deletion"
                     );
+                    ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_GROUP,
+                        KANIDM_OP_DELETE,
+                        KANIDM_OUTCOME_UNCHANGED,
+                        start.elapsed(),
+                    );
                 }
                 Err(e) => {
+                    ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_GROUP,
+                        KANIDM_OP_DELETE,
+                        KANIDM_OUTCOME_ERROR,
+                        start.elapsed(),
+                    );
                     return Err(Error::kanidm_client_error(
                         "delete",
                         name,
@@ -664,7 +853,7 @@ impl KanidmGroup {
                 }
             }
         }
-        Ok(Action::requeue(idm_reconcile_interval()))
+        Ok((Action::requeue(idm_reconcile_interval()), changed))
     }
 
     async fn update_status(
@@ -675,18 +864,22 @@ impl KanidmGroup {
         // safe unwrap: person is namespaced scoped
         let namespace = self.get_namespace();
         let name = self.kanidm_entity_name();
-        let current_group = kanidm_client
-            .idm_group_get(&name)
-            .map_err(|e| {
-                Error::kanidm_client_error(
-                    "get",
-                    &name,
-                    self.kanidm_namespace(),
-                    self.kanidm_name(),
-                    e,
-                )
-            })
-            .await?;
+        let start = tokio::time::Instant::now();
+        let current_group = kanidm_client.idm_group_get(&name).await.map_err(|e| {
+            ctx.metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_GROUP,
+                KANIDM_OP_GET,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            Error::kanidm_client_error("get", &name, self.kanidm_namespace(), self.kanidm_name(), e)
+        })?;
+        ctx.metrics.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_GROUP,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+            start.elapsed(),
+        );
 
         let status = self.generate_status(current_group)?;
         let status_patch = Patch::Apply(KanidmGroup {

--- a/libs/k8s-util/Cargo.toml
+++ b/libs/k8s-util/Cargo.toml
@@ -43,5 +43,8 @@ openssl = { workspace = true }
 sha2 = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2"] }
 
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+
 [build-dependencies]
 openssl = { workspace = true }

--- a/libs/k8s-util/src/metrics.rs
+++ b/libs/k8s-util/src/metrics.rs
@@ -12,6 +12,8 @@ use tower::{Layer, Service};
 use tracing::debug;
 use url_escape;
 
+const LATENCY_BUCKETS: &[f64] = &[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0];
+
 /// Metrics layer for monitoring HTTP requests
 #[derive(Clone)]
 pub struct MetricsLayer {
@@ -39,6 +41,8 @@ pub struct MetricsService<S> {
     inner: S,
     request_count: Counter<u64>,
     request_duration: Histogram<f64>,
+    transport_failure_count: Counter<u64>,
+    transport_failure_duration: Histogram<f64>,
 }
 
 impl<S> MetricsService<S> {
@@ -52,7 +56,18 @@ impl<S> MetricsService<S> {
         let request_duration = meter
             .f64_histogram("kubernetes_client_http_request_duration_seconds")
             .with_description("HTTP request duration in seconds")
-            .with_boundaries(vec![0.05, 0.1, 0.5, 1.0])
+            .with_boundaries(LATENCY_BUCKETS.to_vec())
+            .build();
+
+        let transport_failure_count = meter
+            .u64_counter("kubernetes_client_http_transport_failures")
+            .with_description("Total number of transport-level failures")
+            .build();
+
+        let transport_failure_duration = meter
+            .f64_histogram("kubernetes_client_http_transport_failure_duration_seconds")
+            .with_description("Duration of failed HTTP requests in seconds")
+            .with_boundaries(LATENCY_BUCKETS.to_vec())
             .build();
 
         debug!("Kubernetes client metrics initialized");
@@ -60,6 +75,8 @@ impl<S> MetricsService<S> {
             inner: service,
             request_count,
             request_duration,
+            transport_failure_count,
+            transport_failure_duration,
         }
     }
 }
@@ -89,6 +106,8 @@ where
             start,
             request_count: self.request_count.clone(),
             request_duration: self.request_duration.clone(),
+            transport_failure_count: self.transport_failure_count.clone(),
+            transport_failure_duration: self.transport_failure_duration.clone(),
         }
     }
 }
@@ -101,6 +120,8 @@ pub struct MetricsFuture<F> {
     start: Instant,
     request_count: Counter<u64>,
     request_duration: Histogram<f64>,
+    transport_failure_count: Counter<u64>,
+    transport_failure_duration: Histogram<f64>,
 }
 
 impl<F, ResBody, E> std::future::Future for MetricsFuture<F>
@@ -113,23 +134,192 @@ where
         let this = self.project();
         let poll_result = this.future.poll(cx);
 
-        if let Poll::Ready(Ok(response)) = &poll_result {
-            let duration = this.start.elapsed().as_secs_f64();
-            let status = response.status().as_str().to_string();
+        match &poll_result {
+            Poll::Ready(Ok(response)) => {
+                let duration = this.start.elapsed().as_secs_f64();
+                let status = response.status().as_str().to_string();
 
-            this.request_count.add(
-                1,
-                &[
-                    KeyValue::new("status", status),
-                    KeyValue::new("endpoint", this.endpoint.clone()),
-                ],
-            );
-            this.request_duration.record(
-                duration,
-                &[KeyValue::new("endpoint", this.endpoint.clone())],
-            );
+                this.request_count.add(
+                    1,
+                    &[
+                        KeyValue::new("status", status),
+                        KeyValue::new("endpoint", this.endpoint.clone()),
+                    ],
+                );
+                this.request_duration.record(
+                    duration,
+                    &[KeyValue::new("endpoint", this.endpoint.clone())],
+                );
+            }
+            Poll::Ready(Err(_)) => {
+                let duration = this.start.elapsed().as_secs_f64();
+
+                this.transport_failure_count
+                    .add(1, &[KeyValue::new("endpoint", this.endpoint.clone())]);
+                this.transport_failure_duration.record(
+                    duration,
+                    &[KeyValue::new("endpoint", this.endpoint.clone())],
+                );
+            }
+            Poll::Pending => {}
         }
 
         poll_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::convert::Infallible;
+
+    use http::{Response, StatusCode};
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+    use tower::service_fn;
+
+    fn test_setup() -> (SdkMeterProvider, InMemoryMetricExporter, Meter) {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        (provider, exporter, meter)
+    }
+
+    async fn wait_for_flush() {
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    #[tokio::test]
+    async fn success_records_request_count_and_duration() {
+        let (provider, exporter, meter) = test_setup();
+
+        let svc = service_fn(|_req: http::Request<()>| async {
+            Ok::<_, Infallible>(Response::builder().status(StatusCode::OK).body(()).unwrap())
+        });
+
+        let layer = MetricsLayer::new(&meter);
+        let mut svc = tower::ServiceBuilder::new().layer(layer).service(svc);
+
+        let req = http::Request::builder()
+            .uri("/api/v1/pods/mypod")
+            .body(())
+            .unwrap();
+
+        let _ = tower::ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(req)
+            .await
+            .unwrap();
+
+        provider.force_flush().unwrap();
+        wait_for_flush().await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("kubernetes_client_http_requests"));
+        assert!(text.contains("kubernetes_client_http_request_duration_seconds"));
+    }
+
+    #[tokio::test]
+    async fn transport_error_records_failure_count_and_duration() {
+        let (provider, exporter, meter) = test_setup();
+
+        let svc = service_fn(|_req: http::Request<()>| async {
+            Err::<Response<()>, std::io::Error>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset",
+            ))
+        });
+
+        let layer = MetricsLayer::new(&meter);
+        let mut svc = tower::ServiceBuilder::new().layer(layer).service(svc);
+
+        let req = http::Request::builder()
+            .uri("/api/v1/pods/mypod")
+            .body(())
+            .unwrap();
+
+        let _ = tower::ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(req)
+            .await;
+
+        provider.force_flush().unwrap();
+        wait_for_flush().await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("kubernetes_client_http_transport_failures"));
+        assert!(text.contains("kubernetes_client_http_transport_failure_duration_seconds"));
+    }
+
+    #[tokio::test]
+    async fn transport_error_does_not_record_success_metrics() {
+        let (provider, exporter, meter) = test_setup();
+
+        let svc = service_fn(|_req: http::Request<()>| async {
+            Err::<Response<()>, std::io::Error>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "connection refused",
+            ))
+        });
+
+        let layer = MetricsLayer::new(&meter);
+        let mut svc = tower::ServiceBuilder::new().layer(layer).service(svc);
+
+        let req = http::Request::builder()
+            .uri("/apis/apps/v1/namespaces/ns/deployments/dep")
+            .body(())
+            .unwrap();
+
+        let _ = tower::ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(req)
+            .await;
+
+        provider.force_flush().unwrap();
+        wait_for_flush().await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(!text.contains("kubernetes_client_http_requests"));
+        assert!(!text.contains("kubernetes_client_http_request_duration_seconds"));
+    }
+
+    #[tokio::test]
+    async fn error_is_passed_through_unchanged() {
+        let (_provider, _exporter, meter) = test_setup();
+
+        let svc = service_fn(|_req: http::Request<()>| async {
+            Err::<Response<()>, std::io::Error>(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "timed out",
+            ))
+        });
+
+        let layer = MetricsLayer::new(&meter);
+        let mut svc = tower::ServiceBuilder::new().layer(layer).service(svc);
+
+        let req = http::Request::builder()
+            .uri("/api/v1/pods")
+            .body(())
+            .unwrap();
+
+        let result = tower::ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(req)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert_eq!(err.to_string(), "timed out");
     }
 }

--- a/libs/oauth2/src/reconcile/mod.rs
+++ b/libs/oauth2/src/reconcile/mod.rs
@@ -25,6 +25,14 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_operator::controller::context::{IdmClientContext, KubeOperations};
 use kaniop_operator::controller::idm_reconcile_interval;
 use kaniop_operator::controller::kanidm::{KanidmResource, is_resource_watched};
+use kaniop_operator::metrics::{
+    KANIDM_OP_ADD_ORIGIN, KANIDM_OP_CREATE, KANIDM_OP_DELETE, KANIDM_OP_DELETE_CLAIM_MAP,
+    KANIDM_OP_DELETE_IMAGE, KANIDM_OP_DELETE_SCOPE_MAP, KANIDM_OP_DELETE_SUP_SCOPE_MAP,
+    KANIDM_OP_GET_SECRET, KANIDM_OP_REMOVE_ORIGIN, KANIDM_OP_RESET_SECRET, KANIDM_OP_UPDATE,
+    KANIDM_OP_UPDATE_CLAIM_MAP, KANIDM_OP_UPDATE_CLAIM_MAP_JOIN, KANIDM_OP_UPDATE_IMAGE,
+    KANIDM_OP_UPDATE_SCOPE_MAP, KANIDM_OP_UPDATE_SUP_SCOPE_MAP, KANIDM_OUTCOME_CHANGED,
+    KANIDM_RESOURCE_OAUTH2, record_kanidm_sdk_call,
+};
 use kaniop_operator::object_meta_template::ObjectMetaTemplateExt;
 use kaniop_operator::telemetry;
 
@@ -81,7 +89,7 @@ pub async fn watched_resource(oauth2: &KanidmOAuth2Client, ctx: Arc<Context>) ->
 pub async fn reconcile_oauth2(
     oauth2: Arc<KanidmOAuth2Client>,
     ctx: Arc<Context>,
-) -> Result<Action> {
+) -> Result<(Action, bool)> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx
@@ -108,7 +116,7 @@ pub async fn reconcile_oauth2(
             warn!(msg = "failed to publish KanidmError event", %e);
             Error::kube_error("publish", "event", oauth2.get_namespace(), oauth2.name_any(), e)
         })?;
-        return Ok(Action::requeue(idm_reconcile_interval()));
+        return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
 
     info!(msg = "reconciling oauth2 client");
@@ -123,10 +131,26 @@ pub async fn reconcile_oauth2(
         })?;
     let persons_api: Api<KanidmOAuth2Client> =
         Api::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
-    finalizer(&persons_api, OAUTH2_FINALIZER, oauth2, |event| async {
-        match event {
-            Finalizer::Apply(p) => p.reconcile(kanidm_client, status, ctx).await,
-            Finalizer::Cleanup(p) => p.cleanup(kanidm_client, status).await,
+    let outcome = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let outcome_clone = outcome.clone();
+    let action = finalizer(&persons_api, OAUTH2_FINALIZER, oauth2, move |event| {
+        let outcome = outcome_clone.clone();
+        let ctx = ctx.clone();
+        let status = status.clone();
+        let kanidm_client = kanidm_client.clone();
+        async move {
+            match event {
+                Finalizer::Apply(p) => {
+                    let (action, changed) = p.reconcile(kanidm_client, status, ctx.clone()).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+                Finalizer::Cleanup(p) => {
+                    let (action, changed) = p.cleanup(kanidm_client, status, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+            }
         }
     })
     .await
@@ -139,7 +163,9 @@ pub async fn reconcile_oauth2(
             "failed on oauth2 client finalizer".to_string(),
             Box::new(e),
         )),
-    })
+    })?;
+    let changed = outcome.load(std::sync::atomic::Ordering::Relaxed);
+    Ok((action, changed))
 }
 
 impl KanidmOAuth2Client {
@@ -244,12 +270,12 @@ impl KanidmOAuth2Client {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmOAuth2ClientStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         match self
             .internal_reconcile(kanidm_client, status, ctx.clone())
             .await
         {
-            Ok(action) => Ok(action),
+            Ok(result) => Ok(result),
             Err(e) => match &e {
                 Error::KanidmClientError(msg, client_err) => {
                     let event_note = match client_err.as_ref() {
@@ -300,51 +326,62 @@ impl KanidmOAuth2Client {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmOAuth2ClientStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
         let namespace = self.get_namespace();
+        let metrics = &ctx.kaniop_ctx.metrics;
         let mut require_status_update = false;
+        let mut changed = false;
         let force_secret_rotation_requested = self.force_secret_rotation_requested();
 
         if is_oauth2_false(TYPE_EXISTS, status.clone()) {
-            self.create(&kanidm_client, name).await?;
+            self.create(&kanidm_client, name, metrics).await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_SECRET_INITIALIZED, status.clone()) {
-            let secret = self
-                .generate_secret(
+            let secret = record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_GET_SECRET,
+                KANIDM_OUTCOME_CHANGED,
+                self.generate_secret(
                     &kanidm_client,
                     self.spec.secret_rotation.as_ref(),
                     self.spec.secret_key_aliases.as_ref(),
-                )
-                .await?;
+                ),
+            )
+            .await?;
             self.apply_secret(&ctx, secret).await?;
-            return Ok(Action::requeue(Duration::from_millis(500)));
+            return Ok((Action::requeue(Duration::from_millis(500)), true));
         }
 
-        // Handle secret key aliases sync - regenerate secret if aliases are not synced.
-        // Skip this if force rotation is requested, as rotation will regenerate the secret.
-        // We regenerate when TYPE_SECRET_KEY_ALIASES_SYNCED is False, regardless of annotation.
-        // This ensures we keep regenerating until the secret actually has the correct keys.
-        // The annotation is updated only when TYPE is True (confirmed synced).
         if is_oauth2_false(TYPE_SECRET_KEY_ALIASES_SYNCED, status.clone())
             && !force_secret_rotation_requested
         {
+            // Handle secret key aliases sync - regenerate secret if aliases are not synced.
+            // Skip this if force rotation is requested, as rotation will regenerate the secret.
+            // We regenerate when TYPE_SECRET_KEY_ALIASES_SYNCED is False, regardless of annotation.
+            // This ensures we keep regenerating until the secret actually has the correct keys.
+            // The annotation is updated only when TYPE is True (confirmed synced).
             info!(msg = "regenerating secret due to secretKeyAliases not synced");
-            let secret = self
-                .generate_secret(
+            let secret = record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_GET_SECRET,
+                KANIDM_OUTCOME_CHANGED,
+                self.generate_secret(
                     &kanidm_client,
                     self.spec.secret_rotation.as_ref(),
                     self.spec.secret_key_aliases.as_ref(),
-                )
-                .await?;
+                ),
+            )
+            .await?;
             self.apply_secret(&ctx, secret).await?;
-            return Ok(Action::requeue(Duration::from_millis(500)));
+            return Ok((Action::requeue(Duration::from_millis(500)), true));
         }
 
-        // Update annotation when aliases are confirmed synced but annotation is outdated.
-        // Do this only after TYPE is True to avoid race conditions.
         let current_generation = self.metadata.generation.unwrap_or(0);
         let annotation_generation = self
             .annotations()
@@ -354,6 +391,8 @@ impl KanidmOAuth2Client {
         if is_oauth2(TYPE_SECRET_KEY_ALIASES_SYNCED, status.clone())
             && current_generation > annotation_generation
         {
+            // Update annotation when aliases are confirmed synced but annotation is outdated.
+            // Do this only after TYPE is True to avoid race conditions.
             self.patch_alias_generation_annotation(ctx.clone(), current_generation)
                 .await?;
             require_status_update = true;
@@ -364,24 +403,26 @@ impl KanidmOAuth2Client {
                 info!(msg = "skipping forced secret rotation annotation for public OAuth2 client");
             } else {
                 info!(msg = "rotating OAuth2 client secret due to force annotation");
-                self.rotate_secret(&kanidm_client, name, ctx.clone())
+                self.rotate_secret(&kanidm_client, name, ctx.clone(), metrics)
                     .await?;
             }
             self.clear_force_secret_rotation_annotation(ctx.clone())
                 .await?;
             require_status_update = true;
+            changed = true;
         } else if is_oauth2_false(TYPE_SECRET_ROTATED, status.clone()) {
             // Handle scheduled secret rotation for confidential clients
-            self.rotate_secret(&kanidm_client, name, ctx.clone())
+            self.rotate_secret(&kanidm_client, name, ctx.clone(), metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
-        // Note: when the Secret is created in this same reconcile cycle,
-        // TYPE_SECRET_TEMPLATE_SYNCED is absent (not False) in `status` because the Secret
-        // didn't exist when `update_status` ran. The template apply is therefore deferred to
-        // the next reconcile after the watch delivers the new Secret to the store.
         if is_oauth2_false(TYPE_SECRET_TEMPLATE_SYNCED, status.clone()) {
+            // Note: when the Secret is created in this same reconcile cycle,
+            // TYPE_SECRET_TEMPLATE_SYNCED is absent (not False) in `status` because the Secret
+            // didn't exist when `update_status` ran. The template apply is therefore deferred to
+            // the next reconcile after the watch delivers the new Secret to the store.
             match ctx.secret_store.find(|s| {
                 s.name_any() == self.secret_name() && s.namespace().as_ref() == Some(&namespace)
             }) {
@@ -439,138 +480,190 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
                         )
                         .await?;
                         require_status_update = true;
+                        changed = true;
                     }
                 }
             }
         }
 
         if is_oauth2_false(TYPE_UPDATED, status.clone()) {
-            self.update(&kanidm_client, name).await?;
+            self.update(&kanidm_client, name, metrics).await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_REDIRECT_URL_UPDATED, status.clone()) {
-            self.update_redirect_url(&kanidm_client, name, &status)
+            self.update_redirect_url(&kanidm_client, name, &status, metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_SCOPE_MAP_UPDATED, status.clone()) {
-            self.update_scope_map(&kanidm_client, name, &status).await?;
+            self.update_scope_map(&kanidm_client, name, &status, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_SUP_SCOPE_MAP_UPDATED, status.clone()) {
-            self.update_sup_scope_map(&kanidm_client, name, &status)
+            self.update_sup_scope_map(&kanidm_client, name, &status, metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_CLAIMS_MAP_UPDATED, status.clone()) {
-            self.update_claims_map(&kanidm_client, name, &status)
+            self.update_claims_map(&kanidm_client, name, &status, metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_STRICT_REDIRECT_URL_UPDATED, status.clone()) {
-            self.update_strict_redirect_url(&kanidm_client, name)
+            self.update_strict_redirect_url(&kanidm_client, name, metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_DISABLE_PKCE_UPDATED, status.clone()) {
-            self.update_disable_pkce(&kanidm_client, name).await?;
+            self.update_disable_pkce(&kanidm_client, name, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_PREFER_SHORT_NAME_UPDATED, status.clone()) {
-            self.update_prefer_short_name(&kanidm_client, name).await?;
+            self.update_prefer_short_name(&kanidm_client, name, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_ALLOW_LOCALHOST_REDIRECT_UPDATED, status.clone()) {
-            self.update_allow_localhost_redirect(&kanidm_client, name)
+            self.update_allow_localhost_redirect(&kanidm_client, name, metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_LEGACY_CRYPTO_UPDATED, status.clone()) {
-            self.update_legacy_crypto(&kanidm_client, name).await?;
+            self.update_legacy_crypto(&kanidm_client, name, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_DISABLE_CONSENT_PROMPT_UPDATED, status.clone()) {
-            self.update_consent_prompt(&kanidm_client, name).await?;
+            self.update_consent_prompt(&kanidm_client, name, metrics)
+                .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_oauth2_false(TYPE_IMAGE_UPDATED, status.clone()) {
-            self.update_image(&kanidm_client, name, &status, ctx.clone())
+            let image_changed = self
+                .update_image(&kanidm_client, name, &status, ctx.clone(), metrics)
                 .await?;
             require_status_update = true;
+            changed = changed || image_changed;
         }
 
         if require_status_update {
             trace!(msg = "status update required, requeueing in 500ms");
-            Ok(Action::requeue(Duration::from_millis(500)))
+            Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
-            Ok(Action::requeue(idm_reconcile_interval()))
+            Ok((Action::requeue(idm_reconcile_interval()), changed))
         }
     }
 
-    async fn create(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn create(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = "create");
         if self.spec.public {
             debug!(msg = "create public client");
-            kanidm_client
-                .idm_oauth2_rs_public_create(name, &self.spec.displayname, &self.spec.origin)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "create",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
-        } else {
-            kanidm_client
-                .idm_oauth2_rs_basic_create(name, &self.spec.displayname, &self.spec.origin)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "create",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
-        }
-        Ok(())
-    }
-
-    async fn update(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "update");
-        kanidm_client
-            .idm_oauth2_rs_update(
-                name,
-                None,
-                Some(&self.spec.displayname),
-                Some(&self.spec.origin),
-                false,
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_oauth2_rs_public_create(
+                    name,
+                    &self.spec.displayname,
+                    &self.spec.origin,
+                ),
             )
             .await
             .map_err(|e| {
                 Error::kanidm_client_error(
-                    "update",
+                    "create",
                     name,
                     self.kanidm_namespace(),
                     self.kanidm_name(),
                     e,
                 )
             })?;
+        } else {
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_oauth2_rs_basic_create(
+                    name,
+                    &self.spec.displayname,
+                    &self.spec.origin,
+                ),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error(
+                    "create",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn update(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
+        debug!(msg = "update");
+        record_kanidm_sdk_call(
+            metrics,
+            KANIDM_RESOURCE_OAUTH2,
+            KANIDM_OP_UPDATE,
+            KANIDM_OUTCOME_CHANGED,
+            kanidm_client.idm_oauth2_rs_update(
+                name,
+                None,
+                Some(&self.spec.displayname),
+                Some(&self.spec.origin),
+                false,
+            ),
+        )
+        .await
+        .map_err(|e| {
+            Error::kanidm_client_error(
+                "update",
+                name,
+                self.kanidm_namespace(),
+                self.kanidm_name(),
+                e,
+            )
+        })?;
         Ok(())
     }
 
@@ -579,31 +672,42 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         kanidm_client: &KanidmClient,
         name: &str,
         ctx: Arc<Context>,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         info!(msg = "rotating OAuth2 client secret");
         // Reset the secret in Kanidm using idm_oauth2_rs_update with reset_secret=true
-        kanidm_client
-            .idm_oauth2_rs_update(name, None, None, None, true)
-            .await
-            .map_err(|e| {
-                Error::kanidm_client_error_attr(
-                    "rotate",
-                    "secret",
-                    name,
-                    self.kanidm_namespace(),
-                    self.kanidm_name(),
-                    e,
-                )
-            })?;
+        record_kanidm_sdk_call(
+            metrics,
+            KANIDM_RESOURCE_OAUTH2,
+            KANIDM_OP_RESET_SECRET,
+            KANIDM_OUTCOME_CHANGED,
+            kanidm_client.idm_oauth2_rs_update(name, None, None, None, true),
+        )
+        .await
+        .map_err(|e| {
+            Error::kanidm_client_error_attr(
+                "rotate",
+                "secret",
+                name,
+                self.kanidm_namespace(),
+                self.kanidm_name(),
+                e,
+            )
+        })?;
 
         // Regenerate and patch the Kubernetes secret with the new client secret
-        let secret = self
-            .generate_secret(
+        let secret = record_kanidm_sdk_call(
+            metrics,
+            KANIDM_RESOURCE_OAUTH2,
+            KANIDM_OP_GET_SECRET,
+            KANIDM_OUTCOME_CHANGED,
+            self.generate_secret(
                 kanidm_client,
                 self.spec.secret_rotation.as_ref(),
                 self.spec.secret_key_aliases.as_ref(),
-            )
-            .await?;
+            ),
+        )
+        .await?;
         self.apply_secret(&ctx, secret).await?;
         Ok(())
     }
@@ -613,6 +717,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         kanidm_client: &KanidmClient,
         name: &str,
         status: &KanidmOAuth2ClientStatus,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_RS_ORIGIN} attribute"));
 
@@ -640,14 +745,40 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             })
             .collect::<Result<BTreeSet<_>>>()?;
 
+        let metrics_remove = metrics.clone();
         let delete_futures = current_urls
             .difference(&redirect_url)
-            .map(|url| kanidm_client.idm_oauth2_client_remove_origin(name, url))
+            .map(|url| {
+                let metrics = metrics_remove.clone();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_REMOVE_ORIGIN,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_client_remove_origin(name, url),
+                    )
+                    .await
+                }
+            })
             .collect::<TryJoinAll<_>>();
 
+        let metrics_add = metrics.clone();
         let add_futures = redirect_url
             .difference(&current_urls)
-            .map(|url| kanidm_client.idm_oauth2_client_add_origin(name, url))
+            .map(|url| {
+                let metrics = metrics_add.clone();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_ADD_ORIGIN,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_client_add_origin(name, url),
+                    )
+                    .await
+                }
+            })
             .collect::<TryJoinAll<_>>();
 
         futures::try_join!(delete_futures, add_futures).map_err(|e| {
@@ -669,6 +800,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         kanidm_client: &KanidmClient,
         name: &str,
         status: &KanidmOAuth2ClientStatus,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_RS_SCOPE_MAP} attribute"));
 
@@ -687,19 +819,40 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             .into_iter()
             .collect();
 
+        let metrics_del = metrics.clone();
         let delete_futures = current_scope_map
             .difference(&scope_map)
-            .map(|s| kanidm_client.idm_oauth2_rs_delete_scope_map(name, &s.group))
+            .map(|s| {
+                let metrics = metrics_del.clone();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_DELETE_SCOPE_MAP,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_rs_delete_scope_map(name, &s.group),
+                    )
+                    .await
+                }
+            })
             .collect::<TryJoinAll<_>>();
 
+        let metrics_add = metrics.clone();
         let add_futures = scope_map
             .difference(&current_scope_map)
             .map(|s| {
-                kanidm_client.idm_oauth2_rs_update_scope_map(
-                    name,
-                    &s.group,
-                    s.scopes.iter().map(|s| s.as_str()).collect(),
-                )
+                let metrics = metrics_add.clone();
+                let scopes: Vec<&str> = s.scopes.iter().map(|s| s.as_str()).collect();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_UPDATE_SCOPE_MAP,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_rs_update_scope_map(name, &s.group, scopes),
+                    )
+                    .await
+                }
             })
             .collect::<TryJoinAll<_>>();
 
@@ -721,6 +874,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         kanidm_client: &KanidmClient,
         name: &str,
         status: &KanidmOAuth2ClientStatus,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_RS_SUP_SCOPE_MAP} attribute"));
 
@@ -739,19 +893,40 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             .into_iter()
             .collect();
 
+        let metrics_del = metrics.clone();
         let delete_futures = current_sup_scope_map
             .difference(&sup_scope_map)
-            .map(|s| kanidm_client.idm_oauth2_rs_delete_sup_scope_map(name, &s.group))
+            .map(|s| {
+                let metrics = metrics_del.clone();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_DELETE_SUP_SCOPE_MAP,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_rs_delete_sup_scope_map(name, &s.group),
+                    )
+                    .await
+                }
+            })
             .collect::<TryJoinAll<_>>();
 
+        let metrics_add = metrics.clone();
         let add_futures = sup_scope_map
             .difference(&current_sup_scope_map)
             .map(|s| {
-                kanidm_client.idm_oauth2_rs_update_sup_scope_map(
-                    name,
-                    &s.group,
-                    s.scopes.iter().map(|s| s.as_str()).collect(),
-                )
+                let metrics = metrics_add.clone();
+                let scopes: Vec<&str> = s.scopes.iter().map(|s| s.as_str()).collect();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_UPDATE_SUP_SCOPE_MAP,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_rs_update_sup_scope_map(name, &s.group, scopes),
+                    )
+                    .await
+                }
             })
             .collect::<TryJoinAll<_>>();
 
@@ -773,6 +948,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         kanidm_client: &KanidmClient,
         name: &str,
         status: &KanidmOAuth2ClientStatus,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_RS_CLAIM_MAP} attribute"));
 
@@ -797,32 +973,76 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             .into_iter()
             .collect();
 
+        let metrics_del = metrics.clone();
         let delete_futures = current_claims_map
             .difference(&claims_map)
             .flat_map(|c| {
                 c.values_map
                     .iter()
-                    .map(|v| kanidm_client.idm_oauth2_rs_delete_claim_map(name, &c.name, &v.group))
+                    .map(|v| {
+                        let metrics = metrics_del.clone();
+                        async move {
+                            record_kanidm_sdk_call(
+                                &metrics,
+                                KANIDM_RESOURCE_OAUTH2,
+                                KANIDM_OP_DELETE_CLAIM_MAP,
+                                KANIDM_OUTCOME_CHANGED,
+                                kanidm_client
+                                    .idm_oauth2_rs_delete_claim_map(name, &c.name, &v.group),
+                            )
+                            .await
+                        }
+                    })
+                    .collect::<Vec<_>>()
             })
             .collect::<TryJoinAll<_>>();
 
         let claims_to_add = claims_map.difference(&current_claims_map);
+        let metrics_add = metrics.clone();
         let add_futures = claims_to_add
             .clone()
             .flat_map(|c| {
-                c.values_map.iter().map(|v| {
-                    kanidm_client.idm_oauth2_rs_update_claim_map(name, &c.name, &v.group, &v.values)
-                })
+                c.values_map
+                    .iter()
+                    .map(|v| {
+                        let metrics = metrics_add.clone();
+                        let values = v.values.clone();
+                        async move {
+                            record_kanidm_sdk_call(
+                                &metrics,
+                                KANIDM_RESOURCE_OAUTH2,
+                                KANIDM_OP_UPDATE_CLAIM_MAP,
+                                KANIDM_OUTCOME_CHANGED,
+                                kanidm_client.idm_oauth2_rs_update_claim_map(
+                                    name, &c.name, &v.group, &values,
+                                ),
+                            )
+                            .await
+                        }
+                    })
+                    .collect::<Vec<_>>()
             })
             .collect::<TryJoinAll<_>>();
 
+        let metrics_join = metrics.clone();
         let join_strategy_futures = claims_to_add
             .map(|c| {
-                kanidm_client.idm_oauth2_rs_update_claim_map_join(
-                    name,
-                    &c.name,
-                    c.join_strategy.to_oauth2_claim_map_join(),
-                )
+                let metrics = metrics_join.clone();
+                let join_strategy = c.join_strategy.to_oauth2_claim_map_join();
+                async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_OAUTH2,
+                        KANIDM_OP_UPDATE_CLAIM_MAP_JOIN,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_oauth2_rs_update_claim_map_join(
+                            name,
+                            &c.name,
+                            join_strategy,
+                        ),
+                    )
+                    .await
+                }
             })
             .collect::<TryJoinAll<_>>();
 
@@ -843,73 +1063,99 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         &self,
         kanidm_client: &KanidmClient,
         name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_STRICT_REDIRECT_URI} attribute"));
         if let Some(strict_redirect_url_enabled) = self.spec.strict_redirect_url {
             if strict_redirect_url_enabled {
-                kanidm_client
-                    .idm_oauth2_rs_enable_strict_redirect_uri(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_STRICT_REDIRECT_URI,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_enable_strict_redirect_uri(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_STRICT_REDIRECT_URI,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_disable_strict_redirect_uri(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_STRICT_REDIRECT_URI,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_disable_strict_redirect_uri(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_STRICT_REDIRECT_URI,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
     }
 
-    async fn update_disable_pkce(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn update_disable_pkce(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE} attribute"));
         if let Some(disable_pkce) = self.spec.allow_insecure_client_disable_pkce {
             if disable_pkce {
-                kanidm_client
-                    .idm_oauth2_rs_disable_pkce(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_disable_pkce(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_enable_pkce(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_enable_pkce(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
@@ -919,37 +1165,48 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         &self,
         kanidm_client: &KanidmClient,
         name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_PREFER_SHORT_USERNAME} attribute"));
         if let Some(prefer_short_username) = self.spec.prefer_short_username {
             if prefer_short_username {
-                kanidm_client
-                    .idm_oauth2_rs_prefer_short_username(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_PREFER_SHORT_USERNAME,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_prefer_short_username(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_PREFER_SHORT_USERNAME,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_prefer_spn_username(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_PREFER_SHORT_USERNAME,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_prefer_spn_username(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_PREFER_SHORT_USERNAME,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
@@ -959,109 +1216,150 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         &self,
         kanidm_client: &KanidmClient,
         name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT} attribute"));
         if let Some(allow_localhost_redirect) = self.spec.allow_localhost_redirect {
             if allow_localhost_redirect {
-                kanidm_client
-                    .idm_oauth2_rs_enable_public_localhost_redirect(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_enable_public_localhost_redirect(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_disable_public_localhost_redirect(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_disable_public_localhost_redirect(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
     }
 
-    async fn update_legacy_crypto(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn update_legacy_crypto(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE} attribute"));
         if let Some(legacy_crypto) = self.spec.jwt_legacy_crypto_enable {
             if legacy_crypto {
-                kanidm_client
-                    .idm_oauth2_rs_enable_legacy_crypto(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_enable_legacy_crypto(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_disable_legacy_crypto(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_disable_legacy_crypto(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
     }
 
-    async fn update_consent_prompt(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn update_consent_prompt(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = format!("update {ATTR_OAUTH2_CONSENT_PROMPT_ENABLE} attribute"));
         if let Some(disable_consent_prompt) = self.spec.disable_consent_prompt {
             if disable_consent_prompt {
-                kanidm_client
-                    .idm_oauth2_rs_disable_consent_prompt(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_CONSENT_PROMPT_ENABLE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_disable_consent_prompt(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_CONSENT_PROMPT_ENABLE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             } else {
-                kanidm_client
-                    .idm_oauth2_rs_enable_consent_prompt(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "update",
-                            ATTR_OAUTH2_CONSENT_PROMPT_ENABLE,
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_UPDATE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_enable_consent_prompt(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "update",
+                        ATTR_OAUTH2_CONSENT_PROMPT_ENABLE,
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
             }
         };
         Ok(())
@@ -1073,23 +1371,30 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         status: &KanidmOAuth2ClientStatus,
         ctx: Arc<Context>,
-    ) -> Result<()> {
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<bool> {
         match &self.spec.image {
             None => {
                 debug!(msg = "deleting image from OAuth2 client");
-                kanidm_client
-                    .idm_oauth2_rs_delete_image(name)
-                    .await
-                    .map_err(|e| {
-                        Error::kanidm_client_error_attr(
-                            "delete",
-                            "image",
-                            name,
-                            self.kanidm_namespace(),
-                            self.kanidm_name(),
-                            e,
-                        )
-                    })?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_OAUTH2,
+                    KANIDM_OP_DELETE_IMAGE,
+                    KANIDM_OUTCOME_CHANGED,
+                    kanidm_client.idm_oauth2_rs_delete_image(name),
+                )
+                .await
+                .map_err(|e| {
+                    Error::kanidm_client_error_attr(
+                        "delete",
+                        "image",
+                        name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
+                Ok(true)
             }
             Some(image_spec) => {
                 let url = &image_spec.url;
@@ -1097,22 +1402,30 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
 
                 let namespace = self.kanidm_namespace();
                 let kanidm = self.kanidm_name();
+                let namespace_for_closure = namespace.clone();
+                let kanidm_for_closure = kanidm.clone();
+                let metrics_clone = metrics.clone();
 
                 let update_result =
-                    update_image_if_needed(url, status.image.as_ref(), |image_value| async {
-                        kanidm_client
-                            .idm_oauth2_rs_update_image(name, image_value)
+                    update_image_if_needed(url, status.image.as_ref(), |image_value| {
+                        let metrics = metrics_clone.clone();
+                        let namespace = namespace_for_closure.clone();
+                        let kanidm = kanidm_for_closure.clone();
+                        async move {
+                            record_kanidm_sdk_call(
+                                &metrics,
+                                KANIDM_RESOURCE_OAUTH2,
+                                KANIDM_OP_UPDATE_IMAGE,
+                                KANIDM_OUTCOME_CHANGED,
+                                kanidm_client.idm_oauth2_rs_update_image(name, image_value),
+                            )
                             .await
                             .map_err(|e| {
                                 Error::kanidm_client_error_attr(
-                                    "update",
-                                    "image",
-                                    name,
-                                    namespace.clone(),
-                                    kanidm.clone(),
-                                    e,
+                                    "update", "image", name, namespace, kanidm, e,
                                 )
                             })
+                        }
                     })
                     .await;
 
@@ -1149,15 +1462,16 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
                             .map_err(|e| {
                                 Error::kube_status_error("KanidmOAuth2Client", &namespace, &name, e)
                             })?;
+                        Ok(true)
                     }
-                    Ok(None) => {}
+                    Ok(None) => Ok(false),
                     Err(e) => {
                         let operation = if matches!(e, Error::HttpError(_, _)) {
                             ImageOperation::Fetch
                         } else {
                             ImageOperation::Download
                         };
-                        return Err(publish_image_error_event(
+                        Err(publish_image_error_event(
                             e,
                             operation,
                             name,
@@ -1166,36 +1480,43 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
                             &ctx.kaniop_ctx.recorder,
                             self,
                         )
-                        .await);
+                        .await)
                     }
                 }
             }
-        };
-        Ok(())
+        }
     }
 
     async fn cleanup(
         &self,
         kanidm_client: Arc<KanidmClient>,
         status: KanidmOAuth2ClientStatus,
-    ) -> Result<Action> {
+        ctx: Arc<Context>,
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let mut changed = false;
         if is_oauth2(TYPE_EXISTS, status.clone()) {
             debug!(msg = "delete");
-            kanidm_client
-                .idm_oauth2_rs_delete(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "delete",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                &ctx.kaniop_ctx.metrics,
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_oauth2_rs_delete(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error(
+                    "delete",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
+            changed = true;
         }
-        Ok(Action::requeue(idm_reconcile_interval()))
+        Ok((Action::requeue(idm_reconcile_interval()), changed))
     }
 }
 

--- a/libs/oauth2/src/reconcile/status.rs
+++ b/libs/oauth2/src/reconcile/status.rs
@@ -10,12 +10,14 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_k8s_util::rotation::needs_rotation as rotation_check;
 use kaniop_k8s_util::types::{compare_urls, get_first_as_bool, get_first_cloned, normalize_url};
 use kaniop_operator::controller::kanidm::KanidmResource;
+use kaniop_operator::metrics::{
+    KANIDM_OP_GET, KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED, KANIDM_RESOURCE_OAUTH2,
+};
 use kaniop_operator::object_meta_template::ObjectMetaTemplateExt;
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use futures::TryFutureExt;
 use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use k8s_openapi::jiff::Timestamp;
@@ -107,12 +109,22 @@ impl StatusExt for KanidmOAuth2Client {
         // safe unwrap: person is namespaced scoped
         let namespace = self.get_namespace();
         let name = self.kanidm_entity_name();
-        let current_oauth2 = kanidm_client
-            .idm_oauth2_rs_get(&name)
-            .map_err(|e| {
-                Error::kanidm_client_error("get", &name, &namespace, &self.spec.kanidm_ref.name, e)
-            })
-            .await?;
+        let start = tokio::time::Instant::now();
+        let current_oauth2 = kanidm_client.idm_oauth2_rs_get(&name).await.map_err(|e| {
+            ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_OAUTH2,
+                KANIDM_OP_GET,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            Error::kanidm_client_error("get", &name, &namespace, &self.spec.kanidm_ref.name, e)
+        })?;
+        ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_OAUTH2,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+            start.elapsed(),
+        );
 
         let (secret, secret_meta) = if self.spec.public {
             (None, None)

--- a/libs/operator/Cargo.toml
+++ b/libs/operator/Cargo.toml
@@ -64,3 +64,4 @@ hyper = "1"
 tower-test = "0.4.0"
 testcontainers = "0.28"
 nix = { version = "0.31", features = ["user"] }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/libs/operator/src/controller/context.rs
+++ b/libs/operator/src/controller/context.rs
@@ -248,10 +248,15 @@ where
             trace!("backoff returned None, using default duration");
             Duration::from_secs(1)
         });
-        self.error_backoff_cache
-            .write()
-            .await
-            .insert(obj_ref.clone(), RwLock::new(backoff));
+        let mut cache = self.error_backoff_cache.write().await;
+        use std::collections::hash_map::Entry;
+        match cache.entry(obj_ref.clone()) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(RwLock::new(backoff));
+                self.metrics.objects_in_backoff_inc();
+            }
+            Entry::Occupied(_occupied) => {}
+        }
         trace!(
             msg = format!("recreate backoff policy"),
             namespace = obj_ref.namespace.as_deref().unwrap(),
@@ -262,15 +267,14 @@ where
 
     /// Reset the backoff policy for the given object
     async fn reset_backoff(&self, obj_ref: ObjectRef<K>) {
-        let read_guard = self.error_backoff_cache.read().await;
-        if read_guard.get(&obj_ref).is_some() {
-            drop(read_guard);
+        let removed = self.error_backoff_cache.write().await.remove(&obj_ref);
+        if removed.is_some() {
             trace!(
                 msg = "reset backoff policy",
                 namespace = obj_ref.namespace.as_deref().unwrap(),
                 name = obj_ref.name
             );
-            self.error_backoff_cache.write().await.remove(&obj_ref);
+            self.metrics.objects_in_backoff_dec();
         }
     }
 }

--- a/libs/operator/src/controller/mod.rs
+++ b/libs/operator/src/controller/mod.rs
@@ -324,10 +324,16 @@ macro_rules! backoff_reconciler {
     ($inner_reconciler:ident) => {
         |obj, ctx| async move {
             use $crate::controller::context::BackoffContext;
+            let _active_guard = ctx.metrics().active_reconcile_inc();
             match $inner_reconciler(obj.clone(), ctx.clone()).await {
-                Ok(action) => {
+                Ok((action, changed)) => {
                     ctx.reset_backoff(kube::runtime::reflector::ObjectRef::from(obj.as_ref()))
                         .await;
+                    if changed {
+                        ctx.metrics().reconcile_outcome_record($crate::metrics::KANIDM_OUTCOME_CHANGED);
+                    } else {
+                        ctx.metrics().reconcile_outcome_record($crate::metrics::KANIDM_OUTCOME_UNCHANGED);
+                    }
                     Ok(action)
                 }
                 Err(error) => {
@@ -336,6 +342,7 @@ macro_rules! backoff_reconciler {
                     let name = kube::ResourceExt::name_any(obj.as_ref());
                     tracing::error!(msg = "failed reconciliation", %namespace, %name, %error);
                     ctx.metrics().reconcile_failure_inc();
+                    ctx.metrics().reconcile_outcome_record($crate::metrics::KANIDM_OUTCOME_ERROR);
                     let backoff_duration = ctx
                         .get_backoff(kube::runtime::reflector::ObjectRef::from(obj.as_ref()))
                         .await;

--- a/libs/operator/src/kanidm/reconcile/domain_appearance.rs
+++ b/libs/operator/src/kanidm/reconcile/domain_appearance.rs
@@ -1,5 +1,9 @@
 use super::super::controller::context::Context;
 use crate::kanidm::crd::{DomainAppearanceImageStatus, Kanidm, KanidmStatus};
+use crate::metrics::{
+    KANIDM_OP_DELETE, KANIDM_OP_IMAGE, KANIDM_OP_SET_DISPLAY_NAME, KANIDM_OUTCOME_CHANGED,
+    KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED, KANIDM_RESOURCE_DOMAIN,
+};
 use kaniop_k8s_util::error::{Error, Result};
 use kaniop_k8s_util::image::{ImageOperation, publish_image_error_event, update_image_if_needed};
 
@@ -11,21 +15,45 @@ use kube::ResourceExt;
 use kube::api::{Api, Patch, PatchParams};
 use tracing::debug;
 
-async fn delete_domain_image(kanidm_client: &KanidmClient) -> Result<()> {
-    match kanidm_client.idm_domain_delete_image().await {
-        Ok(()) => Ok(()),
+async fn delete_domain_image(kanidm_client: &KanidmClient, ctx: &Context) -> Result<()> {
+    let start = tokio::time::Instant::now();
+    let result = kanidm_client.idm_domain_delete_image().await;
+    match result {
+        Ok(()) => {
+            ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_DOMAIN,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_CHANGED,
+                start.elapsed(),
+            );
+            Ok(())
+        }
         Err(ClientError::Http(
             StatusCode::NOT_FOUND,
             Some(OperationError::NoMatchingEntries),
             _,
         )) => {
             debug!(msg = "domain image already absent, skipping delete");
+            ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_DOMAIN,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
             Ok(())
         }
-        Err(e) => Err(Error::KanidmClientError(
-            "failed to delete domain image".to_string(),
-            Box::new(e),
-        )),
+        Err(e) => {
+            ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_DOMAIN,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            Err(Error::KanidmClientError(
+                "failed to delete domain image".to_string(),
+                Box::new(e),
+            ))
+        }
     }
 }
 
@@ -76,17 +104,19 @@ pub async fn reconcile_domain_appearance(
             kanidm,
             kanidm_client.clone(),
             domain_appearance.display_name.as_deref(),
+            &ctx,
         )
         .await?;
 
-        reconcile_domain_image_with_spec(kanidm, kanidm_client, status, ctx, image_spec).await?;
+        reconcile_domain_image_with_spec(kanidm, kanidm_client, status, ctx.clone(), image_spec)
+            .await?;
     } else {
         if status.domain_appearance_image.is_some() {
             clear_domain_appearance_image_status(&kanidm_api, &name, &namespace).await?;
         }
 
         debug!(msg = "removing domain image from Kanidm");
-        delete_domain_image(&kanidm_client).await?;
+        delete_domain_image(&kanidm_client, &ctx).await?;
     }
 
     Ok(())
@@ -96,19 +126,41 @@ async fn reconcile_domain_display_name(
     kanidm: &Kanidm,
     kanidm_client: Arc<KanidmClient>,
     display_name: Option<&str>,
+    ctx: &Context,
 ) -> Result<()> {
     if let Some(name) = display_name {
         debug!(msg = format!("setting domain display name to '{}'", name));
-        match kanidm_client.idm_domain_set_display_name(name).await {
-            Ok(()) => {}
+        let start = tokio::time::Instant::now();
+        let result = kanidm_client.idm_domain_set_display_name(name).await;
+        match result {
+            Ok(()) => {
+                ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_DOMAIN,
+                    KANIDM_OP_SET_DISPLAY_NAME,
+                    KANIDM_OUTCOME_CHANGED,
+                    start.elapsed(),
+                );
+            }
             Err(ClientError::Http(
                 StatusCode::NOT_FOUND,
                 Some(OperationError::NoMatchingEntries),
                 _,
             )) => {
                 debug!(msg = "domain display name target is absent, skipping update");
+                ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_DOMAIN,
+                    KANIDM_OP_SET_DISPLAY_NAME,
+                    KANIDM_OUTCOME_UNCHANGED,
+                    start.elapsed(),
+                );
             }
             Err(e) => {
+                ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_DOMAIN,
+                    KANIDM_OP_SET_DISPLAY_NAME,
+                    KANIDM_OUTCOME_ERROR,
+                    start.elapsed(),
+                );
                 return Err(Error::KanidmClientError(
                     format!(
                         "failed to set domain display name for {namespace}/{name}",
@@ -142,7 +194,7 @@ async fn reconcile_domain_image_with_spec(
                 clear_domain_appearance_image_status(&kanidm_api, &name, &namespace).await?;
             }
 
-            delete_domain_image(&kanidm_client).await?;
+            delete_domain_image(&kanidm_client, &ctx).await?;
         }
         Some(image_spec) => {
             let url = &image_spec.url;
@@ -153,15 +205,37 @@ async fn reconcile_domain_image_with_spec(
             let kanidm_client_clone = kanidm_client.clone();
             let namespace_for_error = namespace.clone();
             let name_for_error = name.clone();
+            let metrics = ctx.kaniop_ctx.metrics.clone();
 
             let update_result = update_image_if_needed(
                 url,
                 status.domain_appearance_image.as_ref(),
-                |image_value| async {
-                    kanidm_client_clone
-                        .idm_domain_update_image(image_value)
-                        .await
-                        .map_err(|e| {
+                |image_value| {
+                    let metrics = metrics.clone();
+                    async move {
+                        let start = tokio::time::Instant::now();
+                        let result = kanidm_client_clone
+                            .idm_domain_update_image(image_value)
+                            .await;
+                        match &result {
+                            Ok(_) => {
+                                metrics.record_kanidm_sdk_outcome(
+                                    KANIDM_RESOURCE_DOMAIN,
+                                    KANIDM_OP_IMAGE,
+                                    KANIDM_OUTCOME_CHANGED,
+                                    start.elapsed(),
+                                );
+                            }
+                            Err(_) => {
+                                metrics.record_kanidm_sdk_outcome(
+                                    KANIDM_RESOURCE_DOMAIN,
+                                    KANIDM_OP_IMAGE,
+                                    KANIDM_OUTCOME_ERROR,
+                                    start.elapsed(),
+                                );
+                            }
+                        }
+                        result.map_err(|e| {
                             Error::KanidmClientError(
                                 format!(
                                     "failed to update domain image for {namespace_for_error}/{name_for_error}",
@@ -169,6 +243,7 @@ async fn reconcile_domain_image_with_spec(
                                 Box::new(e),
                             )
                         })
+                    }
                 },
             )
             .await;

--- a/libs/operator/src/kanidm/reconcile/mail_sender.rs
+++ b/libs/operator/src/kanidm/reconcile/mail_sender.rs
@@ -2,6 +2,12 @@ use super::super::controller::context::Context;
 use super::CLUSTER_LABEL;
 use crate::controller::{INSTANCE_LABEL, MANAGED_BY_LABEL, NAME_LABEL};
 use crate::kanidm::crd::{Kanidm, MailSenderSpec, MailSenderStatus};
+use crate::metrics::{
+    KANIDM_OP_CREATE, KANIDM_OP_DELETE, KANIDM_OP_DESTROY_API_TOKEN, KANIDM_OP_GENERATE_API_TOKEN,
+    KANIDM_OP_LIST_API_TOKENS, KANIDM_OP_REMOVE_MEMBERS, KANIDM_OP_SET_MEMBERS, KANIDM_OP_UPDATE,
+    KANIDM_OUTCOME_CHANGED, KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED,
+    KANIDM_RESOURCE_MAIL_SENDER, record_kanidm_sdk_call,
+};
 use kaniop_k8s_util::error::{Error, Result};
 
 use std::collections::BTreeMap;
@@ -51,7 +57,7 @@ pub async fn reconcile_mail_sender(
     kanidm: &Kanidm,
     kanidm_client: Arc<KanidmClient>,
     ctx: Arc<Context>,
-) -> Result<Option<MailSenderStatus>> {
+) -> Result<(Option<MailSenderStatus>, bool)> {
     let namespace = kanidm.namespace().unwrap();
     let kanidm_name = kanidm.name_any();
 
@@ -62,9 +68,20 @@ pub async fn reconcile_mail_sender(
         let config_secret_name = mail_sender_config_map_name(&kanidm_name);
         let deployment_name = mail_sender_deployment_name(&kanidm_name);
 
-        ensure_mail_sender_service_account(&kanidm_client, &sa_name, &kanidm.spec.domain).await?;
+        let mut changed = false;
 
-        ensure_mail_sender_in_group(&kanidm_client, &sa_name).await?;
+        let sa_changed = ensure_mail_sender_service_account(
+            &kanidm_client,
+            &sa_name,
+            &kanidm.spec.domain,
+            &ctx.kaniop_ctx.metrics,
+        )
+        .await?;
+        changed |= sa_changed;
+
+        let group_changed =
+            ensure_mail_sender_in_group(&kanidm_client, &sa_name, &ctx.kaniop_ctx.metrics).await?;
+        changed |= group_changed;
 
         let current_token_id = kanidm
             .status
@@ -72,15 +89,17 @@ pub async fn reconcile_mail_sender(
             .and_then(|s| s.mail_sender.as_ref())
             .and_then(|ms| ms.token_id.clone());
 
-        let (token, token_id) = ensure_mail_sender_token(
+        let (token, token_id, token_changed) = ensure_mail_sender_token(
             &kanidm_client,
             &ctx,
             &namespace,
             &config_secret_name,
             &sa_name,
             current_token_id,
+            &ctx.kaniop_ctx.metrics,
         )
         .await?;
+        changed |= token_changed;
 
         let smtp_credentials = read_smtp_credentials(&ctx, mail_sender_spec, &namespace).await?;
 
@@ -113,21 +132,24 @@ pub async fn reconcile_mail_sender(
             .as_ref()
             .is_some_and(|s| s.ready_replicas.unwrap_or(0) >= 1);
 
-        Ok(Some(MailSenderStatus {
-            service_account_name: sa_name,
-            token_secret_name: config_secret_name.clone(),
-            deployment_name,
-            config_map_name: config_secret_name,
-            token_id: Some(token_id),
-            ready,
-        }))
+        Ok((
+            Some(MailSenderStatus {
+                service_account_name: sa_name,
+                token_secret_name: config_secret_name.clone(),
+                deployment_name,
+                config_map_name: config_secret_name,
+                token_id: Some(token_id),
+                ready,
+            }),
+            changed,
+        ))
     } else {
         debug!(
             msg = "mail sender not enabled, cleaning up resources",
             namespace, kanidm_name
         );
-        cleanup_mail_sender_resources(kanidm, &ctx).await?;
-        Ok(None)
+        let cleanup_changed = cleanup_mail_sender_resources(kanidm, &ctx).await?;
+        Ok((None, cleanup_changed))
     }
 }
 
@@ -135,54 +157,118 @@ async fn ensure_mail_sender_service_account(
     kanidm_client: &KanidmClient,
     name: &str,
     domain: &str,
-) -> Result<()> {
+    metrics: &crate::metrics::ControllerMetrics,
+) -> Result<bool> {
     debug!(msg = "ensuring mail sender service account exists", name);
 
     let display_name = format!("Mail Sender ({domain})");
 
+    let start = tokio::time::Instant::now();
     let create_result = kanidm_client
         .idm_service_account_create(name, &display_name, ENTRY_MANAGED_BY)
         .await;
 
     match create_result {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                start.elapsed(),
+            );
+            Ok(true)
+        }
         Err(e) if is_already_exists_error(&e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
             debug!(msg = "service account already exists, updating", name);
+            let start = tokio::time::Instant::now();
             kanidm_client
                 .idm_service_account_update(name, None, Some(&display_name), None, None)
                 .await
                 .map_err(|e| {
+                    metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_MAIL_SENDER,
+                        KANIDM_OP_UPDATE,
+                        KANIDM_OUTCOME_ERROR,
+                        start.elapsed(),
+                    );
                     Error::KanidmClientError(
                         format!("failed to update service account {name}"),
                         Box::new(e),
                     )
                 })?;
-            Ok(())
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_UPDATE,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
+            Ok(false)
         }
-        Err(e) => Err(Error::KanidmClientError(
-            format!("failed to create service account {name}"),
-            Box::new(e),
-        )),
+        Err(e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            Err(Error::KanidmClientError(
+                format!("failed to create service account {name}"),
+                Box::new(e),
+            ))
+        }
     }
 }
 
-async fn ensure_mail_sender_in_group(kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+async fn ensure_mail_sender_in_group(
+    kanidm_client: &KanidmClient,
+    name: &str,
+    metrics: &crate::metrics::ControllerMetrics,
+) -> Result<bool> {
     debug!(msg = "adding mail sender to message_senders group", name);
 
+    let start = tokio::time::Instant::now();
     let add_result = kanidm_client
         .idm_group_add_members(MESSAGE_SENDERS_GROUP, &[name])
         .await;
 
     match add_result {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_SET_MEMBERS,
+                KANIDM_OUTCOME_CHANGED,
+                start.elapsed(),
+            );
+            Ok(true)
+        }
         Err(e) if is_already_member_error(&e) => {
             debug!(msg = "service account already in group", name);
-            Ok(())
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_SET_MEMBERS,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
+            Ok(false)
         }
-        Err(e) => Err(Error::KanidmClientError(
-            format!("failed to add {name} to {MESSAGE_SENDERS_GROUP}"),
-            Box::new(e),
-        )),
+        Err(e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_SET_MEMBERS,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            Err(Error::KanidmClientError(
+                format!("failed to add {name} to {MESSAGE_SENDERS_GROUP}"),
+                Box::new(e),
+            ))
+        }
     }
 }
 
@@ -193,23 +279,48 @@ async fn ensure_mail_sender_token(
     config_secret_name: &str,
     name: &str,
     current_token_id: Option<String>,
-) -> Result<(String, String)> {
+    metrics: &crate::metrics::ControllerMetrics,
+) -> Result<(String, String, bool)> {
     debug!(
         msg = "ensuring mail sender API token exists",
         name,
         current_token_id = ?current_token_id
     );
 
-    let existing_tokens = kanidm_client
-        .idm_service_account_list_api_token(name)
-        .await
-        .or_else(|e| match e {
-            ClientError::Http(status, _, _) if status == 404 => Ok(vec![]),
-            _ => Err(Error::KanidmClientError(
+    let start = tokio::time::Instant::now();
+    let existing_tokens_result = kanidm_client.idm_service_account_list_api_token(name).await;
+    let existing_tokens = match existing_tokens_result {
+        Ok(tokens) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_LIST_API_TOKENS,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
+            tokens
+        }
+        Err(ClientError::Http(status, _, _)) if status == 404 => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_LIST_API_TOKENS,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
+            vec![]
+        }
+        Err(e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_LIST_API_TOKENS,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
+            return Err(Error::KanidmClientError(
                 format!("failed to list API tokens for {name}"),
                 Box::new(e),
-            )),
-        })?;
+            ));
+        }
+    };
 
     let existing_mail_sender_tokens: Vec<_> = existing_tokens
         .iter()
@@ -226,7 +337,7 @@ async fn ensure_mail_sender_token(
             if let Some(existing_token_value) =
                 read_token_from_config_secret(ctx, namespace, config_secret_name).await?
             {
-                return Ok((existing_token_value, token.token_id.to_string()));
+                return Ok((existing_token_value, token.token_id.to_string(), false));
             }
             debug!(
                 msg = "existing token value not found in secret, destroying all tokens and regenerating",
@@ -243,15 +354,20 @@ async fn ensure_mail_sender_token(
         }
 
         for token in existing_mail_sender_tokens {
-            kanidm_client
-                .idm_service_account_destroy_api_token(name, token.token_id)
-                .await
-                .map_err(|e| {
-                    Error::KanidmClientError(
-                        format!("failed to destroy API token {} for {name}", token.token_id),
-                        Box::new(e),
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_DESTROY_API_TOKEN,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_service_account_destroy_api_token(name, token.token_id),
+            )
+            .await
+            .map_err(|e| {
+                Error::KanidmClientError(
+                    format!("failed to destroy API token {} for {name}", token.token_id),
+                    Box::new(e),
+                )
+            })?;
         }
     }
 
@@ -260,25 +376,41 @@ async fn ensure_mail_sender_token(
         name
     );
 
-    let token_value = kanidm_client
-        .idm_service_account_generate_api_token(name, MAIL_SENDER_COMPONENT, None, true, false)
-        .await
-        .map_err(|e| {
-            Error::KanidmClientError(
-                format!("failed to generate API token for {name}"),
-                Box::new(e),
-            )
-        })?;
+    let token_value = record_kanidm_sdk_call(
+        metrics,
+        KANIDM_RESOURCE_MAIL_SENDER,
+        KANIDM_OP_GENERATE_API_TOKEN,
+        KANIDM_OUTCOME_CHANGED,
+        kanidm_client.idm_service_account_generate_api_token(
+            name,
+            MAIL_SENDER_COMPONENT,
+            None,
+            true,
+            false,
+        ),
+    )
+    .await
+    .map_err(|e| {
+        Error::KanidmClientError(
+            format!("failed to generate API token for {name}"),
+            Box::new(e),
+        )
+    })?;
 
-    let new_tokens = kanidm_client
-        .idm_service_account_list_api_token(name)
-        .await
-        .map_err(|e| {
-            Error::KanidmClientError(
-                format!("failed to list API tokens for {name} after generation"),
-                Box::new(e),
-            )
-        })?;
+    let new_tokens = record_kanidm_sdk_call(
+        metrics,
+        KANIDM_RESOURCE_MAIL_SENDER,
+        KANIDM_OP_LIST_API_TOKENS,
+        KANIDM_OUTCOME_UNCHANGED,
+        kanidm_client.idm_service_account_list_api_token(name),
+    )
+    .await
+    .map_err(|e| {
+        Error::KanidmClientError(
+            format!("failed to list API tokens for {name} after generation"),
+            Box::new(e),
+        )
+    })?;
 
     let new_token = new_tokens
         .iter()
@@ -289,7 +421,7 @@ async fn ensure_mail_sender_token(
             ))
         })?;
 
-    Ok((token_value, new_token.token_id.to_string()))
+    Ok((token_value, new_token.token_id.to_string(), true))
 }
 
 async fn read_token_from_config_secret(
@@ -590,9 +722,10 @@ async fn read_smtp_credentials(
     })
 }
 
-pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Result<()> {
+pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Result<bool> {
     let namespace = kanidm.namespace().unwrap();
     let kanidm_name = kanidm.name_any();
+    let mut changed = false;
 
     let deployment_name = mail_sender_deployment_name(&kanidm_name);
     let config_secret_name = mail_sender_config_map_name(&kanidm_name);
@@ -605,7 +738,9 @@ pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Re
     let dp = DeleteParams::default();
 
     match deployment_api.delete(&deployment_name, &dp).await {
-        Ok(_) => {}
+        Ok(_) => {
+            changed = true;
+        }
         Err(kube::Error::Api(e)) if e.code == 404 => {
             debug!(
                 msg = "mail sender deployment already absent",
@@ -624,7 +759,9 @@ pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Re
     }
 
     match secret_api.delete(&config_secret_name, &dp).await {
-        Ok(_) => {}
+        Ok(_) => {
+            changed = true;
+        }
         Err(kube::Error::Api(e)) if e.code == 404 => {
             debug!(
                 msg = "mail sender config secret already absent",
@@ -642,28 +779,51 @@ pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Re
         }
     }
 
-    Ok(())
+    Ok(changed)
 }
 
 pub async fn cleanup_mail_sender_in_kanidm(
     kanidm_client: &KanidmClient,
     kanidm_name: &str,
-) -> Result<()> {
+    metrics: &crate::metrics::ControllerMetrics,
+) -> Result<bool> {
     let sa_name = mail_sender_service_account_name(kanidm_name);
+    let mut changed = false;
 
     debug!(
         msg = "removing mail sender from message_senders group",
         sa_name
     );
-    match kanidm_client
+    let start = tokio::time::Instant::now();
+    let remove_result = kanidm_client
         .idm_group_remove_members(MESSAGE_SENDERS_GROUP, &[&sa_name])
-        .await
-    {
-        Ok(()) => {}
+        .await;
+    match remove_result {
+        Ok(()) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_REMOVE_MEMBERS,
+                KANIDM_OUTCOME_CHANGED,
+                start.elapsed(),
+            );
+            changed = true;
+        }
         Err(e) if is_not_found_error(&e) || is_not_a_member_error(&e) => {
             debug!(msg = "mail sender group membership already absent", sa_name);
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_REMOVE_MEMBERS,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
         }
         Err(e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_REMOVE_MEMBERS,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
             return Err(Error::KanidmClientError(
                 format!("failed to remove {sa_name} from {MESSAGE_SENDERS_GROUP}"),
                 Box::new(e),
@@ -672,12 +832,34 @@ pub async fn cleanup_mail_sender_in_kanidm(
     }
 
     debug!(msg = "deleting mail sender service account", sa_name);
-    match kanidm_client.idm_service_account_delete(&sa_name).await {
-        Ok(()) => {}
+    let start = tokio::time::Instant::now();
+    let delete_result = kanidm_client.idm_service_account_delete(&sa_name).await;
+    match delete_result {
+        Ok(()) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_CHANGED,
+                start.elapsed(),
+            );
+            changed = true;
+        }
         Err(e) if is_not_found_error(&e) => {
             debug!(msg = "mail sender service account already absent", sa_name);
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_UNCHANGED,
+                start.elapsed(),
+            );
         }
         Err(e) => {
+            metrics.record_kanidm_sdk_outcome(
+                KANIDM_RESOURCE_MAIL_SENDER,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_ERROR,
+                start.elapsed(),
+            );
             return Err(Error::KanidmClientError(
                 format!("failed to delete service account {sa_name}"),
                 Box::new(e),
@@ -685,7 +867,7 @@ pub async fn cleanup_mail_sender_in_kanidm(
         }
     }
 
-    Ok(())
+    Ok(changed)
 }
 
 fn is_already_exists_error(e: &kanidm_client::ClientError) -> bool {

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -132,19 +132,21 @@ pub async fn reconcile_admins_secret(
     kanidm: Arc<Kanidm>,
     ctx: Arc<Context>,
     status: &KanidmStatus,
-) -> Result<()> {
+) -> Result<bool> {
     if is_kanidm_available(status.clone()) && !is_kanidm_initialized(status.clone()) {
         let admins_secret = kanidm.generate_admins_secret(ctx.clone()).await?;
         kanidm.patch(&ctx, admins_secret).await?;
+        return Ok(true);
     }
-    Ok(())
+    Ok(false)
 }
 
 pub async fn reconcile_replication_secrets(
     kanidm: Arc<Kanidm>,
     ctx: Arc<Context>,
     status: &KanidmStatus,
-) -> Result<()> {
+) -> Result<bool> {
+    let mut changed = false;
     let expected_secret_names = if kanidm.is_replication_enabled() {
         status
             .replica_statuses
@@ -170,6 +172,9 @@ pub async fn reconcile_replication_secrets(
                     .is_some_and(|l| l.get(CLUSTER_LABEL) == Some(&kanidm.name_any()))
         })
         .collect::<Vec<_>>();
+    if !deprecated_secrets.is_empty() {
+        changed = true;
+    }
     let secret_delete_future = deprecated_secrets
         .iter()
         .map(|secret| kanidm.delete(&ctx, secret.as_ref()))
@@ -195,6 +200,7 @@ pub async fn reconcile_replication_secrets(
             Api::<StatefulSet>::namespaced(ctx.kaniop_ctx.client.clone(), &kanidm.get_namespace());
 
         if has_pending {
+            changed = true;
             stream::iter(
                 status
                     .replica_statuses
@@ -270,6 +276,7 @@ pub async fn reconcile_replication_secrets(
             .collect();
 
         if !host_invalid_replicas.is_empty() {
+            changed = true;
             let restart_futures = host_invalid_replicas
                 .iter()
                 .map(|rs| sts_api.restart(&rs.statefulset_name));
@@ -347,6 +354,7 @@ pub async fn reconcile_replication_secrets(
         }
 
         if !cert_expiring_replicas.is_empty() {
+            changed = true;
             let renew_futures = cert_expiring_replicas
                 .iter()
                 .map(|rs| kanidm.renew_replica_cert(ctx.clone(), &rs.pod_name));
@@ -387,6 +395,7 @@ pub async fn reconcile_replication_secrets(
             && !has_certificate_host_invalid
             && !has_certificate_expiring
         {
+            changed = true;
             let has_single_replica = kanidm.spec.replica_groups.iter().any(|rg| rg.replicas == 1);
 
             let restart_futures = status
@@ -420,11 +429,11 @@ pub async fn reconcile_replication_secrets(
         }
     }
 
-    Ok(())
+    Ok(changed)
 }
 
 #[instrument(skip(ctx, kanidm))]
-pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<Action> {
+pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<(Action, bool)> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx
@@ -440,10 +449,25 @@ pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<
     })?;
     let kanidm_api: Api<Kanidm> =
         Api::namespaced(ctx.kaniop_ctx.client.clone(), &kanidm.get_namespace());
-    finalizer(&kanidm_api, KANIDM_FINALIZER, kanidm, |event| async {
-        match event {
-            Finalizer::Apply(kanidm) => reconcile(kanidm, ctx, status).await,
-            Finalizer::Cleanup(kanidm) => cleanup(kanidm, ctx).await,
+    let outcome = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let outcome_clone = outcome.clone();
+    let action = finalizer(&kanidm_api, KANIDM_FINALIZER, kanidm, move |event| {
+        let outcome = outcome_clone.clone();
+        let ctx = ctx.clone();
+        let status = status.clone();
+        async move {
+            match event {
+                Finalizer::Apply(kanidm) => {
+                    let (action, changed) = reconcile(kanidm, ctx, status).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+                Finalizer::Cleanup(kanidm) => {
+                    let (action, changed) = cleanup(kanidm, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+            }
         }
     })
     .await
@@ -456,7 +480,9 @@ pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<
             "failed on kanidm account finalizer".to_string(),
             Box::new(e),
         )),
-    })
+    })?;
+    let changed = outcome.load(std::sync::atomic::Ordering::Relaxed);
+    Ok((action, changed))
 }
 
 /// Hash of the TLS secret content, injected as a pod template annotation so
@@ -853,7 +879,12 @@ mod statefulset_recreate_recovery_tests {
     }
 }
 
-async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus) -> Result<Action> {
+async fn reconcile(
+    kanidm: Arc<Kanidm>,
+    ctx: Arc<Context>,
+    status: KanidmStatus,
+) -> Result<(Action, bool)> {
+    let mut changed = false;
     let admin_secret_future = reconcile_admins_secret(kanidm.clone(), ctx.clone(), &status);
     let replication_secret_futures =
         reconcile_replication_secrets(kanidm.clone(), ctx.clone(), &status);
@@ -880,6 +911,9 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             })
             .collect::<Vec<_>>()
     };
+    if !sts_to_delete.is_empty() {
+        changed = true;
+    }
     let sts_delete_futures = sts_to_delete
         .iter()
         .map(|sts| kanidm.delete(&ctx, sts.as_ref()))
@@ -957,6 +991,9 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             })
             .collect::<Vec<_>>()
     };
+    if !deprecated_rg_svcs.is_empty() {
+        changed = true;
+    }
     let rg_svcs_delete_futures = deprecated_rg_svcs
         .iter()
         .map(|svc| kanidm.delete(&ctx, svc.as_ref()))
@@ -1000,6 +1037,9 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             })
             .collect::<Vec<_>>()
     };
+    if !deprecated_ingresses.is_empty() {
+        changed = true;
+    }
     let ingress_delete_futures = deprecated_ingresses
         .iter()
         .map(|ing| kanidm.delete(&ctx, ing.as_ref()))
@@ -1020,7 +1060,7 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
                 .as_ref()
                 .map(|_| vec![kanidm.name_any()])
                 .unwrap_or_default();
-            store
+            let routes: Vec<_> = store
                 .state()
                 .into_iter()
                 .filter(|route| {
@@ -1028,7 +1068,11 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
                         && !expected_names.contains(&route.name_any())
                         && route.metadata.labels == Some(kanidm.generate_labels())
                 })
-                .collect::<Vec<_>>()
+                .collect();
+            if !routes.is_empty() {
+                changed = true;
+            }
+            routes
         }
         None => Vec::new(),
     };
@@ -1056,7 +1100,7 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
                 .and_then(|g| g.backend_tls_policy.as_ref())
                 .map(|_| vec![kanidm.name_any()])
                 .unwrap_or_default();
-            store
+            let policies: Vec<_> = store
                 .state()
                 .into_iter()
                 .filter(|policy| {
@@ -1064,7 +1108,11 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
                         && !expected_names.contains(&policy.name_any())
                         && policy.metadata.labels == Some(kanidm.generate_labels())
                 })
-                .collect::<Vec<_>>()
+                .collect();
+            if !policies.is_empty() {
+                changed = true;
+            }
+            policies
         }
         None => Vec::new(),
     };
@@ -1083,7 +1131,7 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
         try_join_all(Vec::new())
     };
 
-    try_join!(
+    let (_, admin_secret_changed, replication_secrets_changed, _, _, _, _, _, _, _, _, _, _) = try_join!(
         sts_delete_futures,
         admin_secret_future,
         replication_secret_futures,
@@ -1098,6 +1146,10 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
         backend_tls_policy_delete_futures,
         backend_tls_policy_futures
     )?;
+
+    if admin_secret_changed || replication_secrets_changed {
+        changed = true;
+    }
 
     if is_kanidm_available(status.clone()) {
         let namespace = kanidm.namespace().unwrap();
@@ -1118,8 +1170,11 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
             ctx.kaniop_ctx.client.clone(),
         )
         .await?;
-        let mail_sender_status =
+        let (mail_sender_status, mail_sender_mutated) =
             reconcile_mail_sender(&kanidm, kanidm_client.clone(), ctx.clone()).await?;
+        if mail_sender_mutated {
+            changed = true;
+        }
         let current_mail_sender_status = kanidm.status.as_ref().and_then(|s| s.mail_sender.clone());
         if mail_sender_status != current_mail_sender_status {
             let kanidm_api: Api<Kanidm> =
@@ -1141,13 +1196,17 @@ async fn reconcile(kanidm: Arc<Kanidm>, ctx: Arc<Context>, status: KanidmStatus)
         }
     }
 
-    Ok(Action::requeue(DEFAULT_RECONCILE_INTERVAL))
+    Ok((Action::requeue(DEFAULT_RECONCILE_INTERVAL), changed))
 }
 
-async fn cleanup(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<Action> {
+async fn cleanup(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<(Action, bool)> {
     debug!(msg = "cleanup");
 
-    cleanup_mail_sender_resources(&kanidm, &ctx).await?;
+    let mut changed = false;
+    let mail_resources_cleaned = cleanup_mail_sender_resources(&kanidm, &ctx).await?;
+    if mail_resources_cleaned {
+        changed = true;
+    }
 
     let namespace = kanidm.namespace().unwrap();
     let name = kanidm.name_any();
@@ -1160,11 +1219,15 @@ async fn cleanup(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<Action> {
     )
     .await
     {
-        cleanup_mail_sender_in_kanidm(&kanidm_client, &name).await?;
+        let kanidm_cleanup_done =
+            cleanup_mail_sender_in_kanidm(&kanidm_client, &name, &ctx.kaniop_ctx.metrics).await?;
+        if kanidm_cleanup_done {
+            changed = true;
+        }
     }
 
     ctx.kaniop_ctx.release_kanidm_clients(&kanidm).await;
-    Ok(Action::requeue(DEFAULT_RECONCILE_INTERVAL))
+    Ok((Action::requeue(DEFAULT_RECONCILE_INTERVAL), changed))
 }
 
 async fn wait_for_sts_rollout(client: kube::Client, namespace: &str, sts_name: &str) -> Result<()> {

--- a/libs/operator/src/metrics.rs
+++ b/libs/operator/src/metrics.rs
@@ -2,11 +2,98 @@ use crate::controller::ControllerId;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 use opentelemetry::{KeyValue, trace::TraceId};
 use tokio::time::Instant;
 use tracing::debug;
+
+pub const KANIDM_RESOURCE_PERSON: &str = "Person";
+pub const KANIDM_RESOURCE_GROUP: &str = "Group";
+pub const KANIDM_RESOURCE_OAUTH2: &str = "OAuth2Client";
+pub const KANIDM_RESOURCE_SERVICE_ACCOUNT: &str = "ServiceAccount";
+pub const KANIDM_RESOURCE_DOMAIN: &str = "Domain";
+pub const KANIDM_RESOURCE_MAIL_SENDER: &str = "MailSender";
+
+pub const KANIDM_OP_GET: &str = "get";
+pub const KANIDM_OP_GET_CREDENTIAL_STATUS: &str = "get_credential_status";
+pub const KANIDM_OP_CREATE: &str = "create";
+pub const KANIDM_OP_UPDATE: &str = "update";
+pub const KANIDM_OP_DELETE: &str = "delete";
+pub const KANIDM_OP_UNIX_EXTEND: &str = "unix_extend";
+pub const KANIDM_OP_CREDENTIAL_UPDATE_INTENT: &str = "credential_update_intent";
+pub const KANIDM_OP_SET_MEMBERS: &str = "set_members";
+pub const KANIDM_OP_SET_MAIL: &str = "set_mail";
+pub const KANIDM_OP_PURGE_MAIL: &str = "purge_mail";
+pub const KANIDM_OP_ADD_MAIL: &str = "add_mail";
+pub const KANIDM_OP_REMOVE_MAIL: &str = "remove_mail";
+pub const KANIDM_OP_ACCOUNT_POLICY: &str = "account_policy";
+pub const KANIDM_OP_PURGE_ATTR: &str = "purge_attr";
+pub const KANIDM_OP_ROTATE_SECRET: &str = "rotate_secret";
+pub const KANIDM_OP_GET_SECRET: &str = "get_secret";
+pub const KANIDM_OP_ADD_ORIGIN: &str = "add_origin";
+pub const KANIDM_OP_REMOVE_ORIGIN: &str = "remove_origin";
+pub const KANIDM_OP_SCOPE_MAP: &str = "scope_map";
+pub const KANIDM_OP_DELETE_SCOPE_MAP: &str = "delete_scope_map";
+pub const KANIDM_OP_UPDATE_SCOPE_MAP: &str = "update_scope_map";
+pub const KANIDM_OP_SUP_SCOPE_MAP: &str = "sup_scope_map";
+pub const KANIDM_OP_DELETE_SUP_SCOPE_MAP: &str = "delete_sup_scope_map";
+pub const KANIDM_OP_UPDATE_SUP_SCOPE_MAP: &str = "update_sup_scope_map";
+pub const KANIDM_OP_CLAIM_MAP: &str = "claim_map";
+pub const KANIDM_OP_DELETE_CLAIM_MAP: &str = "delete_claim_map";
+pub const KANIDM_OP_UPDATE_CLAIM_MAP: &str = "update_claim_map";
+pub const KANIDM_OP_CLAIM_MAP_JOIN: &str = "claim_map_join";
+pub const KANIDM_OP_UPDATE_CLAIM_MAP_JOIN: &str = "update_claim_map_join";
+pub const KANIDM_OP_IMAGE: &str = "image";
+pub const KANIDM_OP_DELETE_IMAGE: &str = "delete_image";
+pub const KANIDM_OP_UPDATE_IMAGE: &str = "update_image";
+pub const KANIDM_OP_RESET_SECRET: &str = "reset_secret";
+pub const KANIDM_OP_GENERATE_API_TOKEN: &str = "generate_api_token";
+pub const KANIDM_OP_DESTROY_API_TOKEN: &str = "destroy_api_token";
+pub const KANIDM_OP_LIST_API_TOKENS: &str = "list_api_tokens";
+pub const KANIDM_OP_GENERATE_PASSWORD: &str = "generate_password";
+pub const KANIDM_OP_SET_DISPLAY_NAME: &str = "set_display_name";
+pub const KANIDM_OP_ADD_MEMBERS: &str = "add_members";
+pub const KANIDM_OP_REMOVE_MEMBERS: &str = "remove_members";
+
+pub const KANIDM_OUTCOME_CHANGED: &str = "changed";
+pub const KANIDM_OUTCOME_UNCHANGED: &str = "unchanged";
+pub const KANIDM_OUTCOME_ERROR: &str = "error";
+
+pub async fn record_kanidm_sdk_call<F, T, E>(
+    metrics: &ControllerMetrics,
+    resource: &'static str,
+    operation: &'static str,
+    success_outcome: &'static str,
+    future: F,
+) -> std::result::Result<T, E>
+where
+    F: std::future::Future<Output = std::result::Result<T, E>>,
+{
+    let start = Instant::now();
+    let result = future.await;
+    let outcome = match &result {
+        Ok(_) => success_outcome,
+        Err(_) => KANIDM_OUTCOME_ERROR,
+    };
+    metrics.kanidm_sdk_calls.add(
+        1,
+        &[
+            KeyValue::new("resource", resource),
+            KeyValue::new("operation", operation),
+            KeyValue::new("outcome", outcome),
+        ],
+    );
+    metrics.kanidm_sdk_call_duration.record(
+        start.elapsed().as_secs_f64(),
+        &[
+            KeyValue::new("resource", resource),
+            KeyValue::new("operation", operation),
+        ],
+    );
+    result
+}
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -38,6 +125,13 @@ pub struct ControllerMetrics {
     triggered: Counter<u64>,
     watch_operations_failed: Counter<u64>,
     ready: Gauge<i64>,
+    active_reconciles: Gauge<i64>,
+    active_reconciles_count: Arc<AtomicI64>,
+    objects_in_backoff: Gauge<i64>,
+    objects_in_backoff_count: Arc<AtomicI64>,
+    kanidm_sdk_calls: Counter<u64>,
+    kanidm_sdk_call_duration: Histogram<f64>,
+    reconcile_outcome: Counter<u64>,
 }
 
 impl ControllerMetrics {
@@ -71,6 +165,32 @@ impl ControllerMetrics {
             .with_description("1 when the controller is ready to reconcile resources, 0 otherwise")
             .build();
 
+        let active_reconciles = meter
+            .i64_gauge("active_reconciles")
+            .with_description("Number of reconcile operations currently in flight")
+            .build();
+
+        let objects_in_backoff = meter
+            .i64_gauge("objects_in_backoff")
+            .with_description("Number of objects currently in error backoff state")
+            .build();
+
+        let kanidm_sdk_calls = meter
+            .u64_counter("kanidm_sdk_calls")
+            .with_description("Total number of Kanidm SDK calls")
+            .build();
+
+        let kanidm_sdk_call_duration = meter
+            .f64_histogram("kanidm_sdk_call_duration_seconds")
+            .with_description("Duration of Kanidm SDK calls in seconds")
+            .with_boundaries(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0])
+            .build();
+
+        let reconcile_outcome = meter
+            .u64_counter("reconcile_outcome")
+            .with_description("Outcome of reconcile operations: changed, unchanged, or error")
+            .build();
+
         Self {
             controller: controller.to_string(),
             reconcile,
@@ -79,6 +199,13 @@ impl ControllerMetrics {
             triggered,
             watch_operations_failed,
             ready,
+            active_reconciles,
+            active_reconciles_count: Arc::new(AtomicI64::new(0)),
+            objects_in_backoff,
+            objects_in_backoff_count: Arc::new(AtomicI64::new(0)),
+            kanidm_sdk_calls,
+            kanidm_sdk_call_duration,
+            reconcile_outcome,
         }
     }
 
@@ -148,6 +275,93 @@ impl ControllerMetrics {
             &[KeyValue::new("controller", self.controller.clone())],
         );
     }
+
+    pub fn active_reconcile_inc(&self) -> ActiveReconcileGuard {
+        let new = self.active_reconciles_count.fetch_add(1, Ordering::Relaxed) + 1;
+        self.active_reconciles
+            .record(new, &[KeyValue::new("controller", self.controller.clone())]);
+        ActiveReconcileGuard {
+            count: self.active_reconciles_count.clone(),
+            gauge: self.active_reconciles.clone(),
+            controller: self.controller.clone(),
+        }
+    }
+
+    pub fn objects_in_backoff_inc(&self) {
+        let new = self
+            .objects_in_backoff_count
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        self.objects_in_backoff
+            .record(new, &[KeyValue::new("controller", self.controller.clone())]);
+    }
+
+    pub fn objects_in_backoff_dec(&self) {
+        let prev = self
+            .objects_in_backoff_count
+            .fetch_sub(1, Ordering::Relaxed);
+        let new = (prev - 1).max(0);
+        self.objects_in_backoff
+            .record(new, &[KeyValue::new("controller", self.controller.clone())]);
+    }
+
+    pub fn active_reconciles_count(&self) -> i64 {
+        self.active_reconciles_count.load(Ordering::Relaxed)
+    }
+
+    pub fn objects_in_backoff_count(&self) -> i64 {
+        self.objects_in_backoff_count.load(Ordering::Relaxed)
+    }
+
+    pub fn kanidm_sdk_call_inc(
+        &self,
+        resource: &'static str,
+        operation: &'static str,
+        outcome: &'static str,
+    ) {
+        self.kanidm_sdk_calls.add(
+            1,
+            &[
+                KeyValue::new("resource", resource),
+                KeyValue::new("operation", operation),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+    }
+
+    pub fn record_kanidm_sdk_outcome(
+        &self,
+        resource: &'static str,
+        operation: &'static str,
+        outcome: &'static str,
+        duration: std::time::Duration,
+    ) {
+        self.kanidm_sdk_calls.add(
+            1,
+            &[
+                KeyValue::new("resource", resource),
+                KeyValue::new("operation", operation),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+        self.kanidm_sdk_call_duration.record(
+            duration.as_secs_f64(),
+            &[
+                KeyValue::new("resource", resource),
+                KeyValue::new("operation", operation),
+            ],
+        );
+    }
+
+    pub fn reconcile_outcome_record(&self, outcome: &'static str) {
+        self.reconcile_outcome.add(
+            1,
+            &[
+                KeyValue::new("controller", self.controller.clone()),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+    }
 }
 
 #[derive(Clone)]
@@ -211,6 +425,22 @@ impl Drop for ReconcileMeasurer {
     }
 }
 
+pub struct ActiveReconcileGuard {
+    count: Arc<AtomicI64>,
+    gauge: Gauge<i64>,
+    controller: String,
+}
+
+impl Drop for ActiveReconcileGuard {
+    fn drop(&mut self) {
+        let prev = self.count.fetch_sub(1, Ordering::Relaxed);
+        self.gauge.record(
+            (prev - 1).max(0),
+            &[KeyValue::new("controller", self.controller.clone())],
+        );
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum Action {
     Apply,
@@ -223,5 +453,402 @@ impl Action {
             Action::Apply => "apply",
             Action::Delete => "delete",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::metrics::MeterProvider;
+
+    fn test_metrics() -> ControllerMetrics {
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+        let meter = provider.meter("test");
+        ControllerMetrics::new("test-controller", &meter)
+    }
+
+    #[test]
+    fn active_reconcile_guard_increments_on_creation() {
+        let m = test_metrics();
+        assert_eq!(m.active_reconciles_count(), 0);
+        let _guard = m.active_reconcile_inc();
+        assert_eq!(m.active_reconciles_count(), 1);
+    }
+
+    #[test]
+    fn active_reconcile_guard_decrements_on_drop() {
+        let m = test_metrics();
+        let guard = m.active_reconcile_inc();
+        assert_eq!(m.active_reconciles_count(), 1);
+        drop(guard);
+        assert_eq!(m.active_reconciles_count(), 0);
+    }
+
+    #[test]
+    fn active_reconcile_multiple_guards() {
+        let m = test_metrics();
+        let g1 = m.active_reconcile_inc();
+        let g2 = m.active_reconcile_inc();
+        let g3 = m.active_reconcile_inc();
+        assert_eq!(m.active_reconciles_count(), 3);
+        drop(g2);
+        assert_eq!(m.active_reconciles_count(), 2);
+        drop(g1);
+        assert_eq!(m.active_reconciles_count(), 1);
+        drop(g3);
+        assert_eq!(m.active_reconciles_count(), 0);
+    }
+
+    #[test]
+    fn active_reconcile_guard_does_not_underflow() {
+        let m = test_metrics();
+        let guard = m.active_reconcile_inc();
+        drop(guard);
+        assert_eq!(m.active_reconciles_count(), 0);
+    }
+
+    #[test]
+    fn objects_in_backoff_inc_dec() {
+        let m = test_metrics();
+        assert_eq!(m.objects_in_backoff_count(), 0);
+        m.objects_in_backoff_inc();
+        assert_eq!(m.objects_in_backoff_count(), 1);
+        m.objects_in_backoff_inc();
+        assert_eq!(m.objects_in_backoff_count(), 2);
+        m.objects_in_backoff_dec();
+        assert_eq!(m.objects_in_backoff_count(), 1);
+        m.objects_in_backoff_dec();
+        assert_eq!(m.objects_in_backoff_count(), 0);
+    }
+
+    #[test]
+    fn cloned_metrics_share_active_reconcile_counter() {
+        let m = test_metrics();
+        let m2 = m.clone();
+        let _g = m.active_reconcile_inc();
+        assert_eq!(m2.active_reconciles_count(), 1);
+    }
+
+    #[test]
+    fn cloned_metrics_share_backoff_counter() {
+        let m = test_metrics();
+        let m2 = m.clone();
+        m.objects_in_backoff_inc();
+        assert_eq!(m2.objects_in_backoff_count(), 1);
+        m2.objects_in_backoff_dec();
+        assert_eq!(m.objects_in_backoff_count(), 0);
+    }
+
+    #[test]
+    fn kanidm_sdk_call_inc_records_counter() {
+        let m = test_metrics();
+        m.kanidm_sdk_call_inc(
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_CREATE,
+            KANIDM_OUTCOME_CHANGED,
+        );
+        m.kanidm_sdk_call_inc(
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+        );
+        m.kanidm_sdk_call_inc(
+            KANIDM_RESOURCE_GROUP,
+            KANIDM_OP_DELETE,
+            KANIDM_OUTCOME_ERROR,
+        );
+    }
+
+    #[test]
+    fn record_kanidm_sdk_outcome_records_count_and_duration() {
+        let m = test_metrics();
+        m.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_CREATE,
+            KANIDM_OUTCOME_CHANGED,
+            std::time::Duration::from_millis(50),
+        );
+        m.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+            std::time::Duration::from_millis(10),
+        );
+    }
+
+    #[tokio::test]
+    async fn record_kanidm_sdk_call_helper_records_changed_on_success() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test", &meter);
+
+        let result: std::result::Result<(), &str> = record_kanidm_sdk_call(
+            &m,
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_CREATE,
+            KANIDM_OUTCOME_CHANGED,
+            async { Ok(()) },
+        )
+        .await;
+        assert!(result.is_ok());
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("kanidm_sdk_calls"));
+        assert!(text.contains("kanidm_sdk_call_duration_seconds"));
+        assert!(text.contains("changed"));
+    }
+
+    #[tokio::test]
+    async fn record_kanidm_sdk_call_helper_records_error_on_failure() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test", &meter);
+
+        let result: std::result::Result<(), &str> = record_kanidm_sdk_call(
+            &m,
+            KANIDM_RESOURCE_GROUP,
+            KANIDM_OP_DELETE,
+            KANIDM_OUTCOME_CHANGED,
+            async { Err("something failed") },
+        )
+        .await;
+        assert!(result.is_err());
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("error"));
+    }
+
+    #[tokio::test]
+    async fn record_kanidm_sdk_call_with_explicit_outcome() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test", &meter);
+
+        let result: std::result::Result<(), &str> = record_kanidm_sdk_call(
+            &m,
+            KANIDM_RESOURCE_OAUTH2,
+            KANIDM_OP_GET_SECRET,
+            KANIDM_OUTCOME_UNCHANGED,
+            async { Ok(()) },
+        )
+        .await;
+        assert!(result.is_ok());
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains(r#""unchanged""#));
+        assert!(!text.contains(r#""changed""#));
+    }
+
+    #[tokio::test]
+    async fn concurrent_active_reconcile_guards_track_correctly() {
+        let m = Arc::new(test_metrics());
+        let mut handles = Vec::new();
+        for _ in 0..100 {
+            let m = m.clone();
+            handles.push(tokio::spawn(async move {
+                let _guard = m.active_reconcile_inc();
+                tokio::task::yield_now().await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(m.active_reconciles_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_backoff_inc_dec_stays_balanced() {
+        let m = Arc::new(test_metrics());
+        let mut handles = Vec::new();
+        for _ in 0..50 {
+            let m = m.clone();
+            handles.push(tokio::spawn(async move {
+                m.objects_in_backoff_inc();
+                tokio::task::yield_now().await;
+                m.objects_in_backoff_dec();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(m.objects_in_backoff_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn entry_api_insert_only_increments_once() {
+        use std::collections::HashMap;
+        use std::collections::hash_map::Entry;
+        use tokio::sync::RwLock;
+
+        let m = Arc::new(test_metrics());
+        let cache: Arc<RwLock<HashMap<String, RwLock<u32>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let mut handles = Vec::new();
+
+        for _ in 0..100 {
+            let m = m.clone();
+            let cache = cache.clone();
+            handles.push(tokio::spawn(async move {
+                let mut guard = cache.write().await;
+                match guard.entry("same-key".to_string()) {
+                    Entry::Vacant(v) => {
+                        v.insert(RwLock::new(0));
+                        m.objects_in_backoff_inc();
+                    }
+                    Entry::Occupied(_) => {}
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(m.objects_in_backoff_count(), 1);
+        assert_eq!(cache.read().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_only_decrements_on_actual_removal() {
+        use std::collections::HashMap;
+        use tokio::sync::RwLock;
+
+        let m = Arc::new(test_metrics());
+        let cache: Arc<RwLock<HashMap<String, u32>>> = Arc::new(RwLock::new(HashMap::new()));
+        cache.write().await.insert("key".to_string(), 42);
+        m.objects_in_backoff_inc();
+
+        let mut handles = Vec::new();
+        for _ in 0..100 {
+            let m = m.clone();
+            let cache = cache.clone();
+            handles.push(tokio::spawn(async move {
+                let removed = cache.write().await.remove("key");
+                if removed.is_some() {
+                    m.objects_in_backoff_dec();
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(m.objects_in_backoff_count(), 0);
+        assert!(cache.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reconcile_outcome_record_records_changed() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test-ctrl", &meter);
+
+        m.reconcile_outcome_record(KANIDM_OUTCOME_CHANGED);
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("reconcile_outcome"));
+        assert!(text.contains("changed"));
+        assert!(text.contains("test-ctrl"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_outcome_record_records_unchanged() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test-ctrl", &meter);
+
+        m.reconcile_outcome_record(KANIDM_OUTCOME_UNCHANGED);
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("reconcile_outcome"));
+        assert!(text.contains("unchanged"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_outcome_record_records_error() {
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(std::time::Duration::from_millis(50))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test");
+        let m = ControllerMetrics::new("test-ctrl", &meter);
+
+        m.reconcile_outcome_record(KANIDM_OUTCOME_ERROR);
+
+        provider.force_flush().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let text = format!("{:?}", metrics);
+        assert!(text.contains("reconcile_outcome"));
+        assert!(text.contains("error"));
     }
 }

--- a/libs/operator/src/prometheus_exporter.rs
+++ b/libs/operator/src/prometheus_exporter.rs
@@ -20,7 +20,7 @@ impl PrometheusExporter {
     pub fn new() -> Self {
         debug!("Creating new Prometheus exporter");
         Self {
-            data: Arc::new(parking_lot::Mutex::new(None)),
+            data: Arc::new(parking_lot::Mutex::new(Some("# EOF\n".to_string()))),
         }
     }
 

--- a/libs/person/src/reconcile.rs
+++ b/libs/person/src/reconcile.rs
@@ -5,6 +5,12 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_operator::controller::kanidm::{KanidmResource, is_resource_watched};
 use kaniop_operator::controller::{context::IdmClientContext, idm_reconcile_interval};
 use kaniop_operator::crd::KanidmAccountPosixAttributes;
+use kaniop_operator::metrics::{
+    KANIDM_OP_CREATE, KANIDM_OP_CREDENTIAL_UPDATE_INTENT, KANIDM_OP_DELETE, KANIDM_OP_GET,
+    KANIDM_OP_GET_CREDENTIAL_STATUS, KANIDM_OP_UNIX_EXTEND, KANIDM_OP_UPDATE,
+    KANIDM_OUTCOME_CHANGED, KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED, KANIDM_RESOURCE_PERSON,
+    record_kanidm_sdk_call,
+};
 use kaniop_operator::telemetry;
 
 use std::collections::BTreeMap;
@@ -12,7 +18,6 @@ use std::ops::Not;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::TryFutureExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use k8s_openapi::jiff::Timestamp;
 use kanidm_client::{ClientError, KanidmClient};
@@ -63,7 +68,7 @@ pub async fn watched_resource(person: &KanidmPersonAccount, ctx: Arc<Context>) -
 pub async fn reconcile_person_account(
     person: Arc<KanidmPersonAccount>,
     ctx: Arc<Context>,
-) -> Result<Action> {
+) -> Result<(Action, bool)> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx
@@ -91,7 +96,7 @@ pub async fn reconcile_person_account(
             warn!(msg = "failed to publish ResourceNotWatched event", %e);
             Error::kube_error("publish", "event", person.get_namespace(), person.name_any(), e)
         })?;
-        return Ok(Action::requeue(idm_reconcile_interval()));
+        return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
     info!(msg = "reconciling person account");
 
@@ -106,10 +111,26 @@ pub async fn reconcile_person_account(
         })?;
     let persons_api: Api<KanidmPersonAccount> =
         Api::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
-    finalizer(&persons_api, PERSON_FINALIZER, person, |event| async {
-        match event {
-            Finalizer::Apply(p) => p.reconcile(kanidm_client, status, ctx).await,
-            Finalizer::Cleanup(p) => p.cleanup(kanidm_client, status, ctx).await,
+    let outcome = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let outcome_clone = outcome.clone();
+    let action = finalizer(&persons_api, PERSON_FINALIZER, person, move |event| {
+        let outcome = outcome_clone.clone();
+        let ctx = ctx.clone();
+        let status = status.clone();
+        let kanidm_client = kanidm_client.clone();
+        async move {
+            match event {
+                Finalizer::Apply(p) => {
+                    let (action, changed) = p.reconcile(kanidm_client, status, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+                Finalizer::Cleanup(p) => {
+                    let (action, changed) = p.cleanup(kanidm_client, status, ctx).await?;
+                    outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                    Ok(action)
+                }
+            }
         }
     })
     .await
@@ -122,7 +143,9 @@ pub async fn reconcile_person_account(
             "failed on person account finalizer".to_string(),
             Box::new(e),
         )),
-    })
+    })?;
+    let changed = outcome.load(std::sync::atomic::Ordering::Relaxed);
+    Ok((action, changed))
 }
 
 impl KanidmPersonAccount {
@@ -138,12 +161,12 @@ impl KanidmPersonAccount {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmPersonAccountStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         match self
             .internal_reconcile(kanidm_client, status, ctx.clone())
             .await
         {
-            Ok(action) => Ok(action),
+            Ok(result) => Ok(result),
             Err(e) => match e {
                 Error::KanidmClientError(_, _) => {
                     ctx.kaniop_ctx
@@ -181,10 +204,12 @@ impl KanidmPersonAccount {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmPersonAccountStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let metrics = &ctx.kaniop_ctx.metrics;
 
         let mut require_status_update = false;
+        let mut changed = false;
         let mut actions = Vec::new();
         if is_person_false(TYPE_EXISTS, status.clone()) {
             debug!(
@@ -193,8 +218,16 @@ impl KanidmPersonAccount {
                 status = CONDITION_FALSE,
                 action = "create"
             );
-            self.create(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_PERSON,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                self.create(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
             actions.push("create");
         }
         if is_person_false(TYPE_UPDATED, status.clone()) {
@@ -204,8 +237,9 @@ impl KanidmPersonAccount {
                 status = CONDITION_FALSE,
                 action = "update"
             );
-            self.update(&kanidm_client, name).await?;
+            self.update(&kanidm_client, name, metrics).await?;
             require_status_update = true;
+            changed = true;
             actions.push("update");
         }
 
@@ -219,8 +253,16 @@ impl KanidmPersonAccount {
                 status = CONDITION_FALSE,
                 action = "update_posix_attributes"
             );
-            self.update_posix_attributes(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_PERSON,
+                KANIDM_OP_UNIX_EXTEND,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_posix_attributes(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
             actions.push("update_posix");
         }
 
@@ -239,16 +281,24 @@ impl KanidmPersonAccount {
                     status = CONDITION_FALSE,
                     action = "create_reset_token"
                 );
-                self.create_reset_token(&kanidm_client, name, ctx).await?;
+                record_kanidm_sdk_call(
+                    metrics,
+                    KANIDM_RESOURCE_PERSON,
+                    KANIDM_OP_CREDENTIAL_UPDATE_INTENT,
+                    KANIDM_OUTCOME_CHANGED,
+                    self.create_reset_token(&kanidm_client, name, ctx.clone()),
+                )
+                .await?;
+                changed = true;
             };
         };
 
         if require_status_update {
             debug!(msg = "requeueing in 500ms after actions", actions = ?actions);
-            Ok(Action::requeue(Duration::from_millis(500)))
+            Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
             debug!(msg = "reconciliation complete, requeueing for next interval");
-            Ok(Action::requeue(idm_reconcile_interval()))
+            Ok((Action::requeue(idm_reconcile_interval()), changed))
         }
     }
 
@@ -269,27 +319,37 @@ impl KanidmPersonAccount {
         Ok(())
     }
 
-    async fn update(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
+    async fn update(
+        &self,
+        kanidm_client: &KanidmClient,
+        name: &str,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
+    ) -> Result<()> {
         debug!(msg = "update");
         trace!(msg = format!("update person attributes {:?}", self.spec.person_attributes));
-        kanidm_client
-            .idm_person_account_update(
+        record_kanidm_sdk_call(
+            metrics,
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_UPDATE,
+            KANIDM_OUTCOME_CHANGED,
+            kanidm_client.idm_person_account_update(
                 name,
                 None,
                 Some(&self.spec.person_attributes.displayname),
                 self.spec.person_attributes.legalname.as_deref(),
                 self.spec.person_attributes.mail.as_deref(),
+            ),
+        )
+        .await
+        .map_err(|e| {
+            Error::kanidm_client_error(
+                "update",
+                name,
+                self.kanidm_namespace(),
+                self.kanidm_name(),
+                e,
             )
-            .await
-            .map_err(|e| {
-                Error::kanidm_client_error(
-                    "update",
-                    name,
-                    self.kanidm_namespace(),
-                    self.kanidm_name(),
-                    e,
-                )
-            })?;
+        })?;
         let mut update_entry = Entry {
             attrs: BTreeMap::new(),
         };
@@ -307,18 +367,23 @@ impl KanidmPersonAccount {
         }
 
         if update_entry.attrs.is_empty().not() {
-            let _: Entry = kanidm_client
-                .perform_patch_request(&format!("/v1/person/{name}"), update_entry)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "update",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            let _: Entry = record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_PERSON,
+                KANIDM_OP_UPDATE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.perform_patch_request(&format!("/v1/person/{name}"), update_entry),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error(
+                    "update",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
         }
         Ok(())
     }
@@ -428,30 +493,37 @@ impl KanidmPersonAccount {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmPersonAccountStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let mut changed = false;
 
         if is_person(TYPE_EXISTS, status.clone()) {
             debug!(msg = "delete");
-            kanidm_client
-                .idm_person_account_delete(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "delete",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                &ctx.kaniop_ctx.metrics,
+                KANIDM_RESOURCE_PERSON,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_person_account_delete(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error(
+                    "delete",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
+            changed = true;
 
             ctx.internal_cache
                 .write()
                 .await
                 .remove(&ObjectRef::from(self));
         }
-        Ok(Action::requeue(idm_reconcile_interval()))
+        Ok((Action::requeue(idm_reconcile_interval()), changed))
     }
 
     async fn update_status(
@@ -462,9 +534,19 @@ impl KanidmPersonAccount {
         // safe unwrap: person is namespaced scoped
         let namespace = self.get_namespace();
         let name = self.kanidm_entity_name();
+        let metrics = &ctx.kaniop_ctx.metrics;
+        let start = tokio::time::Instant::now();
         let current_person = kanidm_client
             .idm_person_account_get(&name)
+            .await
             .map_err(|e| {
+                let elapsed = start.elapsed();
+                metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_PERSON,
+                    KANIDM_OP_GET,
+                    KANIDM_OUTCOME_ERROR,
+                    elapsed,
+                );
                 Error::kanidm_client_error(
                     "get",
                     name.as_str(),
@@ -472,8 +554,14 @@ impl KanidmPersonAccount {
                     self.kanidm_name(),
                     e,
                 )
-            })
-            .await?;
+            })?;
+        metrics.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_PERSON,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+            start.elapsed(),
+        );
+        let cred_start = tokio::time::Instant::now();
         let credential_present = match kanidm_client
             .idm_person_account_get_credential_status(&name)
             .await
@@ -485,6 +573,12 @@ impl KanidmPersonAccount {
                     credential_present = present,
                     creds_count = cs.creds.len()
                 );
+                metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_PERSON,
+                    KANIDM_OP_GET_CREDENTIAL_STATUS,
+                    KANIDM_OUTCOME_UNCHANGED,
+                    cred_start.elapsed(),
+                );
                 Some(present)
             }
             Err(ClientError::EmptyResponse) => {
@@ -493,10 +587,22 @@ impl KanidmPersonAccount {
                     credential_present = false,
                     reason = "EmptyResponse"
                 );
+                metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_PERSON,
+                    KANIDM_OP_GET_CREDENTIAL_STATUS,
+                    KANIDM_OUTCOME_UNCHANGED,
+                    cred_start.elapsed(),
+                );
                 Some(false)
             }
             Err(e) => {
                 trace!(msg = "credential status error", error = ?e);
+                metrics.record_kanidm_sdk_outcome(
+                    KANIDM_RESOURCE_PERSON,
+                    KANIDM_OP_GET_CREDENTIAL_STATUS,
+                    KANIDM_OUTCOME_ERROR,
+                    cred_start.elapsed(),
+                );
                 None
             }
         };

--- a/libs/service-account/src/reconcile/mod.rs
+++ b/libs/service-account/src/reconcile/mod.rs
@@ -19,6 +19,11 @@ use kaniop_operator::controller::INSTANCE_LABEL;
 use kaniop_operator::controller::context::KubeOperations;
 use kaniop_operator::controller::kanidm::{KanidmResource, is_resource_watched};
 use kaniop_operator::controller::{context::IdmClientContext, idm_reconcile_interval};
+use kaniop_operator::metrics::{
+    KANIDM_OP_CREATE, KANIDM_OP_DELETE, KANIDM_OP_DESTROY_API_TOKEN, KANIDM_OP_GENERATE_API_TOKEN,
+    KANIDM_OP_GENERATE_PASSWORD, KANIDM_OP_UNIX_EXTEND, KANIDM_OP_UPDATE, KANIDM_OUTCOME_CHANGED,
+    KANIDM_RESOURCE_SERVICE_ACCOUNT, record_kanidm_sdk_call,
+};
 use kaniop_operator::telemetry;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -27,7 +32,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::TryJoinAll;
-use futures::{TryFutureExt, try_join};
+use futures::try_join;
 use k8s_openapi::NamespaceResourceScope;
 use kanidm_client::KanidmClient;
 use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM};
@@ -65,7 +70,7 @@ pub async fn watched_resource(service_account: &KanidmServiceAccount, ctx: Arc<C
 pub async fn reconcile_service_account(
     service_account: Arc<KanidmServiceAccount>,
     ctx: Arc<Context>,
-) -> Result<Action> {
+) -> Result<(Action, bool)> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx
@@ -99,7 +104,7 @@ pub async fn reconcile_service_account(
                     e,
                 )
             })?;
-        return Ok(Action::requeue(idm_reconcile_interval()));
+        return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
     info!(msg = "reconciling service account");
 
@@ -114,14 +119,31 @@ pub async fn reconcile_service_account(
         })?;
     let service_accounts_api: Api<KanidmServiceAccount> =
         Api::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
-    finalizer(
+    let outcome = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let outcome_clone = outcome.clone();
+    let action = finalizer(
         &service_accounts_api,
         SERVICE_ACCOUNT_FINALIZER,
         service_account,
-        |event| async {
-            match event {
-                Finalizer::Apply(p) => p.reconcile(kanidm_client, status, ctx).await,
-                Finalizer::Cleanup(p) => p.cleanup(kanidm_client, status).await,
+        move |event| {
+            let outcome = outcome_clone.clone();
+            let ctx = ctx.clone();
+            let status = status.clone();
+            let kanidm_client = kanidm_client.clone();
+            async move {
+                match event {
+                    Finalizer::Apply(p) => {
+                        let (action, changed) =
+                            p.reconcile(kanidm_client, status, ctx.clone()).await?;
+                        outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                        Ok(action)
+                    }
+                    Finalizer::Cleanup(p) => {
+                        let (action, changed) = p.cleanup(kanidm_client, status, ctx).await?;
+                        outcome.store(changed, std::sync::atomic::Ordering::Relaxed);
+                        Ok(action)
+                    }
+                }
             }
         },
     )
@@ -135,7 +157,9 @@ pub async fn reconcile_service_account(
             "failed on service account finalizer".to_string(),
             Box::new(e),
         )),
-    })
+    })?;
+    let changed = outcome.load(std::sync::atomic::Ordering::Relaxed);
+    Ok((action, changed))
 }
 
 impl KanidmServiceAccount {
@@ -189,12 +213,12 @@ impl KanidmServiceAccount {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmServiceAccountStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         match self
             .internal_reconcile(kanidm_client, status, ctx.clone())
             .await
         {
-            Ok(action) => Ok(action),
+            Ok(result) => Ok(result),
             Err(e) => match e {
                 Error::KanidmClientError(_, _) => {
                     ctx.kaniop_ctx
@@ -232,28 +256,57 @@ impl KanidmServiceAccount {
         kanidm_client: Arc<KanidmClient>,
         status: KanidmServiceAccountStatus,
         ctx: Arc<Context>,
-    ) -> Result<Action> {
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let metrics = &ctx.kaniop_ctx.metrics;
 
         let mut require_status_update = false;
+        let mut changed = false;
         if is_service_account_false(TYPE_EXISTS, status.clone()) {
-            self.create(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                KANIDM_OP_CREATE,
+                KANIDM_OUTCOME_CHANGED,
+                self.create(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
         if is_service_account_false(TYPE_UPDATED, status.clone()) {
-            self.update(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                KANIDM_OP_UPDATE,
+                KANIDM_OUTCOME_CHANGED,
+                self.update(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
         if is_service_account_false(TYPE_POSIX_UPDATED, status.clone())
             || (is_service_account_false(TYPE_POSIX_INITIALIZED, status.clone())
                 && is_service_account(TYPE_POSIX_UPDATED, status.clone()))
         {
-            self.update_posix_attributes(&kanidm_client, name).await?;
+            record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                KANIDM_OP_UNIX_EXTEND,
+                KANIDM_OUTCOME_CHANGED,
+                self.update_posix_attributes(&kanidm_client, name),
+            )
+            .await?;
             require_status_update = true;
+            changed = true;
         }
 
-        self.clean_undesired_secrets(ctx.clone()).await?;
+        let secrets_cleaned = self.clean_undesired_secrets(ctx.clone()).await?;
+        if secrets_cleaned {
+            changed = true;
+        }
 
         // Check if any API token secrets need rotation
         let api_token_needs_rotation = self.check_api_tokens_rotation(&ctx);
@@ -262,9 +315,10 @@ impl KanidmServiceAccount {
             if api_token_needs_rotation {
                 info!(msg = "rotating API tokens due to rotation policy");
             }
-            self.update_api_tokens(&kanidm_client, name, &status, ctx.clone())
+            self.update_api_tokens(&kanidm_client, name, &status, ctx.clone(), metrics)
                 .await?;
             require_status_update = true;
+            changed = true;
         }
 
         // Check if credentials secret needs to be generated or rotated
@@ -289,14 +343,20 @@ impl KanidmServiceAccount {
             if should_rotate_credentials {
                 info!(msg = "rotating credentials secret due to rotation policy");
             }
-            let secret = self
-                .generate_credentials_secret(
+            let secret = record_kanidm_sdk_call(
+                metrics,
+                KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                KANIDM_OP_GENERATE_PASSWORD,
+                KANIDM_OUTCOME_CHANGED,
+                self.generate_credentials_secret(
                     &kanidm_client,
                     self.spec.credentials_rotation.as_ref(),
-                )
-                .await?;
+                ),
+            )
+            .await?;
             self.patch(&ctx, secret).await?;
             require_status_update = true;
+            changed = true;
         } else if is_service_account_missing_type(TYPE_CREDENTIALS_INITIALIZED, status.clone())
             && !self.spec.generate_credentials
         {
@@ -307,14 +367,15 @@ impl KanidmServiceAccount {
                 })
             }) {
                 self.delete(&ctx, secret.as_ref()).await?;
+                changed = true;
             }
         }
 
         if require_status_update {
             trace!(msg = "status update required, requeueing in 500ms");
-            Ok(Action::requeue(Duration::from_millis(500)))
+            Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
-            Ok(Action::requeue(idm_reconcile_interval()))
+            Ok((Action::requeue(idm_reconcile_interval()), changed))
         }
     }
 
@@ -441,6 +502,7 @@ impl KanidmServiceAccount {
         name: &str,
         status: &KanidmServiceAccountStatus,
         ctx: Arc<Context>,
+        metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
         debug!(msg = "update API tokens");
         let api_tokens = self.spec.api_tokens.clone().unwrap_or_default();
@@ -475,6 +537,7 @@ impl KanidmServiceAccount {
             None => BTreeSet::new(),
         };
 
+        let metrics_del = metrics.clone();
         let delete_futures: TryJoinAll<_> = status
             .api_tokens
             .clone()
@@ -490,18 +553,28 @@ impl KanidmServiceAccount {
                         t.token_id, t.label
                     ))
                 })?;
-                Ok(kanidm_client
-                    .idm_service_account_destroy_api_token(name, token_id)
-                    .map_err(move |e| {
+                let metrics = metrics_del.clone();
+                let label = t.label.clone();
+                Ok(async move {
+                    record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                        KANIDM_OP_DESTROY_API_TOKEN,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_service_account_destroy_api_token(name, token_id),
+                    )
+                    .await
+                    .map_err(|e| {
                         Error::kanidm_client_error_attr(
                             "delete",
-                            format!("API token '{}'", t.label),
+                            format!("API token '{}'", label),
                             name,
                             self.kanidm_namespace(),
                             self.kanidm_name(),
                             e,
                         )
-                    }))
+                    })
+                })
             })
             .collect::<Result<Vec<_>>>()?
             .into_iter()
@@ -527,6 +600,7 @@ impl KanidmServiceAccount {
             .collect::<BTreeSet<_>>();
 
         // Ensure we never try to create the same label twice.
+        let metrics_add = metrics.clone();
         let add_futures = tokens_to_create
             .iter()
             .map(|t| {
@@ -535,25 +609,34 @@ impl KanidmServiceAccount {
                 });
                 let label = t.label.clone();
                 let secret_name = t.secret_name.clone();
-                kanidm_client
-                    .idm_service_account_generate_api_token(
-                        name,
-                        &t.label,
-                        expiry,
-                        t.purpose == KanidmApiTokenPurpose::ReadWrite,
-                        false,
+                let metrics = metrics_add.clone();
+                async move {
+                    let token = record_kanidm_sdk_call(
+                        &metrics,
+                        KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                        KANIDM_OP_GENERATE_API_TOKEN,
+                        KANIDM_OUTCOME_CHANGED,
+                        kanidm_client.idm_service_account_generate_api_token(
+                            name,
+                            &label,
+                            expiry,
+                            t.purpose == KanidmApiTokenPurpose::ReadWrite,
+                            false,
+                        ),
                     )
-                    .map_ok(move |token| (token, label, secret_name))
+                    .await
                     .map_err(|e| {
                         Error::kanidm_client_error_attr(
                             "create",
-                            format!("API token '{}'", t.label),
+                            format!("API token '{}'", label),
                             name,
                             self.kanidm_namespace(),
                             self.kanidm_name(),
                             e,
                         )
-                    })
+                    })?;
+                    Ok((token, label, secret_name))
+                }
             })
             .collect::<TryJoinAll<_>>();
 
@@ -599,7 +682,7 @@ impl KanidmServiceAccount {
             .any(|secret| needs_rotation(secret.as_ref(), Some(rotation_config)))
     }
 
-    async fn clean_undesired_secrets(&self, ctx: Arc<Context>) -> Result<()> {
+    async fn clean_undesired_secrets(&self, ctx: Arc<Context>) -> Result<bool> {
         let desired_secrets = self
             .spec
             .api_tokens
@@ -623,37 +706,46 @@ impl KanidmServiceAccount {
                 })
             })
             .collect::<Vec<_>>();
+        let had_undesired = !undesired_secrets.is_empty();
         let delete_secrets_future = undesired_secrets
             .iter()
             .map(|s| self.delete(&ctx, s.as_ref()))
             .collect::<TryJoinAll<_>>();
         try_join!(delete_secrets_future)?;
-        Ok(())
+        Ok(had_undesired)
     }
 
     async fn cleanup(
         &self,
         kanidm_client: Arc<KanidmClient>,
         status: KanidmServiceAccountStatus,
-    ) -> Result<Action> {
+        ctx: Arc<Context>,
+    ) -> Result<(Action, bool)> {
         let name = &self.kanidm_entity_name();
+        let mut changed = false;
 
         if is_service_account(TYPE_EXISTS, status.clone()) {
             debug!(msg = "delete");
-            kanidm_client
-                .idm_service_account_delete(name)
-                .await
-                .map_err(|e| {
-                    Error::kanidm_client_error(
-                        "delete",
-                        name,
-                        self.kanidm_namespace(),
-                        self.kanidm_name(),
-                        e,
-                    )
-                })?;
+            record_kanidm_sdk_call(
+                &ctx.kaniop_ctx.metrics,
+                KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                KANIDM_OP_DELETE,
+                KANIDM_OUTCOME_CHANGED,
+                kanidm_client.idm_service_account_delete(name),
+            )
+            .await
+            .map_err(|e| {
+                Error::kanidm_client_error(
+                    "delete",
+                    name,
+                    self.kanidm_namespace(),
+                    self.kanidm_name(),
+                    e,
+                )
+            })?;
+            changed = true;
         }
-        Ok(Action::requeue(idm_reconcile_interval()))
+        Ok((Action::requeue(idm_reconcile_interval()), changed))
     }
 }
 

--- a/libs/service-account/src/reconcile/status.rs
+++ b/libs/service-account/src/reconcile/status.rs
@@ -12,11 +12,14 @@ use kaniop_k8s_util::error::{Error, Result};
 use kaniop_operator::controller::INSTANCE_LABEL;
 use kaniop_operator::controller::kanidm::KanidmResource;
 use kaniop_operator::crd::KanidmAccountPosixAttributes;
+use kaniop_operator::metrics::{
+    KANIDM_OP_GET, KANIDM_OP_LIST_API_TOKENS, KANIDM_OUTCOME_ERROR, KANIDM_OUTCOME_UNCHANGED,
+    KANIDM_RESOURCE_SERVICE_ACCOUNT,
+};
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use futures::TryFutureExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use k8s_openapi::jiff::Timestamp;
 use kanidm_client::KanidmClient;
@@ -55,33 +58,71 @@ impl StatusExt for KanidmServiceAccount {
         // safe unwrap: service account is namespaced scoped
         let namespace = self.get_namespace();
         let name = self.kanidm_entity_name();
-        let current_service_account = kanidm_client
-            .idm_service_account_get(&name)
-            .map_err(|e| {
-                Error::kanidm_client_error(
-                    "get",
-                    &name,
-                    self.kanidm_namespace(),
-                    self.kanidm_name(),
-                    e,
-                )
-            })
-            .await?;
-        let api_tokens: Vec<KanidmAPITokenStatus> = kanidm_client
+        let start = tokio::time::Instant::now();
+        let current_service_account =
+            kanidm_client
+                .idm_service_account_get(&name)
+                .await
+                .map_err(|e| {
+                    ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                        KANIDM_OP_GET,
+                        KANIDM_OUTCOME_ERROR,
+                        start.elapsed(),
+                    );
+                    Error::kanidm_client_error(
+                        "get",
+                        &name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    )
+                })?;
+        ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_SERVICE_ACCOUNT,
+            KANIDM_OP_GET,
+            KANIDM_OUTCOME_UNCHANGED,
+            start.elapsed(),
+        );
+        let token_start = tokio::time::Instant::now();
+        let api_tokens_raw: Vec<_> = kanidm_client
             .idm_service_account_list_api_token(&name)
             .await
             .or_else(|e| match e {
-                // if service account does not exist, return empty list of tokens
-                kanidm_client::ClientError::Http(status, _, _) if status == 404 => Ok(vec![]),
-                _ => Err(Error::kanidm_client_error_attr(
-                    "list",
-                    "API tokens",
-                    &name,
-                    self.kanidm_namespace(),
-                    self.kanidm_name(),
-                    e,
-                )),
-            })?
+                kanidm_client::ClientError::Http(status, _, _) if status == 404 => {
+                    // if service account does not exist, return empty list of tokens
+                    ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                        KANIDM_OP_LIST_API_TOKENS,
+                        KANIDM_OUTCOME_UNCHANGED,
+                        token_start.elapsed(),
+                    );
+                    Ok(vec![])
+                }
+                _ => {
+                    ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+                        KANIDM_RESOURCE_SERVICE_ACCOUNT,
+                        KANIDM_OP_LIST_API_TOKENS,
+                        KANIDM_OUTCOME_ERROR,
+                        token_start.elapsed(),
+                    );
+                    Err(Error::kanidm_client_error_attr(
+                        "list",
+                        "API tokens",
+                        &name,
+                        self.kanidm_namespace(),
+                        self.kanidm_name(),
+                        e,
+                    ))
+                }
+            })?;
+        ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
+            KANIDM_RESOURCE_SERVICE_ACCOUNT,
+            KANIDM_OP_LIST_API_TOKENS,
+            KANIDM_OUTCOME_UNCHANGED,
+            token_start.elapsed(),
+        );
+        let api_tokens: Vec<KanidmAPITokenStatus> = api_tokens_raw
             .into_iter()
             .map(|t| {
                 let secret_name = ctx

--- a/tests/e2e/test/metrics.rs
+++ b/tests/e2e/test/metrics.rs
@@ -1,0 +1,273 @@
+use super::{setup_kanidm_connection, stabilization_delay, wait_for};
+
+use kaniop_person::crd::KanidmPersonAccount;
+
+use std::process::{Child, Command, Stdio};
+
+use kube::{
+    Api,
+    api::{DeleteParams, PostParams},
+    runtime::wait::Condition,
+};
+use serde_json::json;
+
+const KANIDM_NAME: &str = "test-metrics";
+const OPERATOR_NAMESPACE: &str = "kaniop";
+const OPERATOR_SERVICE: &str = "kaniop";
+const METRICS_LOCAL_PORT: u16 = 19090;
+
+struct PortForward(Child);
+
+impl PortForward {
+    fn start(local_port: u16, namespace: &str, service: &str, target_port: u16) -> Self {
+        let child = Command::new("kubectl")
+            .args([
+                "port-forward",
+                "-n",
+                namespace,
+                &format!("svc/{service}"),
+                &format!("{local_port}:{target_port}"),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start kubectl port-forward");
+        Self(child)
+    }
+
+    fn wait_ready(&self, local_port: u16, max_attempts: u32) {
+        let url = format!("http://127.0.0.1:{local_port}/healthz");
+        for _ in 0..max_attempts {
+            if ureq::get(&url).call().is_ok() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+        panic!("port-forward not ready after {max_attempts} attempts");
+    }
+}
+
+impl Drop for PortForward {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn scrape_metrics(local_port: u16) -> String {
+    let url = format!("http://127.0.0.1:{local_port}/metrics");
+    for _ in 0..40 {
+        if let Ok(response) = ureq::get(&url).call()
+            && let Ok(metrics) = response.into_body().read_to_string()
+            && metrics.contains("kaniop_")
+        {
+            return metrics;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    panic!("metrics not available after 40 attempts");
+}
+
+fn is_person_ready() -> impl Condition<KanidmPersonAccount> + 'static {
+    move |obj: Option<&KanidmPersonAccount>| {
+        obj.and_then(|p| p.status.as_ref()).is_some_and(|s| s.ready)
+    }
+}
+
+e2e_test!(
+    #[serial_test::serial(metrics)]
+    metrics_exposed_after_person_reconcile,
+    {
+        let name = "test-metrics-person-reconcile";
+        let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+        let person_spec = json!({
+            "kanidmRef": {
+                "name": KANIDM_NAME,
+            },
+            "personAttributes": {
+                "displayname": "Metrics Test",
+                "mail": ["metrics@example.com"],
+            },
+        });
+        let person = KanidmPersonAccount::new(name, serde_json::from_value(person_spec).unwrap());
+        let person_api = Api::<KanidmPersonAccount>::namespaced(s.client.clone(), "default");
+        person_api
+            .create(&PostParams::default(), &person)
+            .await
+            .unwrap();
+
+        wait_for(person_api.clone(), name, is_person_ready()).await;
+
+        tokio::time::sleep(stabilization_delay()).await;
+
+        let pf = PortForward::start(
+            METRICS_LOCAL_PORT,
+            OPERATOR_NAMESPACE,
+            OPERATOR_SERVICE,
+            8080,
+        );
+        pf.wait_ready(METRICS_LOCAL_PORT, 20);
+
+        let metrics = scrape_metrics(METRICS_LOCAL_PORT);
+
+        assert!(
+            metrics.contains("kaniop_kanidm_sdk_calls_total"),
+            "kanidm_sdk_calls metric missing"
+        );
+        assert!(
+            metrics.contains("kaniop_kanidm_sdk_call_duration_seconds"),
+            "kanidm_sdk_call_duration metric missing"
+        );
+        assert!(
+            metrics.contains("kaniop_reconcile_outcome_total"),
+            "reconcile_outcome metric missing"
+        );
+
+        assert!(
+            metrics.contains(r#"resource="Person""#),
+            "Person resource label missing from kanidm_sdk_calls"
+        );
+        assert!(
+            metrics.contains(r#"operation="create""#),
+            "create operation label missing from kanidm_sdk_calls"
+        );
+        assert!(
+            metrics.contains(r#"outcome="changed""#),
+            "changed outcome missing from metrics"
+        );
+
+        assert!(
+            metrics.contains(r#"resource="Person""#),
+            "Person resource label missing from kanidm_sdk_calls"
+        );
+
+        let known_outcomes = ["changed", "unchanged"];
+        for outcome in known_outcomes {
+            let label = format!(r#"outcome="{outcome}""#);
+            assert!(
+                metrics.contains(&label),
+                "expected bounded outcome {outcome} not found"
+            );
+        }
+
+        assert!(
+            metrics.contains("kaniop_active_reconciles"),
+            "active_reconciles gauge missing"
+        );
+
+        person_api.delete(name, &DeleteParams::default()).await.ok();
+    }
+);
+
+e2e_test!(
+    #[serial_test::serial(metrics)]
+    metrics_kanidm_sdk_operations_bounded,
+    {
+        let name = "test-metrics-sdk-ops-bounded";
+        let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+        let person_spec = json!({
+            "kanidmRef": {
+                "name": KANIDM_NAME,
+            },
+            "personAttributes": {
+                "displayname": "Metrics SDK Ops Test",
+            },
+        });
+        let person = KanidmPersonAccount::new(name, serde_json::from_value(person_spec).unwrap());
+        let person_api = Api::<KanidmPersonAccount>::namespaced(s.client.clone(), "default");
+        person_api
+            .create(&PostParams::default(), &person)
+            .await
+            .unwrap();
+
+        wait_for(person_api.clone(), name, is_person_ready()).await;
+
+        tokio::time::sleep(stabilization_delay()).await;
+
+        let pf = PortForward::start(
+            METRICS_LOCAL_PORT,
+            OPERATOR_NAMESPACE,
+            OPERATOR_SERVICE,
+            8080,
+        );
+        pf.wait_ready(METRICS_LOCAL_PORT, 20);
+
+        let metrics = scrape_metrics(METRICS_LOCAL_PORT);
+
+        let expected_operations = ["get", "create", "update"];
+        for op in expected_operations {
+            let label = format!(r#"operation="{op}""#);
+            assert!(
+                metrics.contains(&label),
+                "expected bounded operation {op} not found in metrics"
+            );
+        }
+
+        assert!(
+            metrics.contains("kaniop_kanidm_sdk_call_duration_seconds_bucket"),
+            "histogram buckets missing for kanidm_sdk_call_duration"
+        );
+        assert!(
+            metrics.contains("kaniop_kanidm_sdk_call_duration_seconds_count"),
+            "histogram count missing for kanidm_sdk_call_duration"
+        );
+
+        person_api.delete(name, &DeleteParams::default()).await.ok();
+    }
+);
+
+e2e_test!(
+    #[serial_test::serial(metrics)]
+    metrics_reconcile_outcome_per_controller,
+    {
+        let name = "test-metrics-reconcile-outcome";
+        let s = setup_kanidm_connection(KANIDM_NAME).await;
+
+        let person_spec = json!({
+            "kanidmRef": {
+                "name": KANIDM_NAME,
+            },
+            "personAttributes": {
+                "displayname": "Reconcile Outcome Test",
+            },
+        });
+        let person = KanidmPersonAccount::new(name, serde_json::from_value(person_spec).unwrap());
+        let person_api = Api::<KanidmPersonAccount>::namespaced(s.client.clone(), "default");
+        person_api
+            .create(&PostParams::default(), &person)
+            .await
+            .unwrap();
+
+        wait_for(person_api.clone(), name, is_person_ready()).await;
+
+        tokio::time::sleep(stabilization_delay()).await;
+
+        let pf = PortForward::start(
+            METRICS_LOCAL_PORT,
+            OPERATOR_NAMESPACE,
+            OPERATOR_SERVICE,
+            8080,
+        );
+        pf.wait_ready(METRICS_LOCAL_PORT, 20);
+
+        let metrics = scrape_metrics(METRICS_LOCAL_PORT);
+
+        let known_controllers = ["kanidm", "person-account"];
+        for controller in known_controllers {
+            let label = format!(r#"controller="{controller}""#);
+            assert!(
+                metrics.contains(&label),
+                "expected controller label {controller} not found in reconcile_outcome"
+            );
+        }
+
+        assert!(
+            metrics.contains(r#"outcome="changed""#),
+            "changed outcome missing from reconcile_outcome"
+        );
+
+        person_api.delete(name, &DeleteParams::default()).await.ok();
+    }
+);

--- a/tests/e2e/test/mod.rs
+++ b/tests/e2e/test/mod.rs
@@ -44,6 +44,7 @@ mod group;
 mod kanidm;
 mod kanidm_ref;
 mod mail_sender;
+mod metrics;
 mod oauth2;
 mod oauth2_secret_key_aliases;
 mod oauth2_secret_template;


### PR DESCRIPTION
## Summary
- instrument Kanidm SDK calls, reconcile outcomes, active reconciles, backoff state, and Kubernetes transport failures
- expand the Grafana dashboard with reconciliation, SDK, API latency, transport, CPU, and memory panels
- add deterministic e2e coverage for exported metric families and enable metrics in the e2e Helm installation
- avoid cold-start metric scrape failures and export metrics every five seconds

## Validation
- `make lint`
- `helm unittest charts/kaniop` (144 tests)
- `cargo test -p kaniop-operator prometheus_exporter`
- `cargo check -p kaniop-e2e-tests --features e2e-test`
- `RUST_TEST_THREADS=16 KANIDM_DEV_YOLO=1 cargo test -p kaniop-e2e-tests --features e2e-test metrics`
- live Grafana development dashboard validation