### PR TITLE
ci: split e2e tests into 6 parallel shards per architecture

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -170,16 +170,156 @@ jobs:
       - name: Run integration tests
         run: CARGO_TARGET=${{ matrix.job.target }} make integration-test
 
-      - name: Clean debug artifacts to free disk space for e2e
-        if: matrix.job.use-cross != true
+  build-e2e-images:
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu}
+          - {os: ubuntu-24.04, target: x86_64-unknown-linux-gnu}
+    name: build e2e images (${{ matrix.job.target }})
+    runs-on: ${{ matrix.job.os }}
+    needs: determine_changes
+    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+    timeout-minutes: 45
+    env:
+      CARGO_TARGET: ${{ matrix.job.target }}
+      CARGO_RELEASE_PROFILE: release-e2e
+    steps:
+      - name: Free disk space
         run: |
-          rm -rf $(find . -type d -name debug -path '*/target-*/*' -maxdepth 3)
-          cargo cache --autoclean 2>/dev/null || true
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /usr/local/share/boost \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/lib/node_modules \
+            /opt/microsoft \
+            /opt/google \
+            /opt/azure \
+            /usr/local/share/vcpkg \
+            /usr/local/share/man \
+            /usr/local/share/doc \
+            /usr/share/swift \
+            /usr/local/julia*
+          sudo apt-get purge -y \
+            libgtk-3-0 \
+            libpango-1.0-0 \
+            libpangoft2-1.0-0 \
+            libgdk-pixbuf2.0-0 \
+            libcairo2 \
+            libthai0 \
+            libdatrie1 \
+            libgraphite2-3 \
+            2>/dev/null || true
+          sudo apt-get autoremove -y 2>/dev/null || true
+          sudo apt-get clean 2>/dev/null || true
+          mkdir -p /opt/hostedtoolcache
           df -h /
 
-      # Run e2e tests only on x86_64 target until we have aarch64 runner
+      - name: Checkout source code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.job.target }}
+
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.job.target }}
+          workspaces: ". -> target-${{ matrix.job.target }}"
+
+      - name: Build e2e images
+        run: make images
+
+      - name: Generate CRDs
+        run: make crdgen
+
+      - name: Export images
+        run: TMP_DIR="$RUNNER_TEMP" make save-images
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kaniop-images-${{ matrix.job.target }}
+          path: ${{ runner.temp }}/kaniop-images-*.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload CRDs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kaniop-crds-${{ matrix.job.target }}
+          path: charts/kaniop/crds/crds.yaml
+          retention-days: 1
+          if-no-files-found: error
+
+  e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu}
+          - {os: ubuntu-24.04, target: x86_64-unknown-linux-gnu}
+        shard: [kanidm-core, kanidm-ha, kanidm-data, oauth2, resources, misc]
+    name: e2e ${{ matrix.shard }} (${{ matrix.job.target }})
+    runs-on: ${{ matrix.job.os }}
+    needs: build-e2e-images
+    timeout-minutes: 45
+    env:
+      CARGO_TARGET: ${{ matrix.job.target }}
+      SKIP_IMAGE_BUILD: "1"
+      SKIP_CRDGEN: "1"
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /usr/local/share/boost \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/lib/node_modules \
+            /opt/microsoft \
+            /opt/google \
+            /opt/azure \
+            /usr/local/share/vcpkg \
+            /usr/local/share/man \
+            /usr/local/share/doc \
+            /usr/share/swift \
+            /usr/local/julia*
+          sudo apt-get purge -y \
+            libgtk-3-0 \
+            libpango-1.0-0 \
+            libpangoft2-1.0-0 \
+            libgdk-pixbuf2.0-0 \
+            libcairo2 \
+            libthai0 \
+            libdatrie1 \
+            libgraphite2-3 \
+            2>/dev/null || true
+          sudo apt-get autoremove -y 2>/dev/null || true
+          sudo apt-get clean 2>/dev/null || true
+          mkdir -p /opt/hostedtoolcache
+          df -h /
+
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
       - name: Install kind
-        if: matrix.job.use-cross != true
         uses: helm/kind-action@v1.14.0
         with:
           # renovate: datasource=github-releases depName=kubernetes-sigs/kind
