### PR TITLE
chore: remove stale v0.10.0 legacy replica cert fallback

### DIFF
--- a/libs/operator/src/kanidm/reconcile/status.rs
+++ b/libs/operator/src/kanidm/reconcile/status.rs
@@ -129,24 +129,20 @@ impl StatusExt for Kanidm {
                     async move {
                         let replica_secret = secret_store.get(&secret_ref);
                         if let Some(secret) = replica_secret.as_deref() {
-                            // TODO(v0.10.0): remove this legacy fallback once pre-0.7.2
-                            // replica certificate secrets without SECRET_TYPE_LABEL are unsupported.
-                            let is_missing_replica_cert_label = secret
+                            let has_replica_cert_label = secret
                                 .metadata
                                 .labels
                                 .as_ref()
-                                .is_none_or(|labels| {
-                                    labels.get(SECRET_TYPE_LABEL) != Some(&replica_cert_label)
+                                .is_some_and(|labels| {
+                                    labels.get(SECRET_TYPE_LABEL) == Some(&replica_cert_label)
                                 });
-                            if is_missing_replica_cert_label {
+                            if !has_replica_cert_label {
                                 warn!(
-                                    msg = "legacy replica certificate secret is missing the current replica-cert label; this compatibility path is deprecated and will be removed in v0.10.0",
+                                    msg = "replica certificate secret is missing the required replica-cert label and will be ignored",
                                     namespace,
                                     name = secret_name,
                                 );
-                            }
-
-                            if let Err(e) = ctx.insert_repl_cert_exp(secret).await {
+                            } else if let Err(e) = ctx.insert_repl_cert_exp(secret).await {
                                 warn!(
                                     msg = "failed to parse replica certificate secret, automatic certificate renewal may be affected",
                                     namespace,


### PR DESCRIPTION
## Summary

Remove the compatibility path for pre-0.7.2 replica certificate secrets that lacked the `SECRET_TYPE_LABEL`. The TODO was marked for removal in v0.10.0 but the current version is 0.12.1.

## Changes

- Secrets without the required `SECRET_TYPE_LABEL` are now rejected with a warning instead of being accepted with a deprecation notice
- Removes the stale `TODO(v0.10.0)` comment

## Context

This legacy fallback was introduced to support replica certificate secrets created before v0.7.2 that did not have the proper label. After 5 minor versions, this compatibility path is no longer needed.

## Checklist

- [x] `make lint` passes
- [x] Pre-commit hooks pass