### PR TITLE
ci: add explicit skip condition for e2e job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -275,6 +275,7 @@ jobs:
     name: e2e ${{ matrix.shard }} (${{ matrix.job.target }})
     runs-on: ${{ matrix.job.os }}
     needs: build-e2e-images
+    if: ${{ needs.build-e2e-images.result == 'success' }}
     timeout-minutes: 45
     env:
       CARGO_TARGET: ${{ matrix.job.target }}


### PR DESCRIPTION
Add explicit `if` condition to the `e2e` job to skip when `build-e2e-images` is skipped (e.g., docs-only PRs).

This makes the skip behavior explicit rather than relying on implicit propagation through the `needs` dependency, which is clearer for ruleset configuration and avoids potential confusion about whether skipped required checks will block merges.

GitHub treats skipped required checks as passed, so this change doesn't affect behavior -- it just makes the intent explicit.