@@ -187,25 +327,56 @@ jobs:
           install_only: true
 
       - name: Install helm
-        if: matrix.job.use-cross != true
         run: |
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Run e2e tests
-        if: matrix.job.use-cross != true
+      - name: Install Rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.job.target }}
+
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.job.target }}
+          workspaces: ". -> target-${{ matrix.job.target }}"
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kaniop-images-${{ matrix.job.target }}
+          path: /tmp/kaniop-artifacts
+
+      - name: Load e2e images
+        run: TMP_DIR=/tmp/kaniop-artifacts make load-images
+
+      - name: Download CRDs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kaniop-crds-${{ matrix.job.target }}
+          path: charts/kaniop/crds
+
+      - name: Check e2e shard coverage
+        if: matrix.shard == 'misc' && matrix.job.target == 'x86_64-unknown-linux-gnu'
+        run: make check-e2e-shards
+
+      - name: Run e2e shard
         env:
           E2E_TEST_THREADS: "8"
           E2E_WAIT_TIMEOUT_SECONDS: "300"
           E2E_EVENT_TIMEOUT_SECONDS: "30"
-        run: |
-          CARGO_TARGET=${{ matrix.job.target }} E2E_LOGGING_LEVEL=info make e2e-test
+          E2E_LOGGING_LEVEL: info
+        run: make e2e-test-shard SHARD=${{ matrix.shard }}
 
   rerun-failed-jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - e2e
     # Only attempt an automatic rerun once per workflow run. Prevents an infinite
     # loop where a rerun triggers the rerun job again on subsequent attempts.
     # Disabled for now, but kept in the workflow so it can be re-enabled if CI
@@ -223,6 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - e2e
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout source code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,17 @@ make delete-kind
 RUST_TEST_THREADS=16 cargo test -p kaniop-e2e-tests --features e2e-test <test_name>
 ```
 
+### Run One e2e Shard Locally
+```bash
+# After `make e2e` has created the cluster:
+make e2e-test-shard SHARD=kanidm-core
+
+# Verify shard filters still cover every test (run after adding/removing tests):
+make check-e2e-shards
+```
+
+Valid shards: `kanidm-core`, `kanidm-ha`, `kanidm-data`, `oauth2`, `resources`, `misc`. Shard filters are defined in the Makefile (`E2E_SHARD_FILTER_*` / `E2E_SHARD_SKIP_*`) and consumed by the CI `e2e` job matrix in `.github/workflows/rust.yml`.
+
 ### Build and Push Images
 ```bash
 # Build single-arch local images

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,21 @@ DOCKER_BUILD_PARAMS = --build-arg "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)" \
 E2E_LOGGING_LEVEL ?= 'info\,kaniop=debug\,kaniop_webhook=debug'
 E2E_TEST_THREADS ?= 16
 # set KANIDM_DEV_YOLO=1 to avoid Kanidm client exiting silently when dev derived profile is used
+E2E_TEST_FILTERS ?=
+E2E_TEST_SKIPS ?= test::crd_migration
+E2E_SHARDS := kanidm-core kanidm-ha kanidm-data oauth2 resources misc
+E2E_SHARD_FILTER_kanidm-core := test::kanidm
+E2E_SHARD_SKIP_kanidm-core := test::kanidm::replication test::kanidm::restore test::kanidm::backup test::kanidm::upgrade test::kanidm_ref
+E2E_SHARD_FILTER_kanidm-ha := test::kanidm::replication test::kanidm::upgrade
+E2E_SHARD_SKIP_kanidm-ha :=
+E2E_SHARD_FILTER_kanidm-data := test::kanidm::restore test::kanidm::backup
+E2E_SHARD_SKIP_kanidm-data :=
+E2E_SHARD_FILTER_oauth2 := test::oauth2 test::oauth2_secret_template test::oauth2_secret_key_aliases
+E2E_SHARD_SKIP_oauth2 :=
+E2E_SHARD_FILTER_resources := test::person test::group test::service_account
+E2E_SHARD_SKIP_resources :=
+E2E_SHARD_FILTER_misc := test::mail_sender test::metrics test::kanidm_ref
+E2E_SHARD_SKIP_misc :=
 HELM_PARAMS = --namespace $(KANIOP_NAMESPACE) \
 		--set-string image.tag=$(VERSION) \
 		--set metrics.enabled=true \
