### PR TITLE
feat: add insecure flag for HTTP S3 endpoints

### DIFF
--- a/cmd/data-mover/src/commands/delete_plan.rs
+++ b/cmd/data-mover/src/commands/delete_plan.rs
@@ -46,6 +46,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         region: op.region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
+        insecure: op.insecure,
     };
 
     let bucket = create_bucket(&s3_config).await.map_err(|e| {

--- a/cmd/data-mover/src/commands/discover.rs
+++ b/cmd/data-mover/src/commands/discover.rs
@@ -49,6 +49,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         region: op.region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
+        insecure: op.insecure,
     };
 
     let bucket = create_bucket(&s3_config).await.map_err(|e| {

--- a/cmd/data-mover/src/commands/download.rs
+++ b/cmd/data-mover/src/commands/download.rs
@@ -38,6 +38,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         region: op.region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
+        insecure: op.insecure,
     };
 
     let bucket = create_bucket(&s3_config).await.map_err(|e| {

--- a/cmd/data-mover/src/commands/probe.rs
+++ b/cmd/data-mover/src/commands/probe.rs
@@ -34,6 +34,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         region: op.region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
+        insecure: op.insecure,
     };
 
     let bucket = create_bucket(&s3_config).await.map_err(|e| {

--- a/cmd/data-mover/src/commands/upload.rs
+++ b/cmd/data-mover/src/commands/upload.rs
@@ -88,6 +88,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         region: op.region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
+        insecure: op.insecure,
     };
 
     let bucket = create_bucket(&s3_config).await.map_err(|e| {
@@ -456,6 +457,7 @@ mod tests {
             region: "us-east-1".to_string(),
             force_path_style: false,
             ca_bundle_path: None,
+            insecure: false,
             backup_id: "019c7c76-f423-7a12-8f41-2bea7588a303".to_string(),
             namespace_uid: "ns-uid".to_string(),
             kanidm_uid: "k-uid".to_string(),

--- a/cmd/data-mover/src/s3.rs
+++ b/cmd/data-mover/src/s3.rs
@@ -27,10 +27,11 @@ pub struct S3Config {
     pub region: String,
     pub force_path_style: bool,
     pub ca_bundle_path: Option<String>,
+    pub insecure: bool,
 }
 
 pub async fn create_bucket(config: &S3Config) -> Result<Box<Bucket>, S3Error> {
-    validate_endpoint(&config.endpoint)?;
+    validate_endpoint(&config.endpoint, config.insecure)?;
 
     let region = Region::Custom {
         region: config.region.clone(),
@@ -136,7 +137,7 @@ pub async fn probe_conditional_put_capability(bucket: &Bucket, probe_key: &str) 
     conditional_works
 }
 
-fn validate_endpoint(endpoint: &str) -> Result<(), S3Error> {
+fn validate_endpoint(endpoint: &str, insecure: bool) -> Result<(), S3Error> {
     if endpoint.is_empty() {
         return Err(S3Error::Operation("endpoint is empty".to_string()));
     }
@@ -145,7 +146,7 @@ fn validate_endpoint(endpoint: &str) -> Result<(), S3Error> {
             "endpoint must start with https:// or http://: {endpoint}"
         )));
     }
-    if endpoint.starts_with("http://") && !is_loopback_endpoint(endpoint) {
+    if endpoint.starts_with("http://") && !insecure && !is_loopback_endpoint(endpoint) {
         return Err(S3Error::InsecureEndpoint(format!(
             "non-loopback endpoints must use HTTPS: {endpoint}"
         )));
@@ -194,24 +195,24 @@ mod tests {
 
     #[test]
     fn https_endpoint_is_accepted() {
-        assert!(validate_endpoint("https://s3.example.com").is_ok());
+        assert!(validate_endpoint("https://s3.example.com", false).is_ok());
     }
 
     #[test]
     fn http_loopback_is_accepted() {
-        assert!(validate_endpoint("http://localhost:9000").is_ok());
-        assert!(validate_endpoint("http://127.0.0.1:9000").is_ok());
-        assert!(validate_endpoint("http://[::1]:9000").is_ok());
+        assert!(validate_endpoint("http://localhost:9000", false).is_ok());
+        assert!(validate_endpoint("http://127.0.0.1:9000", false).is_ok());
+        assert!(validate_endpoint("http://[::1]:9000", false).is_ok());
     }
 
     #[test]
     fn http_loopback_subdomain_is_rejected() {
         assert!(matches!(
-            validate_endpoint("http://localhost.evil.com:9000"),
+            validate_endpoint("http://localhost.evil.com:9000", false),
             Err(S3Error::InsecureEndpoint(_))
         ));
         assert!(matches!(
-            validate_endpoint("http://127.0.0.1.evil.com:9000"),
+            validate_endpoint("http://127.0.0.1.evil.com:9000", false),
             Err(S3Error::InsecureEndpoint(_))
         ));
     }
@@ -219,19 +220,24 @@ mod tests {
     #[test]
     fn http_non_loopback_is_rejected() {
         assert!(matches!(
-            validate_endpoint("http://minio.internal:9000"),
+            validate_endpoint("http://minio.internal:9000", false),
             Err(S3Error::InsecureEndpoint(_))
         ));
     }
 
     #[test]
+    fn http_non_loopback_accepted_when_insecure() {
+        assert!(validate_endpoint("http://minio.internal:9000", true).is_ok());
+    }
+
+    #[test]
     fn empty_endpoint_is_rejected() {
-        assert!(validate_endpoint("").is_err());
+        assert!(validate_endpoint("", false).is_err());
     }
 
     #[test]
     fn no_scheme_is_rejected() {
-        assert!(validate_endpoint("s3.example.com").is_err());
+        assert!(validate_endpoint("s3.example.com", false).is_err());
     }
 
     #[test]

--- a/cmd/examples/src/backup.rs
+++ b/cmd/examples/src/backup.rs
@@ -21,6 +21,7 @@ pub fn repository_example() -> KanidmBackupRepository {
                 region: Some("eu-west-1".to_string()),
                 endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
                 force_path_style: false,
+                insecure: false,
                 ca_bundle_ref: None,
             },
             authentication: RepositoryAuthentication {

--- a/cmd/webhook/src/backup_validator.rs
+++ b/cmd/webhook/src/backup_validator.rs
@@ -378,6 +378,7 @@ mod tests {
                     endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
                     force_path_style: false,
                     ca_bundle_ref: None,
+                    insecure: false,
                 },
                 authentication: RepositoryAuthentication {
                     writer: AuthMethod {

--- a/cmd/webhook/src/handlers.rs
+++ b/cmd/webhook/src/handlers.rs
@@ -197,7 +197,7 @@ pub async fn validate_backup_repository(
     }
 
     if let Some(endpoint) = &object.spec.s3.endpoint {
-        if !endpoint.starts_with("https://") {
+        if !endpoint.starts_with("https://") && !object.spec.s3.insecure {
             return Json(review.response(AdmissionResponse::deny(
                 uid,
                 "Repository endpoint must use HTTPS",

--- a/examples/backup-repository.yaml
+++ b/examples/backup-repository.yaml
@@ -11,6 +11,7 @@ spec:
     # region: eu-west-1
     # endpoint: https://s3.eu-west-1.amazonaws.com
     # forcePathStyle: false
+    # insecure: false
 
   authentication:
     writer:

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -50,6 +50,15 @@ pub struct KanidmBackupRepositorySpec {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(extend("x-kubernetes-validations" = [
+        {
+            "message": "endpoint must use HTTPS unless insecure is enabled",
+            "rule": "!has(self.endpoint) || self.endpoint.startsWith('https://') || self.insecure"
+        }
+    ]))
+)]
 #[serde(rename_all = "camelCase")]
 pub struct S3Config {
     #[schemars(extend("x-kubernetes-validations" = [{"message": "bucket must not be empty", "rule": "self.size() > 0"}]))]
@@ -58,13 +67,14 @@ pub struct S3Config {
     pub prefix: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
-    #[schemars(extend("x-kubernetes-validations" = [{"message": "endpoint must use HTTPS", "rule": "self.startsWith('https://')"}]))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
     #[serde(default)]
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_ref: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -446,6 +456,7 @@ mod tests {
                 endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
                 force_path_style: false,
                 ca_bundle_ref: None,
+                insecure: false,
             },
             authentication: RepositoryAuthentication {
                 writer: AuthMethod {

--- a/libs/backup-core/src/operation.rs
+++ b/libs/backup-core/src/operation.rs
@@ -56,6 +56,8 @@ pub struct UploadOperation {
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_path: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
     pub backup_id: String,
     pub namespace_uid: String,
     pub kanidm_uid: String,
@@ -89,6 +91,8 @@ pub struct DownloadOperation {
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_path: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
     pub expected_backup_id: String,
     pub expected_kanidm_uid: String,
     pub expected_domain: String,
@@ -111,6 +115,8 @@ pub struct DiscoverOperation {
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_path: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
     pub namespace_uid: String,
     pub kanidm_uid: String,
     pub result_path: String,
@@ -131,6 +137,8 @@ pub struct ProbeOperation {
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_path: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
     pub result_path: String,
 }
 
@@ -146,6 +154,8 @@ pub struct DeletePlanOperation {
     pub force_path_style: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_path: Option<String>,
+    #[serde(default)]
+    pub insecure: bool,
     pub result_path: String,
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
@@ -286,6 +296,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 backup_id: "019c7c76-f423-7a12-8f41-2bea7588a303".to_string(),
                 namespace_uid: "ns-uid".to_string(),
                 kanidm_uid: "k-uid".to_string(),
@@ -363,6 +374,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 expected_backup_id: "019c7c76-f423-7a12-8f41-2bea7588a303".to_string(),
                 expected_kanidm_uid: "k-uid".to_string(),
                 expected_domain: "idm.example.com".to_string(),
@@ -387,6 +399,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 namespace_uid: "ns-uid".to_string(),
                 kanidm_uid: "k-uid".to_string(),
                 result_path: "/result/result.json".to_string(),
@@ -409,6 +422,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 namespace_uid: String::new(),
                 kanidm_uid: "k-uid".to_string(),
                 result_path: "/result/result.json".to_string(),
@@ -434,6 +448,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 result_path: "/result/result.json".to_string(),
             }),
         };
@@ -453,6 +468,7 @@ mod tests {
                 region: "us-east-1".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 result_path: "/result/result.json".to_string(),
                 max_retries: 3,
             }),
@@ -473,6 +489,7 @@ mod tests {
                 region: "r".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 result_path: "/r".to_string(),
                 max_retries: 3,
             }),
@@ -495,6 +512,7 @@ mod tests {
                 region: "r".to_string(),
                 force_path_style: false,
                 ca_bundle_path: None,
+                insecure: false,
                 namespace_uid: "".to_string(),
                 kanidm_uid: "k".to_string(),
                 result_path: "/r".to_string(),

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -104,6 +104,7 @@ pub fn build_validation_job(
         "endpoint": endpoint,
         "region": region,
         "forcePathStyle": spec.s3.force_path_style,
+        "insecure": spec.s3.insecure,
         "caBundlePath": ca_bundle_path,
         "expectedBackupId": backup.spec.backup_id,
         "expectedKanidmUid": backup.spec.kanidm_ref.uid,
@@ -244,6 +245,7 @@ pub fn build_deletion_job(
         "endpoint": endpoint,
         "region": region,
         "forcePathStyle": spec.s3.force_path_style,
+        "insecure": spec.s3.insecure,
         "caBundlePath": ca_bundle_path,
         "resultPath": RESULT_PATH,
     });
@@ -1001,6 +1003,7 @@ mod tests {
                     region: Some("us-east-1".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: crate::crd::RepositoryAuthentication {
@@ -1066,6 +1069,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: crate::crd::RepositoryAuthentication {
@@ -1130,6 +1134,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: crate::crd::RepositoryAuthentication {
@@ -1279,6 +1284,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: crate::crd::RepositoryAuthentication {

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -627,6 +627,7 @@ fn build_discover_job(
         "endpoint": endpoint,
         "region": region,
         "forcePathStyle": spec.s3.force_path_style,
+        "insecure": spec.s3.insecure,
         "caBundlePath": ca_bundle_path,
         "namespaceUid": namespace_uid,
         "kanidmUid": kanidm_uid,
@@ -1014,6 +1015,7 @@ mod tests {
                     region: Some("us-east-1".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: RepositoryAuthentication {

--- a/libs/backup/src/controller/repository.rs
+++ b/libs/backup/src/controller/repository.rs
@@ -98,6 +98,7 @@ fn build_probe_job(repository: &KanidmBackupRepository, namespace: &str) -> Job 
         "endpoint": endpoint,
         "region": region,
         "forcePathStyle": spec.s3.force_path_style,
+        "insecure": spec.s3.insecure,
         "caBundlePath": ca_bundle_path,
         "resultPath": RESULT_PATH,
     });
@@ -266,7 +267,7 @@ async fn reconcile_repository(
     }
 
     if let Some(endpoint) = &spec.s3.endpoint {
-        if !endpoint.starts_with("https://") {
+        if !endpoint.starts_with("https://") && !spec.s3.insecure {
             return Err(Error::MissingData("endpoint must use HTTPS".to_string()));
         }
     }
@@ -587,6 +588,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: RepositoryAuthentication {
@@ -651,6 +653,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: Some("my-ca-cm".to_string()),
                 },
                 authentication: RepositoryAuthentication {
@@ -717,6 +720,7 @@ mod tests {
                     region: Some("r".to_string()),
                     endpoint: Some("https://s3.example.com".to_string()),
                     force_path_style: false,
+                    insecure: false,
                     ca_bundle_ref: None,
                 },
                 authentication: RepositoryAuthentication {

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -2121,6 +2121,7 @@ async fn ensure_safety_backup_job(
         endpoint,
         region,
         repo.spec.s3.force_path_style,
+        repo.spec.s3.insecure,
         repo.spec
             .s3
             .ca_bundle_ref
@@ -2387,6 +2388,7 @@ async fn ensure_source_prep_job(
         endpoint,
         region,
         repo.spec.s3.force_path_style,
+        repo.spec.s3.insecure,
         repo.spec
             .s3
             .ca_bundle_ref
@@ -2553,6 +2555,7 @@ fn build_safety_upload_operation_doc(
     endpoint: &str,
     region: &str,
     force_path_style: bool,
+    insecure: bool,
     ca_bundle_path: Option<&str>,
 ) -> Result<String> {
     let op = UploadOperation {
@@ -2562,6 +2565,7 @@ fn build_safety_upload_operation_doc(
         endpoint: endpoint.to_string(),
         region: region.to_string(),
         force_path_style,
+        insecure,
         ca_bundle_path: ca_bundle_path.map(str::to_string),
         backup_id: backup_id.to_string(),
         namespace_uid: restore.namespace().unwrap_or_default(),
@@ -2707,6 +2711,7 @@ fn build_download_operation_doc(
     endpoint: &str,
     region: &str,
     force_path_style: bool,
+    insecure: bool,
     ca_bundle_path: Option<&str>,
 ) -> String {
     serde_json::json!({
@@ -2719,6 +2724,7 @@ fn build_download_operation_doc(
         "endpoint": endpoint,
         "region": region,
         "forcePathStyle": force_path_style,
+        "insecure": insecure,
         "caBundlePath": ca_bundle_path,
         "expectedBackupId": expected_backup_id,
         "expectedKanidmUid": restore.spec.target_ref.uid,
@@ -3300,6 +3306,7 @@ mod tests {
             "https://s3.example.com",
             "us-east-1",
             false,
+            false,
             None,
         )
         .unwrap();
@@ -3341,6 +3348,7 @@ mod tests {
             "https://real-endpoint.com",
             "eu-west-1",
             true,
+            false,
             None,
         );
         let parsed: serde_json::Value = serde_json::from_str(&doc_str).unwrap();
@@ -3853,6 +3861,7 @@ mod tests {
             "https://s3.example.com",
             "us-east-1",
             false,
+            false,
             Some(&ca_path),
         )
         .unwrap();
@@ -3880,6 +3889,7 @@ mod tests {
             "prod",
             "https://s3.example.com",
             "us-east-1",
+            false,
             false,
             None,
         )
@@ -3909,6 +3919,7 @@ mod tests {
             "https://real-endpoint.com",
             "eu-west-1",
             true,
+            false,
             Some(&ca_path),
         );
         let parsed: serde_json::Value = serde_json::from_str(&doc_str).unwrap();
@@ -3935,6 +3946,7 @@ mod tests {
             "https://real-endpoint.com",
             "eu-west-1",
             true,
+            false,
             None,
         );
         let parsed: serde_json::Value = serde_json::from_str(&doc_str).unwrap();

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -44,6 +44,7 @@ fn minio_s3_config(prefix: &str) -> S3Config {
         region: Some(MINIO_REGION.to_string()),
         endpoint: Some(MINIO_ENDPOINT.to_string()),
         force_path_style: true,
+        insecure: false,
         ca_bundle_ref: Some(MINIO_CA_CM.to_string()),
     }
 }
@@ -1190,6 +1191,7 @@ e2e_test!(
                     region: Some(MINIO_REGION.to_string()),
                     endpoint: Some(MINIO_ENDPOINT.to_string()),
                     force_path_style: true,
+                    insecure: false,
                     ca_bundle_ref: Some(wrong_ca_cm.to_string()),
                 },
                 authentication: minio_auth(MINIO_CREDS_SECRET),


### PR DESCRIPTION
## Summary

Add `insecure: bool` field to `S3Config` to allow HTTP endpoints for S3-compatible storage (e.g., local MinIO, internal networks).

## Changes

### CRD (`libs/backup-core/src/crd.rs`)
- Add `insecure: bool` field to `S3Config` (default: `false`)
- Update CEL validation: endpoint must use HTTPS **unless** `insecure` is true

### Operation types (`libs/backup-core/src/operation.rs`)
- Add `insecure: bool` field to all S3 operations: Upload, Download, Probe, Discover, DeletePlan

### Controllers
- **Repository controller**: Pass `insecure` flag to probe job; relax HTTPS validation when `insecure` is true
- **Backup controller**: Pass `insecure` flag to validation and deletion jobs
- **Discovery controller**: Pass `insecure` flag to discover jobs
- **Restore controller**: Pass `insecure` flag to safety upload and source prep jobs

### Webhook
- Update endpoint HTTPS validation to allow HTTP when `insecure` is true

### Data-mover
- Add `insecure` field to local `S3Config` struct
- Update `validate_endpoint` to accept HTTP endpoints when `insecure` is true
- Pass `insecure` flag through all commands (probe, upload, download, discover, delete-plan)

## Usage

```yaml
apiVersion: kaniop.rs/v1alpha1
kind: KanidmBackupRepository
metadata:
  name: local-minio
  namespace: default
spec:
  s3:
    bucket: kaniop-backups
    prefix: prod
    endpoint: http://minio.local:9000
    insecure: true
    forcePathStyle: true
  authentication:
    writer:
      secretRef:
        name: backup-writer
    reader:
      secretRef:
        name: backup-reader
    deleter:
      secretRef:
        name: backup-deleter
```

## Verification

- `make lint` passes (zero clippy warnings)
- `make test` passes (594 tests)
- `make crdgen` regenerates CRDs with insecure field
- `make examples` regenerates example YAMLs