@@ -50,6 +65,10 @@ help:	## Show this help menu.
 	@echo ""
 
 .PHONY: crdgen
+ifeq ($(SKIP_CRDGEN),1)
+crdgen:
+	@echo "SKIP_CRDGEN=1: using committed charts/kaniop/crds/crds.yaml"
+else
 crdgen: CRD_DIR := charts/kaniop/crds
 crdgen: CRD_GEN_BIN := $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/$(CARGO_RELEASE_PROFILE)/crdgen
 crdgen: release
@@ -58,6 +77,7 @@ crdgen: ## Generate CRDs
 		mkdir -p $(CRD_DIR); \
 	fi
 	$(CRD_GEN_BIN) > $(CRD_DIR)/crds.yaml
+endif
 
 .PHONY: lint
 lint:	## lint code
@@ -346,7 +366,7 @@ e2e-test: e2e
 e2e-test: export KANIDM_DEV_YOLO=1 # avoid Kanidm client exiting silently
 e2e-test: export RUST_MIN_STACK=8388608 # increase stack size for async tests (8MB)
 e2e-test: export DATA_MOVER_IMAGE=$(DATA_MOVER_DOCKER_IMAGE)
-e2e-test:	## run end to end tests (retries failed tests once)
+e2e-test:	## run end to end tests (retries failed tests once; accepts E2E_TEST_FILTERS/E2E_TEST_SKIPS)
 	@if [ "$$(kubectl config current-context)" != "$(KUBE_CONTEXT)" ]; then \
 		echo "ERROR: switch to kind context: kubectl config use-context $(KUBE_CONTEXT)"; \
 		exit 1; \
@@ -357,7 +377,7 @@ e2e-test:	## run end to end tests (retries failed tests once)
 	trap "rm -f $$E2E_TEST_OUTPUT" EXIT; \
 	RUST_TEST_THREADS=$(E2E_TEST_THREADS) cargo test $(CARGO_BUILD_PARAMS) \
 		-p kaniop-e2e-tests --features e2e-test --no-fail-fast \
-		-- --skip test::crd_migration \
+		-- $(E2E_TEST_FILTERS) $(foreach s,$(E2E_TEST_SKIPS),--skip $s) \
 		2>&1 | tee $$E2E_TEST_OUTPUT; \
 	EXIT_CODE=$${PIPESTATUS[0]}; \
 	FAILED_TESTS=$$(awk '/^failures:/{p=1; next} /^test result:/{p=0} p' $$E2E_TEST_OUTPUT | \
@@ -391,6 +411,47 @@ e2e-test:	## run end to end tests (retries failed tests once)
 	fi; \
 	echo ""; \
 	echo "=== All retries passed ==="
+
+.PHONY: e2e-test-shard
+e2e-test-shard: SHARD ?=
+e2e-test-shard: ## run end to end tests for a single shard (SHARD=kanidm-core|kanidm-ha|kanidm-data|oauth2|resources|misc)
+	@if [ -z "$(SHARD)" ]; then \
+		echo "usage: make e2e-test-shard SHARD=<name> (valid: $(E2E_SHARDS))"; \
+		exit 2; \
+	fi
+	@if [ -z "$(E2E_SHARD_FILTER_$(SHARD))" ]; then \
+		echo "ERROR: unknown shard '$(SHARD)' (valid: $(E2E_SHARDS))"; \
+		exit 2; \
+	fi
+	@$(MAKE) e2e-test \
+		E2E_TEST_FILTERS="$(E2E_SHARD_FILTER_$(SHARD))" \
+		E2E_TEST_SKIPS="$(E2E_SHARD_SKIP_$(SHARD)) test::crd_migration"
+
+.PHONY: check-e2e-shards
+check-e2e-shards: ## verify shard filters partition the e2e test suite without gaps or overlap
+	@set -e; \
+	TMP_CHECK=$$(mktemp -d); \
+	trap "rm -rf $$TMP_CHECK" EXIT; \
+	LIST_CMD="cargo test $(CARGO_BUILD_PARAMS) -p kaniop-e2e-tests --features e2e-test --"; \
+	TOTAL=$$($$LIST_CMD --skip test::crd_migration --list 2>/dev/null | grep ': test$$' | sed 's/: test$$//' | sort -u | tee $$TMP_CHECK/all.txt | wc -l); \
+	> $$TMP_CHECK/sharded.txt; \
+	COUNTED=0; \
+	$(foreach shard,$(E2E_SHARDS), \
+		n=$$($$LIST_CMD $(E2E_SHARD_FILTER_$(shard)) $(foreach s,$(E2E_SHARD_SKIP_$(shard)) test::crd_migration,--skip $s) --list 2>/dev/null | grep ': test$$' | sed 's/: test$$//' | sort -u | tee -a $$TMP_CHECK/sharded.txt | wc -l); \
+		echo "shard $(shard): $$n tests"; \
+		COUNTED=$$((COUNTED + n)); \
+	) \
+	if ! diff -u $$TMP_CHECK/all.txt <(sort -u $$TMP_CHECK/sharded.txt); then \
+		echo "ERROR: shard coverage mismatch (missing or unknown tests)"; \
+		exit 1; \
+	fi; \
+	DUPS=$$(sort $$TMP_CHECK/sharded.txt | uniq -d); \
+	if [ -n "$$DUPS" ]; then \
+		echo "ERROR: tests assigned to multiple shards:"; \
+		echo "$$DUPS"; \
+		exit 1; \
+	fi; \
+	echo "Shards OK: $$TOTAL tests across $(words $(E2E_SHARDS)) shards"
 
 .PHONY: clean-e2e
 clean-e2e:	## clean end to end environment: delete all created resources in kind


### PR DESCRIPTION
## Summary

Splits the single ~50 min e2e run (unit tests → integration tests → image build → Kind setup → all 173 tests, serialized in one job) into:

```
build-e2e-images (2 archs, parallel)  ──►  e2e (2 archs × 6 shards = 12 parallel jobs)
```

- **`build-e2e-images`**: builds operator images once per arch (`release-e2e` profile), exports them as artifacts (same pattern as `crd-migration-e2e.yml`).
- **`e2e`**: each shard downloads the pre-built images, gets its own isolated Kind cluster, and runs only its filtered subset via the existing `cargo test` harness (multiple name filters + `--skip`).

## Shards (verified partition: 173 tests, no gaps/overlaps)

| Shard | Tests | Contents |
|---|---|---|
| `kanidm-core` | 24 | `test::kanidm` core lifecycle minus submodules |
| `kanidm-ha` | 15 | replication + upgrade (slow, serialized lane) |
| `kanidm-data` | 27 | restore + backup (destructive: DB/PVC/operator pods) |
| `oauth2` | 56 | oauth2 + secret templates + key aliases |
| `resources` | 39 | person + group + service_account |
| `misc` | 12 | mail_sender + metrics + kanidm_ref |

## Why any partition is safe

Tests are independent: every test creates its own CRs with unique names; shared Kanidm instances are get-or-create fixtures. The `serial()` groups only guard intra-cluster interference (Kind CPU/PVC exhaustion, shared MinIO bucket, operator-pod deletion, global metrics). Per-shard isolated clusters strictly reduce interference versus today's single-cluster run.

## Changes

- **Makefile**: shard filters as single source of truth (`E2E_SHARD_FILTER_*/E2E_SHARD_SKIP_*`), new targets:
  - `make e2e-test-shard SHARD=<name>` — run one shard locally
  - `make check-e2e-shards` — fails if shards don't partition the suite (runs in the `misc` shard job to catch drift when tests are added)
  - `SKIP_CRDGEN=1` guard to reuse committed CRDs in shard jobs
- **rust.yml**: `build` job keeps unit+integration tests only; new `build-e2e-images` and `e2e` jobs; `publish`/`rerun-failed-jobs` now need `e2e` too.
- **AGENTS.md**: documents the new shard targets.

## Expected impact

Wall clock drops from ~50 min to roughly **30–35 min** (≈12 min image build + ~20 min slowest shard). Verified locally with `make check-e2e-shards` and dry-run invocations; first real CI run will confirm per-shard timings for future rebalancing.