### PR TITLE
fix(logging): enforce canonical structured logging

### DIFF
--- a/.ci/check-logging.py
+++ b/.ci/check-logging.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Enforce Kaniop's canonical tracing message convention."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MACRO_RE = re.compile(
+    r"(?<![\w:])(?:(?:tracing)::)?(?:trace|debug|info|warn|error)!\s*\("
+)
+FORBIDDEN_FIELD_RE = re.compile(r"\b(?:msg|message)\s*=")
+
+
+def macro_body(text: str, opening_paren: int) -> tuple[str, int]:
+    """Return a tracing macro body and the offset after its closing parenthesis."""
+    depth = 1
+    i = opening_paren + 1
+    start = i
+    state = "code"
+    block_comment_depth = 0
+
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if state == "code":
+            if ch == '"':
+                state = "string"
+            elif ch == "'":
+                state = "char"
+            elif ch == "/" and nxt == "/":
+                state = "line_comment"
+                i += 1
+            elif ch == "/" and nxt == "*":
+                state = "block_comment"
+                block_comment_depth = 1
+                i += 1
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return text[start:i], i + 1
+        elif state == "string":
+            if ch == "\\":
+                i += 1
+            elif ch == '"':
+                state = "code"
+        elif state == "char":
+            if ch == "\\":
+                i += 1
+            elif ch == "'":
+                state = "code"
+        elif state == "line_comment":
+            if ch == "\n":
+                state = "code"
+        elif state == "block_comment":
+            if ch == "/" and nxt == "*":
+                block_comment_depth += 1
+                i += 1
+            elif ch == "*" and nxt == "/":
+                block_comment_depth -= 1
+                i += 1
+                if block_comment_depth == 0:
+                    state = "code"
+
+        i += 1
+
+    return text[start:], len(text)
+
+
+def violations_in_text(text: str) -> list[tuple[int, str]]:
+    found: list[tuple[int, str]] = []
+
+    for macro in MACRO_RE.finditer(text):
+        opening_paren = macro.end() - 1
+        body, _ = macro_body(text, opening_paren)
+        for field in FORBIDDEN_FIELD_RE.finditer(body):
+            absolute = opening_paren + 1 + field.start()
+            line = text.count("\n", 0, absolute) + 1
+            found.append((line, field.group(0)))
+
+    return found
+
+
+def violations(path: Path) -> list[tuple[int, str]]:
+    return violations_in_text(path.read_text(encoding="utf-8"))
+
+
+def self_test() -> None:
+    """Fail closed if the scanner stops detecting supported legacy forms."""
+    forbidden = (
+        'info!(msg = "legacy");',
+        'tracing::warn!(message = "legacy");',
+        'debug!(\n    controller = "test",\n    msg = "legacy",\n);',
+        'error!(\n    error = %err,\n    message = format!("legacy {err}"),\n);',
+    )
+    allowed = (
+        'info!("canonical message");',
+        'warn!(controller = "test", "canonical message");',
+        'let msg = "not a tracing field";',
+    )
+
+    for sample in forbidden:
+        if not violations_in_text(sample):
+            raise AssertionError(f"logging checker failed to reject: {sample!r}")
+    for sample in allowed:
+        if violations_in_text(sample):
+            raise AssertionError(f"logging checker rejected valid source: {sample!r}")
+
+
+def rust_sources() -> list[Path]:
+    """Return tracked and non-ignored untracked Rust sources in the checkout.
+
+    Including untracked sources is intentional: CI creates a temporary multiline
+    legacy tracing fixture and requires this checker to reject it. Ignored build
+    output (for example `target/`) remains excluded.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.rs",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return sorted(
+        ROOT / path.decode("utf-8")
+        for path in result.stdout.split(b"\0")
+        if path
+    )
+
+
+def main() -> int:
+    self_test()
+    failures: list[str] = []
+
+    for path in rust_sources():
+        for line, field in violations(path):
+            rel = path.relative_to(ROOT)
+            failures.append(f"{rel}:{line}: forbidden tracing field `{field}`")
+
+    if not failures:
+        return 0
+
+    print("Logging convention violations found:", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    print(
+        "Use the trailing tracing message syntax; see Documentation/logging.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -40,6 +40,7 @@
         "image",
         "k8s-util",
         "kanidm",
+        "logging",
         "mail-sender",
         "makefile",
         "oauth2",

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,6 +31,28 @@ jobs:
           restore-keys: |
             pre-commit-
 
+      - name: Verify structured logging guard rejects legacy msg fields
+        run: |
+          fixture=.ci/structured-logging-guard-fixture.rs
+          trap 'rm -f "$fixture"' EXIT
+          cat > "$fixture" <<'EOF'
+          fn main() {
+              tracing::info!(
+                  msg = "legacy message",
+                  "fixture"
+              );
+          }
+          EOF
+          if output=$(python3 .ci/check-logging.py 2>&1); then
+            echo "structured logging guard unexpectedly accepted a legacy msg field"
+            exit 1
+          fi
+          printf '%s\n' "$output"
+          printf '%s\n' "$output" | grep -F '.ci/structured-logging-guard-fixture.rs:3: forbidden tracing field `msg =`'
+
+      - name: Verify structured logging conventions
+        run: python3 .ci/check-logging.py
+
       - name: Run commit-msg hooks for PR commits
         if: github.event_name == 'pull_request'
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,16 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ['@commitlint/config-conventional']
 
+  - repo: local
+    hooks:
+      - id: structured-logging
+        name: structured logging conventions
+        description: Enforce canonical tracing message fields
+        entry: python3 .ci/check-logging.py
+        language: system
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:

--- a/Documentation/logging.md
+++ b/Documentation/logging.md
@@ -1,0 +1,95 @@
+# Logging conventions
+
+Kaniop uses `tracing` for application logs. Log events are part of the operator's observability API: they are consumed by humans as well as log aggregation systems, so their shape must remain predictable.
+
+## Output formats
+
+Kaniop supports `text` and `json` log formats.
+
+### JSON
+
+JSON logs **must use newline-delimited JSON (NDJSON)**:
+
+- one tracing event is serialized as exactly one JSON object;
+- one event occupies exactly one physical output line;
+- pretty-printed or multiline JSON is not permitted;
+- tracing metadata such as `timestamp`, `level`, and `target` remains at the top level;
+- application event fields remain nested under `fields`.
+
+Example:
+
+```json
+{"timestamp":"2026-08-27T17:55:44.468890Z","level":"INFO","fields":{"message":"starting controller loop","controller":"backup-discovery","interval_secs":300},"target":"kaniop_backup::controller::discovery"}
+```
+
+Keeping event fields nested avoids collisions between application fields and tracing metadata.
+
+### Text
+
+Text logs use the compact human-readable formatter and are intended primarily for interactive use.
+
+## Event authoring
+
+The central rule is:
+
+> Messages describe what happened; fields describe what it happened to.
+
+Use the trailing tracing message syntax for the human-readable event message:
+
+```rust
+info!(
+    controller = CONTROLLER_ID,
+    interval_secs = interval.as_secs(),
+    "starting controller loop"
+);
+```
+
+Do not create `msg` or explicit `message` fields:
+
+```rust
+// Do not do this.
+info!(msg = format!("starting {CONTROLLER_ID} controller"));
+info!(message = "starting controller");
+```
+
+`tracing` creates the canonical `message` field from the trailing message automatically. This keeps JSON output consistent across Kaniop and upstream libraries.
+
+## Structured fields
+
+- Field names use `snake_case`.
+- Prefer stable, semantic names such as `controller`, `namespace`, `kanidm`, `repository`, `schedule`, and `job`.
+- Put dynamic identifiers and values in fields instead of interpolating them into the message when practical.
+- Errors use the `error` field, normally `error = %error` or `error = %err`.
+- Never log credentials, access tokens, private keys, secret values, or other sensitive data.
+
+Prefer:
+
+```rust
+warn!(
+    controller = CONTROLLER_ID,
+    namespace,
+    schedule = schedule.name_any(),
+    error = %error,
+    "discovery processing failed for schedule"
+);
+```
+
+Instead of:
+
+```rust
+warn!("discovery processing failed for schedule {namespace}/{}: {error}", schedule.name_any());
+```
+
+## Levels
+
+- `ERROR`: an operation failed and needs investigation or the current operation cannot continue.
+- `WARN`: recoverable abnormal state, retry, degraded behavior, or an intentional skip that operators should notice.
+- `INFO`: lifecycle events and meaningful state transitions.
+- `DEBUG`: routine reconciliation details and diagnostic context.
+- `TRACE`: very high-volume implementation detail.
+
+## Enforcement
+
+`.ci/check-logging.py` rejects `msg = ...` and explicit `message = ...` fields inside `trace!`, `debug!`, `info!`, `warn!`, and `error!` invocations. The check runs through pre-commit and therefore in CI.
+
+The telemetry unit tests additionally enforce the runtime JSON contract: every emitted JSON event must be independently parseable from a single output line and use the canonical `fields.message` field.

--- a/charts/kaniop/templates/deployment.yaml
+++ b/charts/kaniop/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         - name: {{ include "kaniop.name" . }}
           image: {{ .Values.image.repository }}:{{ include "kaniop.version" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:
@@ -47,6 +51,8 @@ spec:
               value: "{{ .Values.containerPorts.metrics }}"
             - name: LOG_FILTER
               value: {{ .Values.logging.level }}
+            - name: LOG_FORMAT
+              value: {{ .Values.logging.format | quote }}
             - name: IDM_RECONCILE_INTERVAL_SECONDS
               value: "{{ .Values.idmReconcileIntervalSeconds }}"
             - name: CLUSTER_DOMAIN

--- a/charts/kaniop/templates/webhook/deployment.yaml
+++ b/charts/kaniop/templates/webhook/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           image: {{ .Values.webhook.image.repository }}:{{ include "kaniop.webhook.version" . }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           command: ["kaniop-webhook"]
+          {{- with .Values.webhook.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:
@@ -40,6 +44,8 @@ spec:
               value: "{{ .Values.webhook.port }}"
             - name: LOG_FILTER
               value: {{ .Values.webhook.logging.level }}
+            - name: LOG_FORMAT
+              value: {{ .Values.webhook.logging.format | quote }}
             - name: TLS_CERT
               value: /etc/webhook/certs/tls.crt
             - name: TLS_KEY

--- a/charts/kaniop/tests/deployment_test.yaml
+++ b/charts/kaniop/tests/deployment_test.yaml
@@ -44,6 +44,8 @@ tests:
           path: spec.template.spec.containers[0].envFrom
       - notExists:
           path: spec.template.spec.containers[0].lifecycle
+      - notExists:
+          path: spec.template.spec.containers[0].args
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -63,6 +65,12 @@ tests:
           content:
             name: DATA_MOVER_IMAGE
             value: ghcr.io/pando85/kaniop-data-mover:0.14.0
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: text
           any: true
   - it: Render with custom dataMoverImage
     release:
@@ -231,3 +239,30 @@ tests:
             name: LEADER_ELECTION_LEASE_TTL_SECONDS
             value: "30"
           any: true
+  - it: Should set JSON log format
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      logging.format: json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: json
+          any: true
+  - it: Should pass operator extra args
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      extraArgs:
+        - --sample-ratio=0.5
+        - --leader-election
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --sample-ratio=0.5
+            - --leader-election

--- a/charts/kaniop/tests/webhook-deployment_test.yaml
+++ b/charts/kaniop/tests/webhook-deployment_test.yaml
@@ -37,12 +37,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].command
           value: ["kaniop-webhook"]
+      - notExists:
+          path: spec.template.spec.containers[0].args
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8443
       - equal:
           path: spec.template.spec.containers[0].ports[0].name
           value: webhook
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: text
+          any: true
 
   - it: Should use custom image repository and tag
     release:
@@ -68,3 +76,32 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
+
+  - it: Should set JSON log format
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      webhook.enabled: true
+      webhook.logging.format: json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: json
+          any: true
+
+  - it: Should pass webhook extra args
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      webhook.enabled: true
+      webhook.extraArgs:
+        - --sample-ratio=0.5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --sample-ratio=0.5

--- a/charts/kaniop/values.schema.json
+++ b/charts/kaniop/values.schema.json
@@ -126,7 +126,22 @@
         "level": {
           "type": "string",
           "description": "Log level defined by RUST_LOG environment variable."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "text",
+            "json"
+          ],
+          "description": "Log output format. JSON emits newline-delimited JSON with one object per event line."
         }
+      }
+    },
+    "extraArgs": {
+      "type": "array",
+      "description": "Additional CLI arguments passed to the operator container.",
+      "items": {
+        "type": "string"
       }
     },
     "idmReconcileIntervalSeconds": {
@@ -517,7 +532,22 @@
             "level": {
               "type": "string",
               "description": "Log level defined by RUST_LOG environment variable."
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "text",
+                "json"
+              ],
+              "description": "Log output format. JSON emits newline-delimited JSON with one object per event line."
             }
+          }
+        },
+        "extraArgs": {
+          "type": "array",
+          "description": "Additional CLI arguments passed to the webhook container.",
+          "items": {
+            "type": "string"
           }
         },
         "service": {

--- a/charts/kaniop/values.yaml
+++ b/charts/kaniop/values.yaml
@@ -33,6 +33,13 @@ logging:
   ## Log level defined by RUST_LOG environment variable. Example: info,kaniop=trace
   ## Ref: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#filtering-events-with-environment-variables
   level: "info"
+  ## Log output format. JSON uses NDJSON: exactly one JSON object per event line.
+  format: "text"
+
+## Additional CLI arguments passed to the operator container. Prefer dedicated chart
+## values for supported options; use this as an escape hatch for other CLI arguments.
+extraArgs: []
+# - --sample-ratio=0.5
 
 ## Reconciliation interval in seconds for IDM resources (groups, OAuth2 clients,
 ## person accounts, service accounts). This does not affect the Kanidm cluster
@@ -284,11 +291,16 @@ webhook:
   ## Port for webhook server
   port: 8443
 
-  ## Logging level for webhook deployment
+  ## Logging settings for webhook deployment
   logging:
     ## Log level defined by RUST_LOG environment variable. Example: info,kaniop=trace
     ## Ref: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#filtering-events-with-environment-variables
     level: "info"
+    ## Log output format. JSON uses NDJSON: exactly one JSON object per event line.
+    format: "text"
+
+  ## Additional CLI arguments passed to the webhook container.
+  extraArgs: []
 
   service:
     ## Service annotations

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -49,7 +49,7 @@ pub async fn run(state: State, client: Client) {
 
     let ctx = Arc::new(state.to_context(client, CONTROLLER_ID));
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!("starting {CONTROLLER_ID} controller");
     let backup_controller = Controller::new(backup, Config::default().any_semantic())
         .with_config(controller::Config::default().debounce(Duration::from_millis(500)))
         .shutdown_on_signal()
@@ -457,7 +457,7 @@ async fn reconcile_backup(
 ) -> Result<(kube::runtime::controller::Action, bool)> {
     let name = obj.name_any();
     let namespace = obj.namespace().unwrap_or_default();
-    debug!(msg = "reconciling KanidmBackup", %namespace, %name);
+    debug!(%namespace, %name, "reconciling KanidmBackup");
 
     let spec = &obj.spec;
 
@@ -663,8 +663,8 @@ async fn handle_discovering(
                 }
                 None => {
                     debug!(
-                        msg = "validation Job completed but result not yet readable; requeueing",
-                        namespace, name,
+                        namespace,
+                        name, "validation Job completed but result not yet readable; requeueing"
                     );
                     patch_backup_status(ctx, namespace, name, status).await?;
                     return Ok((
@@ -675,7 +675,7 @@ async fn handle_discovering(
             }
         }
 
-        debug!(msg = "validation Job still running", namespace, name);
+        debug!(namespace, name, "validation Job still running");
         patch_backup_status(ctx, namespace, name, status).await?;
         return Ok((
             kube::runtime::controller::Action::requeue(REQUEUE_JOB_PENDING),
@@ -687,10 +687,10 @@ async fn handle_discovering(
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
     match job_api.create(&Default::default(), &validation_job).await {
         Ok(_) => {
-            info!(msg = "created validation Job", namespace, name);
+            info!(namespace, name, "created validation Job");
         }
         Err(kube::Error::Api(ae)) if ae.code == 409 => {
-            debug!(msg = "validation Job already exists", namespace, name);
+            debug!(namespace, name, "validation Job already exists");
         }
         Err(e) => {
             return Err(Error::KubeError(
@@ -728,8 +728,8 @@ async fn handle_deletion(
     let is_referenced = check_referenced_by_active_restore(ctx, obj, namespace).await?;
     if is_referenced {
         warn!(
-            msg = "backup deletion deferred: referenced by active restore",
-            namespace, name,
+            namespace,
+            name, "backup deletion deferred: referenced by active restore"
         );
         status.phase = KanidmBackupPhase::Ready;
         let deferred_condition = Condition {
@@ -766,10 +766,10 @@ async fn handle_deletion(
                 };
 
             warn!(
-                msg = "deletion Job failed; will retry",
                 namespace,
                 name,
-                error = failure_message
+                error = failure_message,
+                "deletion Job failed; will retry"
             );
             let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
             job_api
@@ -809,7 +809,7 @@ async fn handle_deletion(
             ));
         }
 
-        debug!(msg = "deletion Job still running", namespace, name);
+        debug!(namespace, name, "deletion Job still running");
         patch_backup_status(ctx, namespace, name, status).await?;
         return Ok((
             kube::runtime::controller::Action::requeue(REQUEUE_DELETION),
@@ -823,8 +823,8 @@ async fn handle_deletion(
     let manifest_key = &obj.spec.manifest_key;
     if !repo_path.contains_key(manifest_key) {
         warn!(
-            msg = "manifest key escapes repository; marking deleted",
-            namespace, name
+            namespace,
+            name, "manifest key escapes repository; marking deleted"
         );
         status.phase = KanidmBackupPhase::Deleted;
         patch_backup_status(ctx, namespace, name, status).await?;
@@ -840,10 +840,10 @@ async fn handle_deletion(
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
     match job_api.create(&Default::default(), &deletion_job).await {
         Ok(_) => {
-            info!(msg = "created deletion Job", namespace, name);
+            info!(namespace, name, "created deletion Job");
         }
         Err(kube::Error::Api(ae)) if ae.code == 409 => {
-            debug!(msg = "deletion Job already exists", namespace, name);
+            debug!(namespace, name, "deletion Job already exists");
         }
         Err(e) => {
             return Err(Error::KubeError(

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -154,8 +154,9 @@ pub async fn run(state: State, client: Client, scan_interval: Option<Duration>) 
     let metrics = Arc::new(DiscoveryMetrics::new(&meter));
 
     info!(
-        msg = format!("starting {CONTROLLER_ID} loop"),
-        interval_secs = interval.as_secs()
+        controller = CONTROLLER_ID,
+        interval_secs = interval.as_secs(),
+        "starting controller loop"
     );
 
     loop {
@@ -171,16 +172,16 @@ pub async fn run(state: State, client: Client, scan_interval: Option<Duration>) 
                 let success_ts = Timestamp::now();
                 metrics.set_last_scan_success(success_ts.as_second());
                 debug!(
-                    msg = "discovery scan completed",
                     repos_scanned,
-                    elapsed_secs = elapsed
+                    elapsed_secs = elapsed,
+                    "discovery scan completed"
                 );
             }
             Err(e) => {
                 let elapsed = scan_start.elapsed().as_secs_f64();
                 metrics.record_scan_duration(elapsed);
                 metrics.inc_scan_failures();
-                error!(msg = "discovery scan failed", error = %e);
+                error!(error = %e, "discovery scan failed");
             }
         }
 
@@ -205,9 +206,9 @@ async fn run_discovery_scan(
         for schedule in &schedules {
             if schedule.spec.suspend {
                 debug!(
-                    msg = "skipping suspended schedule",
                     namespace,
-                    schedule = schedule.name_any()
+                    schedule = schedule.name_any(),
+                    "skipping suspended schedule"
                 );
                 continue;
             }
@@ -215,9 +216,9 @@ async fn run_discovery_scan(
             let kanidm = get_kanidm_for_schedule(state, client, &namespace, schedule).await?;
             let Some(kanidm) = kanidm else {
                 debug!(
-                    msg = "kanidm not found for schedule; skipping",
                     namespace,
-                    schedule = schedule.name_any()
+                    schedule = schedule.name_any(),
+                    "kanidm not found for schedule; skipping"
                 );
                 continue;
             };
@@ -227,9 +228,9 @@ async fn run_discovery_scan(
 
             if namespace_uid.is_empty() || kanidm_uid.is_empty() {
                 warn!(
-                    msg = "kanidm missing namespace or uid; skipping discovery",
                     namespace,
-                    kanidm = kanidm.name_any()
+                    kanidm = kanidm.name_any(),
+                    "kanidm missing namespace or uid; skipping discovery"
                 );
                 continue;
             }
@@ -240,10 +241,7 @@ async fn run_discovery_scan(
                 .unwrap_or_default();
 
             if ns_uid.is_empty() {
-                warn!(
-                    msg = "namespace uid not available; skipping discovery",
-                    namespace
-                );
+                warn!(namespace, "namespace uid not available; skipping discovery");
                 continue;
             }
 
@@ -260,10 +258,10 @@ async fn run_discovery_scan(
             .await
             {
                 warn!(
-                    msg = "discovery processing failed for schedule",
                     namespace,
                     schedule = schedule.name_any(),
-                    error = %e
+                    error = %e,
+                    "discovery processing failed for schedule"
                 );
             }
         }
@@ -393,10 +391,10 @@ async fn process_discovery_for_schedule(
             };
 
             debug!(
-                msg = "discover Job failed; will retry on next scan",
                 namespace,
                 job = job.name_any(),
-                error = failure_message
+                error = failure_message,
+                "discover Job failed; will retry on next scan"
             );
             let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
             job_api
@@ -459,20 +457,20 @@ async fn process_discovery_for_schedule(
 
                     if discovery.truncated {
                         warn!(
-                            msg = "discover results were truncated; some backups may not be represented",
                             namespace,
-                            schedule = schedule_name
+                            schedule = schedule_name,
+                            "discover results were truncated; some backups may not be represented"
                         );
                     }
 
                     debug!(
-                        msg = "discover result processed",
                         namespace,
                         schedule = schedule_name,
                         total_found = discovery.total_found,
                         new = new_count,
                         reconciled = reconciled_count,
-                        truncated = discovery.truncated
+                        truncated = discovery.truncated,
+                        "discover result processed"
                     );
                 }
                 Some(result) => {
@@ -483,10 +481,10 @@ async fn process_discovery_for_schedule(
                         .unwrap_or_else(|| "discover returned non-success result".to_string());
 
                     warn!(
-                        msg = "discover result indicates failure",
                         namespace,
                         schedule = schedule_name,
-                        error = error_msg
+                        error = error_msg,
+                        "discover result indicates failure"
                     );
 
                     let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
@@ -508,9 +506,9 @@ async fn process_discovery_for_schedule(
                 }
                 None => {
                     debug!(
-                        msg = "discover Job completed but result not yet readable",
                         namespace,
-                        job = job.name_any()
+                        job = job.name_any(),
+                        "discover Job completed but result not yet readable"
                     );
                 }
             }
@@ -518,9 +516,9 @@ async fn process_discovery_for_schedule(
         }
 
         debug!(
-            msg = "discover Job still running",
             namespace,
-            job = job.name_any()
+            job = job.name_any(),
+            "discover Job still running"
         );
         return Ok(());
     }
@@ -542,9 +540,9 @@ async fn process_discovery_for_schedule(
 
     if !is_stale {
         debug!(
-            msg = "discovery is fresh; skipping Job creation",
             namespace,
-            schedule = schedule_name
+            schedule = schedule_name,
+            "discovery is fresh; skipping Job creation"
         );
         return Ok(());
     }
@@ -561,18 +559,18 @@ async fn process_discovery_for_schedule(
     match job_api.create(&Default::default(), &discover_job).await {
         Ok(_) => {
             info!(
-                msg = "created discover Job",
                 namespace,
                 schedule = schedule_name,
-                repository = repo_name
+                repository = repo_name,
+                "created discover Job"
             );
             metrics.inc_discover_jobs(&repo_name);
         }
         Err(kube::Error::Api(ae)) if ae.code == 409 => {
             debug!(
-                msg = "discover Job already exists",
                 namespace,
-                schedule = schedule_name
+                schedule = schedule_name,
+                "discover Job already exists"
             );
         }
         Err(e) => {
@@ -819,21 +817,21 @@ async fn reconcile_discovered_backups(
     for manifest_key in &discovery.manifest_keys {
         if manifest_key.contains("..") {
             warn!(
-                msg = "skipping manifest key with path traversal",
-                key = manifest_key
+                key = manifest_key,
+                "skipping manifest key with path traversal"
             );
             continue;
         }
 
         if !manifest_key.ends_with("/manifest.json") {
-            warn!(msg = "skipping non-manifest key", key = manifest_key);
+            warn!(key = manifest_key, "skipping non-manifest key");
             continue;
         }
 
         if !repo_path.contains_key(manifest_key) {
             warn!(
-                msg = "skipping manifest key outside repository prefix",
-                key = manifest_key
+                key = manifest_key,
+                "skipping manifest key outside repository prefix"
             );
             continue;
         }
@@ -841,8 +839,8 @@ async fn reconcile_discovered_backups(
         let backup_id = extract_backup_id_from_manifest_key(manifest_key);
         let Some(backup_id) = backup_id else {
             warn!(
-                msg = "could not extract backup_id from manifest key",
-                key = manifest_key
+                key = manifest_key,
+                "could not extract backup_id from manifest key"
             );
             continue;
         };
@@ -863,27 +861,27 @@ async fn reconcile_discovered_backups(
         match backup_api.create(&Default::default(), &backup_cr).await {
             Ok(_) => {
                 info!(
-                    msg = "created KanidmBackup from discovery",
                     namespace,
                     backup = backup_cr.name_any(),
-                    manifest_key
+                    manifest_key,
+                    "created KanidmBackup from discovery"
                 );
                 new_count += 1;
             }
             Err(kube::Error::Api(ae)) if ae.code == 409 => {
                 reconciled_count += 1;
                 debug!(
-                    msg = "KanidmBackup already exists; reconciled",
                     namespace,
-                    backup = backup_cr.name_any()
+                    backup = backup_cr.name_any(),
+                    "KanidmBackup already exists; reconciled"
                 );
             }
             Err(e) => {
                 warn!(
-                    msg = "failed to create KanidmBackup from discovery",
                     namespace,
                     backup = backup_cr.name_any(),
-                    error = %e
+                    error = %e,
+                    "failed to create KanidmBackup from discovery"
                 );
             }
         }

--- a/libs/backup/src/controller/repository.rs
+++ b/libs/backup/src/controller/repository.rs
@@ -37,7 +37,7 @@ pub async fn run(
     let store_for_secret = repository_r.store.clone();
     let store_for_cm = repository_r.store.clone();
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
 
     let repository_watcher = watcher(repository_api, Config::default().any_semantic())
         .default_backoff()
@@ -158,7 +158,7 @@ async fn reconcile_repository(
 ) -> Result<(kube::runtime::controller::Action, bool)> {
     let name = obj.name_any();
     let namespace = obj.namespace().unwrap_or_default();
-    debug!(msg = "reconciling KanidmBackupRepository", %namespace, %name);
+    debug!(%namespace, %name, "reconciling KanidmBackupRepository");
 
     let validation_error = validate_spec(&obj.spec);
 

--- a/libs/backup/src/controller/schedule.rs
+++ b/libs/backup/src/controller/schedule.rs
@@ -31,7 +31,7 @@ pub async fn run(state: State, client: Client) {
 
     let ctx = Arc::new(state.to_context(client, CONTROLLER_ID));
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!("starting {CONTROLLER_ID} controller");
     let schedule_controller = Controller::new(schedule, Config::default().any_semantic())
         .with_config(controller::Config::default().debounce(Duration::from_millis(500)))
         .shutdown_on_signal()
@@ -130,7 +130,7 @@ async fn reconcile_schedule(
 ) -> Result<(kube::runtime::controller::Action, bool)> {
     let name = obj.name_any();
     let namespace = obj.namespace().unwrap_or_default();
-    debug!(msg = "reconciling KanidmBackupSchedule", %namespace, %name);
+    debug!(%namespace, %name, "reconciling KanidmBackupSchedule");
 
     let spec = &obj.spec;
 
@@ -167,8 +167,8 @@ async fn reconcile_schedule(
 
     if spec.suspend && restore_active {
         warn!(
-            msg = "schedule is suspended and restore is in progress; transport will not run",
-            namespace, name,
+            namespace,
+            name, "schedule is suspended and restore is in progress; transport will not run"
         );
     }
 
@@ -290,7 +290,7 @@ async fn reconcile_schedule(
         if let (Some(repo), Some(kanidm_obj)) = (&repository, &kanidm) {
             let kanidm_uid = &kanidm_obj.metadata.uid.clone().unwrap_or_default();
             if let Err(e) = reconcile_retention(&ctx, &obj, repo, kanidm_uid, &namespace).await {
-                warn!(msg = "retention reconciliation failed", error = %e, namespace, name);
+                warn!(error = %e, namespace, name, "retention reconciliation failed");
             }
         }
     }
@@ -404,14 +404,14 @@ async fn reconcile_retention(
     let result = select_deletion_candidates(&entries, &policy, &now);
 
     if result.delete.is_empty() {
-        debug!(msg = "retention: no deletion candidates", namespace);
+        debug!(namespace, "retention: no deletion candidates");
         return Ok(());
     }
 
     info!(
-        msg = "retention: deleting candidates",
         namespace,
-        count = result.delete.len()
+        count = result.delete.len(),
+        "retention: deleting candidates"
     );
 
     for backup_name in &result.delete {

--- a/libs/group/src/controller.rs
+++ b/libs/group/src/controller.rs
@@ -21,7 +21,7 @@ pub async fn run(state: State, client: Client) {
 
     let ctx = Arc::new(state.to_context(client, CONTROLLER_ID));
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
     // TODO: watcher::Config::default().streaming_lists() when stabilized in K8s
     // https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
     let group_controller = Controller::new(group, watcher::Config::default().any_semantic())

--- a/libs/group/src/reconcile.rs
+++ b/libs/group/src/reconcile.rs
@@ -57,7 +57,7 @@ pub async fn watched_resource(group: &KanidmGroup, ctx: Arc<Context<KanidmGroup>
     let kanidm = if let Some(k) = ctx.get_kanidm(group) {
         k
     } else {
-        trace!(msg = "no kanidm found");
+        trace!("no kanidm found");
         return false;
     };
 
@@ -73,13 +73,13 @@ pub async fn reconcile_group(
     Span::current().record("trace_id", field::display(&trace_id));
     let _timer = ctx.metrics.reconcile_count_and_measure(&trace_id);
     if !ctx.kanidm_write_allowed(&group) {
-        debug!(msg = "Kanidm restore in progress, pausing identity writes");
+        debug!("Kanidm restore in progress, pausing identity writes");
         return Ok((Action::requeue(Duration::from_secs(5)), false));
     }
     let kanidm_client = ctx.get_idm_client(&group).await?;
 
     if !watched_resource(&group, ctx.clone()).await {
-        debug!(msg = "resource not watched, skipping reconcile");
+        debug!("resource not watched, skipping reconcile");
         ctx.recorder
         .publish(
             &Event {
@@ -93,13 +93,13 @@ pub async fn reconcile_group(
         )
         .await
         .map_err(|e| {
-            warn!(msg = "failed to publish ResourceNotWatched event", %e);
+            warn!(error = %e, "failed to publish ResourceNotWatched event");
             Error::kube_error("publish", "event", group.get_namespace(), group.name_any(), e)
         })?;
         return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
 
-    info!(msg = "reconciling group");
+    info!("reconciling group");
 
     // safe unwrap: group is namespaced scoped
     let namespace = group.get_namespace();
@@ -107,7 +107,7 @@ pub async fn reconcile_group(
         .update_status(kanidm_client.clone(), ctx.clone())
         .await
         .map_err(|e| {
-            debug!(msg = "failed to reconcile status", %e);
+            debug!(error = %e, "failed to reconcile status");
             ctx.metrics.status_update_errors_inc();
             e
         })?;
@@ -137,7 +137,7 @@ pub async fn reconcile_group(
     .await
     .or_else(|e| match e {
         FinalizerError::RemoveFinalizer(kube::Error::Api(ae)) if ae.code == 404 => {
-            debug!(msg = "resource already removed during finalizer cleanup");
+            debug!("resource already removed during finalizer cleanup");
             Ok(Action::requeue(idm_reconcile_interval()))
         }
         _ => Err(Error::FinalizerError(
@@ -183,7 +183,7 @@ impl KanidmGroup {
                         )
                         .await
                         .map_err(|e| {
-                            warn!(msg = "failed to publish KanidmError event", %e);
+                            warn!(error = %e, "failed to publish KanidmError event");
                             Error::kube_error(
                                 "publish",
                                 "event",
@@ -300,7 +300,7 @@ impl KanidmGroup {
         }
 
         if require_status_update {
-            trace!(msg = "status update required, requeueing in 500ms");
+            trace!("status update required, requeueing in 500ms");
             Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
             Ok((Action::requeue(idm_reconcile_interval()), changed))
@@ -308,7 +308,7 @@ impl KanidmGroup {
     }
 
     async fn create(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "create");
+        debug!("create");
         kanidm_client
             .idm_group_create(name, self.spec.entry_managed_by.as_deref())
             .await
@@ -325,7 +325,7 @@ impl KanidmGroup {
     }
 
     async fn update_managed_by(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = format!("update {ATTR_ENTRY_MANAGED_BY} attribute"));
+        debug!(attribute = ATTR_ENTRY_MANAGED_BY, "updating attribute");
         let entry_managed_by =
             self.spec.entry_managed_by.as_ref().ok_or_else(|| {
                 Error::MissingData("group entryManagedBy is not defined".to_string())
@@ -348,7 +348,7 @@ impl KanidmGroup {
     }
 
     async fn update_mail(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = format!("update {ATTR_MAIL} attribute"));
+        debug!(attribute = ATTR_MAIL, "updating attribute");
         let mail = self
             .spec
             .mail
@@ -388,7 +388,7 @@ impl KanidmGroup {
     }
 
     async fn update_members(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = format!("update {ATTR_MEMBER} attribute"));
+        debug!(attribute = ATTR_MEMBER, "updating attribute");
         let members = self
             .spec
             .members
@@ -419,8 +419,8 @@ impl KanidmGroup {
         kanidm_client: &KanidmClient,
         name: &str,
     ) -> Result<()> {
-        debug!(msg = "update posix attributes");
-        trace!(msg = format!("update posix attributes {:?}", self.spec.posix_attributes));
+        debug!("updating posix attributes");
+        trace!(posix_attributes = ?self.spec.posix_attributes, "updating posix attributes");
         kanidm_client
             .idm_group_unix_extend(
                 name,
@@ -443,7 +443,7 @@ impl KanidmGroup {
     }
 
     async fn enable_account_policy(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "enable account policy");
+        debug!("enabling account policy");
         kanidm_client
             .group_account_policy_enable(name)
             .await
@@ -465,12 +465,12 @@ impl KanidmGroup {
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = "update account policy");
+        debug!("updating account policy");
         let policy =
             self.spec.account_policy.as_ref().ok_or_else(|| {
                 Error::MissingData("group accountPolicy is not defined".to_string())
             })?;
-        trace!(msg = format!("update account policy {:?}", policy));
+        trace!(policy = ?policy, "updating account policy");
 
         // Update or reset auth session expiry
         if let Some(expiry) = policy.auth_session_expiry {
@@ -815,7 +815,7 @@ impl KanidmGroup {
         let mut changed = false;
 
         if is_group(TYPE_EXISTS, status.clone()) {
-            debug!(msg = "delete");
+            debug!("delete");
             let start = tokio::time::Instant::now();
             let result = kanidm_client.idm_group_delete(name).await;
             match result {
@@ -829,10 +829,7 @@ impl KanidmGroup {
                     changed = true;
                 }
                 Err(ClientError::Http(status, _, _)) if status == 403 => {
-                    debug!(
-                        msg =
-                            "group cannot be deleted (likely a built-in group), skipping deletion"
-                    );
+                    debug!("group cannot be deleted (likely a built-in group), skipping deletion");
                     ctx.metrics.record_kanidm_sdk_outcome(
                         KANIDM_RESOURCE_GROUP,
                         KANIDM_OP_DELETE,
@@ -890,8 +887,8 @@ impl KanidmGroup {
             status: Some(status.clone()),
             ..KanidmGroup::default()
         });
-        debug!(msg = "updating status");
-        trace!(msg = format!("status patch {:?}", status_patch));
+        debug!("updating status");
+        trace!(status_patch = ?status_patch, "status patch");
         let patch = PatchParams::apply(GROUP_OPERATOR_NAME).force();
         let kanidm_api = Api::<KanidmGroup>::namespaced(ctx.client.clone(), &namespace);
         let _o = kanidm_api

--- a/libs/k8s-util/src/image.rs
+++ b/libs/k8s-util/src/image.rs
@@ -87,7 +87,7 @@ where
         )
         .await
         .map_err(|e| {
-            warn!(msg = format!("failed to publish {} event", operation.error_reason()), %e);
+            warn!(%e, "failed to publish {} event", operation.error_reason());
         });
     error
 }

--- a/libs/oauth2/src/controller.rs
+++ b/libs/oauth2/src/controller.rs
@@ -86,7 +86,7 @@ pub async fn run(state: State, client: Client) {
         CONTROLLER_ID,
         kaniop_ctx,
     );
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
     // TODO: watcher::Config::default().streaming_lists() when stabilized in K8s
     // https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
     let oauth2_controller = Controller::new(oauth2, watcher::Config::default().any_semantic())

--- a/libs/oauth2/src/reconcile/mod.rs
+++ b/libs/oauth2/src/reconcile/mod.rs
@@ -72,7 +72,7 @@ pub async fn watched_resource(oauth2: &KanidmOAuth2Client, ctx: Arc<Context>) ->
     let kanidm = if let Some(k) = ctx.kaniop_ctx.get_kanidm(oauth2) {
         k
     } else {
-        trace!(msg = "no kanidm found");
+        trace!("no kanidm found");
         return false;
     };
 
@@ -97,13 +97,13 @@ pub async fn reconcile_oauth2(
         .metrics
         .reconcile_count_and_measure(&trace_id);
     if !ctx.kaniop_ctx.kanidm_write_allowed(&oauth2) {
-        debug!(msg = "Kanidm restore in progress, pausing identity writes");
+        debug!("Kanidm restore in progress, pausing identity writes");
         return Ok((Action::requeue(Duration::from_secs(5)), false));
     }
     let kanidm_client = ctx.get_idm_client(&oauth2).await?;
 
     if !watched_resource(&oauth2, ctx.clone()).await {
-        debug!(msg = "resource not watched, skipping reconcile");
+        debug!("resource not watched, skipping reconcile");
         ctx.kaniop_ctx.recorder
         .publish(
             &Event {
@@ -117,19 +117,19 @@ pub async fn reconcile_oauth2(
         )
         .await
         .map_err(|e| {
-            warn!(msg = "failed to publish KanidmError event", %e);
+            warn!(%e, "failed to publish KanidmError event");
             Error::kube_error("publish", "event", oauth2.get_namespace(), oauth2.name_any(), e)
         })?;
         return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
 
-    info!(msg = "reconciling oauth2 client");
+    info!("reconciling oauth2 client");
     let namespace = oauth2.get_namespace();
     let status = oauth2
         .update_status(kanidm_client.clone(), ctx.clone())
         .await
         .map_err(|e| {
-            debug!(msg = "failed to reconcile status", %e);
+            debug!(%e, "failed to reconcile status");
             ctx.kaniop_ctx.metrics.status_update_errors_inc();
             e
         })?;
@@ -160,7 +160,7 @@ pub async fn reconcile_oauth2(
     .await
     .or_else(|e| match e {
         FinalizerError::RemoveFinalizer(kube::Error::Api(ae)) if ae.code == 404 => {
-            debug!(msg = "resource already removed during finalizer cleanup");
+            debug!("resource already removed during finalizer cleanup");
             Ok(Action::requeue(idm_reconcile_interval()))
         }
         _ => Err(Error::FinalizerError(
@@ -308,7 +308,7 @@ impl KanidmOAuth2Client {
                         )
                         .await
                         .map_err(|e| {
-                            warn!(msg = "failed to publish KanidmError event", %e);
+                            warn!(%e, "failed to publish KanidmError event");
                             Error::kube_error(
                                 "publish",
                                 "event",
@@ -369,7 +369,7 @@ impl KanidmOAuth2Client {
             // We regenerate when TYPE_SECRET_KEY_ALIASES_SYNCED is False, regardless of annotation.
             // This ensures we keep regenerating until the secret actually has the correct keys.
             // The annotation is updated only when TYPE is True (confirmed synced).
-            info!(msg = "regenerating secret due to secretKeyAliases not synced");
+            info!("regenerating secret due to secretKeyAliases not synced");
             let secret = record_kanidm_sdk_call(
                 metrics,
                 KANIDM_RESOURCE_OAUTH2,
@@ -404,9 +404,9 @@ impl KanidmOAuth2Client {
 
         if force_secret_rotation_requested {
             if self.spec.public {
-                info!(msg = "skipping forced secret rotation annotation for public OAuth2 client");
+                info!("skipping forced secret rotation annotation for public OAuth2 client");
             } else {
-                info!(msg = "rotating OAuth2 client secret due to force annotation");
+                info!("rotating OAuth2 client secret due to force annotation");
                 self.rotate_secret(&kanidm_client, name, ctx.clone(), metrics)
                     .await?;
             }
@@ -430,7 +430,7 @@ impl KanidmOAuth2Client {
             match ctx.secret_store.find(|s| {
                 s.name_any() == self.secret_name() && s.namespace().as_ref() == Some(&namespace)
             }) {
-                None => debug!(msg = "secret not yet in store, deferring secretTemplate apply"),
+                None => debug!("secret not yet in store, deferring secretTemplate apply"),
                 Some(secret_meta) => {
                     // Re-evaluate here rather than reusing the status result: the store may
                     // have been updated between update_status and now, and we need the
@@ -438,11 +438,7 @@ impl KanidmOAuth2Client {
                     // through the status conditions.
                     if let Some(filtered) = self.needs_meta_template_apply(&secret_meta) {
                         if filtered.has_discards() {
-                            warn!(
-                                msg = "secretTemplate contains keys already owned by the operator; they will be ignored",
-                                discarded_labels = ?filtered.discarded_labels,
-                                discarded_annotations = ?filtered.discarded_annotations,
-                            );
+                            warn!(discarded_labels = ?filtered.discarded_labels, discarded_annotations = ?filtered.discarded_annotations, "secretTemplate contains keys already owned by the operator; they will be ignored");
                             ctx.kaniop_ctx
                                 .recorder
                                 .publish(
@@ -473,8 +469,14 @@ impl KanidmOAuth2Client {
                                 )
                                 .await
                                 .map_err(|e| {
-                                    warn!(msg = "failed to publish SecretTemplateConflict event", %e);
-Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
+                                    warn!(%e, "failed to publish SecretTemplateConflict event");
+                                    Error::kube_error(
+                                        "publish",
+                                        "event",
+                                        self.get_namespace(),
+                                        self.name_any(),
+                                        e,
+                                    )
                                 })?;
                         }
                         self.apply_meta_template(
@@ -575,7 +577,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         }
 
         if require_status_update {
-            trace!(msg = "status update required, requeueing in 500ms");
+            trace!("status update required, requeueing in 500ms");
             Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
             Ok((Action::requeue(idm_reconcile_interval()), changed))
@@ -588,9 +590,9 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = "create");
+        debug!("create");
         if self.spec.public {
-            debug!(msg = "create public client");
+            debug!("create public client");
             record_kanidm_sdk_call(
                 metrics,
                 KANIDM_RESOURCE_OAUTH2,
@@ -644,7 +646,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = "update");
+        debug!("update");
         record_kanidm_sdk_call(
             metrics,
             KANIDM_RESOURCE_OAUTH2,
@@ -678,7 +680,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         ctx: Arc<Context>,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        info!(msg = "rotating OAuth2 client secret");
+        info!("rotating OAuth2 client secret");
         // Reset the secret in Kanidm using idm_oauth2_rs_update with reset_secret=true
         record_kanidm_sdk_call(
             metrics,
@@ -723,7 +725,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         status: &KanidmOAuth2ClientStatus,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_RS_ORIGIN} attribute"));
+        debug!("update {ATTR_OAUTH2_RS_ORIGIN} attribute");
 
         let current_urls: BTreeSet<_> = status
             .origin
@@ -806,7 +808,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         status: &KanidmOAuth2ClientStatus,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_RS_SCOPE_MAP} attribute"));
+        debug!("update {ATTR_OAUTH2_RS_SCOPE_MAP} attribute");
 
         let current_scope_map: BTreeSet<_> = status
             .scope_map
@@ -880,7 +882,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         status: &KanidmOAuth2ClientStatus,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_RS_SUP_SCOPE_MAP} attribute"));
+        debug!("update {ATTR_OAUTH2_RS_SUP_SCOPE_MAP} attribute");
 
         let current_sup_scope_map: BTreeSet<_> = status
             .sup_scope_map
@@ -954,7 +956,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         status: &KanidmOAuth2ClientStatus,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_RS_CLAIM_MAP} attribute"));
+        debug!("update {ATTR_OAUTH2_RS_CLAIM_MAP} attribute");
 
         let current_claims_map: BTreeSet<_> = status
             .claims_map
@@ -1069,7 +1071,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_STRICT_REDIRECT_URI} attribute"));
+        debug!("update {ATTR_OAUTH2_STRICT_REDIRECT_URI} attribute");
         if let Some(strict_redirect_url_enabled) = self.spec.strict_redirect_url {
             if strict_redirect_url_enabled {
                 record_kanidm_sdk_call(
@@ -1120,7 +1122,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE} attribute"));
+        debug!("update {ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE} attribute");
         if let Some(disable_pkce) = self.spec.allow_insecure_client_disable_pkce {
             if disable_pkce {
                 record_kanidm_sdk_call(
@@ -1171,7 +1173,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_PREFER_SHORT_USERNAME} attribute"));
+        debug!("update {ATTR_OAUTH2_PREFER_SHORT_USERNAME} attribute");
         if let Some(prefer_short_username) = self.spec.prefer_short_username {
             if prefer_short_username {
                 record_kanidm_sdk_call(
@@ -1222,7 +1224,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT} attribute"));
+        debug!("update {ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT} attribute");
         if let Some(allow_localhost_redirect) = self.spec.allow_localhost_redirect {
             if allow_localhost_redirect {
                 record_kanidm_sdk_call(
@@ -1273,7 +1275,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE} attribute"));
+        debug!("update {ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE} attribute");
         if let Some(legacy_crypto) = self.spec.jwt_legacy_crypto_enable {
             if legacy_crypto {
                 record_kanidm_sdk_call(
@@ -1324,7 +1326,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = format!("update {ATTR_OAUTH2_CONSENT_PROMPT_ENABLE} attribute"));
+        debug!("update {ATTR_OAUTH2_CONSENT_PROMPT_ENABLE} attribute");
         if let Some(disable_consent_prompt) = self.spec.disable_consent_prompt {
             if disable_consent_prompt {
                 record_kanidm_sdk_call(
@@ -1379,7 +1381,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
     ) -> Result<bool> {
         match &self.spec.image {
             None => {
-                debug!(msg = "deleting image from OAuth2 client");
+                debug!("deleting image from OAuth2 client");
                 record_kanidm_sdk_call(
                     metrics,
                     KANIDM_RESOURCE_OAUTH2,
@@ -1402,7 +1404,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             }
             Some(image_spec) => {
                 let url = &image_spec.url;
-                debug!(msg = format!("updating image for OAuth2 client from {url}"));
+                debug!("updating image for OAuth2 client from {url}");
 
                 let namespace = self.kanidm_namespace();
                 let kanidm = self.kanidm_name();
@@ -1500,7 +1502,7 @@ Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
         let name = &self.kanidm_entity_name();
         let mut changed = false;
         if is_oauth2(TYPE_EXISTS, status.clone()) {
-            debug!(msg = "delete");
+            debug!("delete");
             record_kanidm_sdk_call(
                 &ctx.kaniop_ctx.metrics,
                 KANIDM_RESOURCE_OAUTH2,

--- a/libs/oauth2/src/reconcile/status.rs
+++ b/libs/oauth2/src/reconcile/status.rs
@@ -162,8 +162,8 @@ impl StatusExt for KanidmOAuth2Client {
             status: Some(status.clone()),
             ..KanidmOAuth2Client::default()
         });
-        debug!(msg = "updating status");
-        trace!(msg = format!("status patch {:?}", status_patch));
+        debug!("updating status");
+        trace!("status patch {:?}", status_patch);
         let patch = PatchParams::apply(OAUTH2_OPERATOR_NAME).force();
         let kanidm_api =
             Api::<KanidmOAuth2Client>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);

--- a/libs/operator/src/controller/context.rs
+++ b/libs/operator/src/controller/context.rs
@@ -122,12 +122,9 @@ where
     ) -> Option<Arc<KanidmClient>> {
         let client = cache.read().await.get(key).cloned()?;
 
-        trace!(
-            msg = "check existing Kanidm client session",
-            namespace, name
-        );
+        trace!(namespace, name, "check existing Kanidm client session");
         if client.auth_valid().await.is_ok() {
-            trace!(msg = "reuse Kanidm client session", namespace, name);
+            trace!(namespace, name, "reuse Kanidm client session");
             Some(client)
         } else {
             None
@@ -139,7 +136,7 @@ where
     async fn get_kanidm_client(&self, obj: &K, user: KanidmUser) -> Result<Arc<KanidmClient>> {
         let namespace = obj.kanidm_namespace();
         let name = obj.kanidm_name();
-        debug!(msg = "get Kanidm client", namespace, name);
+        debug!(namespace, name, "get Kanidm client");
 
         let cache = match user {
             KanidmUser::Admin => self.system_clients.clone(),
@@ -191,7 +188,7 @@ where
                     )
                     .await
                     .map_err(|e| {
-                        error!(msg = "failed to create Kanidm client", %e);
+                        error!(%e, "failed to create Kanidm client");
                         Error::KubeError("failed to publish event".to_string(), Box::new(e))
                     })?;
                 Err(e)
@@ -267,9 +264,9 @@ where
             Entry::Occupied(_occupied) => {}
         }
         trace!(
-            msg = "recreate backoff policy".to_string(),
             namespace = obj_ref.namespace.as_deref().unwrap(),
             name = obj_ref.name,
+            "recreate backoff policy"
         );
         duration
     }
@@ -279,9 +276,9 @@ where
         let removed = self.error_backoff_cache.write().await.remove(&obj_ref);
         if removed.is_some() {
             trace!(
-                msg = "reset backoff policy",
                 namespace = obj_ref.namespace.as_deref().unwrap(),
-                name = obj_ref.name
+                name = obj_ref.name,
+                "reset backoff policy"
             );
             self.metrics.objects_in_backoff_dec();
         }
@@ -375,21 +372,20 @@ where
         // safe unwrap: self is namespaced scoped
         let namespace = kube::ResourceExt::namespace(self).unwrap();
         trace!(
-            msg = format!("deleting {}", short_type_name::<K>().unwrap_or("Unknown")),
             resource.name = &name,
-            resource.namespace = &namespace
+            resource.namespace = &namespace,
+            "deleting {}",
+            short_type_name::<K>().unwrap_or("Unknown")
         );
         let api = Api::<K>::namespaced(client, &namespace);
         match api.delete(&name, &Default::default()).await {
             Ok(_) => Ok(()),
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
                 trace!(
-                    msg = format!(
-                        "{} not found, treating delete as successful",
-                        short_type_name::<K>().unwrap_or("Unknown")
-                    ),
                     resource.name = &name,
-                    resource.namespace = &namespace
+                    resource.namespace = &namespace,
+                    "{} not found, treating delete as successful",
+                    short_type_name::<K>().unwrap_or("Unknown")
                 );
                 Ok(())
             }
@@ -408,9 +404,10 @@ where
         // safe unwrap: self is namespaced scoped
         let namespace = kube::ResourceExt::namespace(self).unwrap();
         trace!(
-            msg = format!("applying {}", short_type_name::<K>().unwrap_or("Unknown")),
             resource.name = &name,
-            resource.namespace = &namespace
+            resource.namespace = &namespace,
+            "applying {}",
+            short_type_name::<K>().unwrap_or("Unknown")
         );
         let resource_api = Api::<K>::namespaced(client, &namespace);
 
@@ -451,16 +448,8 @@ where
             && ae.code == 422
             && is_immutable_update_message(&ae.message)
         {
-            info!(
-                msg = format!(
-                    "recreating {} because an immutable field changed",
-                    short_type_name::<K>().unwrap_or("Unknown")
-                ),
-                resource.name = &name,
-                resource.namespace = &namespace,
-                reason = %ae.reason,
-                message = %ae.message,
-            );
+            info!(resource.name = &name, resource.namespace = &namespace, reason = %ae.reason, api_message = %ae.message, "recreating {} because an immutable field changed",
+                    short_type_name::<K>().unwrap_or("Unknown"));
             self.kube_delete(client.clone(), metrics, &obj).await?;
             metrics.reconcile_deploy_delete_create_inc(
                 short_type_name::<K>().unwrap_or("Unknown"),
@@ -473,14 +462,7 @@ where
             && let kube::Error::Api(ae) = cause.as_ref()
             && ae.code == 422
         {
-            debug!(
-                msg = "server-side apply rejected resource with a non-immutable 422; preserving the existing resource",
-                resource.kind = short_type_name::<K>().unwrap_or("Unknown"),
-                resource.name = &name,
-                resource.namespace = &namespace,
-                reason = %ae.reason,
-                message = %ae.message,
-            );
+            debug!(resource.kind = short_type_name::<K>().unwrap_or("Unknown"), resource.name = &name, resource.namespace = &namespace, reason = %ae.reason, api_message = %ae.message, "server-side apply rejected resource with a non-immutable 422; preserving the existing resource");
         }
 
         result

--- a/libs/operator/src/controller/kanidm.rs
+++ b/libs/operator/src/controller/kanidm.rs
@@ -86,28 +86,28 @@ where
     T: KanidmResource,
 {
     let namespace = resource.namespace().unwrap();
-    trace!(msg = "check if resource is watched", %namespace);
+    trace!(%namespace, "check if resource is watched");
 
     let namespace_selector = if let Some(selector) = T::get_namespace_selector(kanidm) {
         selector
     } else {
-        trace!(msg = "no namespace selector found, defaulting to current namespace");
+        trace!("no namespace selector found, defaulting to current namespace");
         return kanidm.namespace().unwrap() == namespace;
     };
 
     if selector_matches_all(namespace_selector) {
-        trace!(msg = "namespace selector matches all namespaces, fast-track accepted");
+        trace!("namespace selector matches all namespaces, fast-track accepted");
         return true;
     }
 
     let selector: Selector = if let Ok(s) = namespace_selector.clone().try_into() {
         s
     } else {
-        trace!(msg = "failed to parse namespace selector, defaulting to current namespace");
+        trace!("failed to parse namespace selector, defaulting to current namespace");
         return kanidm.namespace().unwrap() == namespace;
     };
 
-    trace!(msg = "namespace selector", ?selector);
+    trace!(?selector, "namespace selector");
 
     let found_in_store = namespace_store
         .state()
@@ -119,17 +119,17 @@ where
         return true;
     }
 
-    trace!(msg = "namespace not found in store, fetching from K8s API", %namespace);
+    trace!(%namespace, "namespace not found in store, fetching from K8s API");
     let namespace_api: Api<Namespace> = Api::all(k8s_client.clone());
     match namespace_api.get(&namespace).await {
         Ok(ns) => {
             let matches =
                 selector.matches(ns.metadata.labels.as_ref().unwrap_or(&Default::default()));
-            trace!(msg = "namespace fetched from API", %namespace, matches);
+            trace!(%namespace, matches, "namespace fetched from API");
             matches
         }
         Err(e) => {
-            trace!(msg = "failed to fetch namespace from API, treating as not watched", %namespace, ?e);
+            trace!(%namespace, ?e, "failed to fetch namespace from API, treating as not watched");
             false
         }
     }
@@ -199,7 +199,7 @@ impl KanidmClients {
         user: KanidmUser,
         k_client: Client,
     ) -> Result<Arc<KanidmClient>> {
-        debug!(msg = "create Kanidm client", namespace, name);
+        debug!(namespace, name, "create Kanidm client");
 
         let secret_api = Api::<Secret>::namespaced(k_client.clone(), namespace);
         let kanidm_api = Api::<Kanidm>::namespaced(k_client.clone(), namespace);
@@ -270,8 +270,8 @@ impl KanidmClients {
             KanidmUser::IdmAdmin => (IDM_ADMIN_USER, IDM_ADMIN_PASSWORD_KEY),
         };
         trace!(
-            msg = format!("fetch Kanidm {username} password"),
-            namespace, name, secret_name
+            namespace,
+            name, secret_name, "fetch Kanidm {username} password"
         );
         let password_bytes = secret_data.get(password_key).ok_or_else(|| {
             Error::MissingData(format!(
@@ -282,8 +282,8 @@ impl KanidmClients {
         let password = std::str::from_utf8(&password_bytes.0)
             .map_err(|e| Error::Utf8Error("failed to convert password to string".to_string(), e))?;
         trace!(
-            msg = format!("authenticating with new client and user {username}"),
-            namespace, name
+            namespace,
+            name, "authenticating with new client and user {username}"
         );
         client
             .auth_simple_password(username, password)

--- a/libs/operator/src/controller/mod.rs
+++ b/libs/operator/src/controller/mod.rs
@@ -227,29 +227,29 @@ where
         async move {
             match res {
                 Ok(event) => {
-                    trace!(msg = "watched event", ?event);
+                    trace!(?event, "watched event");
                     match event {
                         watcher::Event::Delete(d) => {
                             debug!(
-                                msg = format!("delete event for {resource_name} trigger reconcile"),
                                 namespace = ResourceExt::namespace(&d).unwrap(),
-                                name = d.name_any()
+                                name = d.name_any(),
+                                "delete event for {resource_name} trigger reconcile"
                             );
 
                             // TODO: remove for each trigger on delete logic when
                             // (dispatch delete events issue)[https://github.com/kube-rs/kube/issues/1590]
                             // is solved
-                            let _ignore_errors = reload_tx_clone.try_send(()).map_err(
-                                |e| error!(msg = "failed to trigger reconcile on delete", %e),
-                            );
+                            let _ignore_errors = reload_tx_clone
+                                .try_send(())
+                                .map_err(|e| error!(%e, "failed to trigger reconcile on delete"));
                             ctx.metrics
                                 .triggered_inc(metrics::Action::Delete, resource_name);
                         }
                         watcher::Event::Apply(d) => {
                             debug!(
-                                msg = format!("apply event for {resource_name} trigger reconcile"),
                                 namespace = ResourceExt::namespace(&d).unwrap(),
-                                name = d.name_any()
+                                name = d.name_any(),
+                                "apply event for {resource_name} trigger reconcile"
                             );
                             ctx.metrics
                                 .triggered_inc(metrics::Action::Apply, resource_name);
@@ -258,7 +258,7 @@ where
                     }
                 }
                 Err(e) => {
-                    error!(msg = format!("unexpected error when watching {resource_name}"), %e);
+                    error!(%e, "unexpected error when watching {resource_name}");
                     ctx.metrics.watch_operations_failed_inc();
                 }
             }
@@ -314,7 +314,7 @@ where
     <K as Lookup>::DynamicType: Default + Eq + std::hash::Hash + Clone,
 {
     tracing::warn!(
-        msg = "error_policy called unexpectedly - all controllers should use backoff_reconciler! macro"
+        "error_policy called unexpectedly - all controllers should use backoff_reconciler! macro"
     );
     Action::requeue(Duration::from_secs(300))
 }
@@ -340,17 +340,13 @@ macro_rules! backoff_reconciler {
                     // safe unwrap: all resources in the operator are namespace scoped resources
                     let namespace = kube::ResourceExt::namespace(obj.as_ref()).unwrap();
                     let name = kube::ResourceExt::name_any(obj.as_ref());
-                    tracing::error!(msg = "failed reconciliation", %namespace, %name, %error);
+                    tracing::error!(%namespace, %name, %error, "failed reconciliation");
                     ctx.metrics().reconcile_failure_inc();
                     ctx.metrics().reconcile_outcome_record($crate::metrics::KANIDM_OUTCOME_ERROR);
                     let backoff_duration = ctx
                         .get_backoff(kube::runtime::reflector::ObjectRef::from(obj.as_ref()))
                         .await;
-                    tracing::trace!(
-                        msg = format!("backoff duration: {backoff_duration:?}"),
-                        %namespace,
-                        %name,
-                    );
+                    tracing::trace!(%namespace, %name, "backoff duration: {backoff_duration:?}");
                     Ok(kube::runtime::controller::Action::requeue(backoff_duration))
                 }
             }

--- a/libs/operator/src/kanidm/controller/context.rs
+++ b/libs/operator/src/kanidm/controller/context.rs
@@ -43,7 +43,7 @@ impl Context {
     }
 
     pub async fn get_repl_cert_exp(&self, secret_ref: &ObjectRef<Secret>) -> Option<i64> {
-        trace!(msg = format!("getting replica certificate expiration for {secret_ref}"));
+        trace!("getting replica certificate expiration for {secret_ref}");
         self.repl_cert_exp_cache
             .read()
             .await
@@ -54,10 +54,8 @@ impl Context {
 
     pub async fn insert_repl_cert_exp(&self, secret: &Secret) -> Result<()> {
         trace!(
-            msg = format!(
-                "inserting replica certificate expiration for {:?}",
-                &ObjectRef::from(secret)
-            )
+            "inserting replica certificate expiration for {:?}",
+            &ObjectRef::from(secret)
         );
         match &secret.data {
             None => Err(Error::MissingData("secret data empty".to_string())),
@@ -88,12 +86,12 @@ impl Context {
 
     #[inline]
     pub async fn remove_repl_cert_exp(&self, secret_ref: &ObjectRef<Secret>) {
-        trace!(msg = format!("removing replica certificate expiration for {secret_ref}",));
+        trace!("removing replica certificate expiration for {secret_ref}",);
         self.repl_cert_exp_cache.write().await.0.remove(secret_ref);
     }
 
     pub async fn get_repl_cert_host(&self, secret_ref: &ObjectRef<Secret>) -> Option<String> {
-        trace!(msg = format!("getting replica certificate host for {secret_ref}"));
+        trace!("getting replica certificate host for {secret_ref}");
         self.repl_cert_host_cache
             .read()
             .await
@@ -104,7 +102,7 @@ impl Context {
 
     #[inline]
     pub async fn remove_repl_cert_host(&self, secret_ref: &ObjectRef<Secret>) {
-        trace!(msg = format!("removing replica certificate host for {secret_ref}",));
+        trace!("removing replica certificate host for {secret_ref}",);
         self.repl_cert_host_cache.write().await.0.remove(secret_ref);
     }
 }
@@ -151,7 +149,7 @@ fn parse_cert_expiration_and_host(cert_b64url: &str) -> Result<(i64, String)> {
     let cert = X509::from_der(&der_bytes)
         .map_err(|e| Error::ParseError(format!("failed to parse DER certificate: {e}")))?;
     let not_after = cert.not_after();
-    trace!(msg = format!("certificate not after: {not_after}"));
+    trace!("certificate not after: {not_after}");
 
     let epoch = Asn1Time::from_unix(0)
         .map_err(|e| Error::ParseError(format!("failed to create epoch time: {e}")))?;

--- a/libs/operator/src/kanidm/controller/mod.rs
+++ b/libs/operator/src/kanidm/controller/mod.rs
@@ -57,23 +57,23 @@ fn create_replica_cert_watcher(
         async move {
             match res {
                 Ok(event) => {
-                    trace!(msg = "watched replica cert event", ?event);
+                    trace!(?event, "watched replica cert event");
                     match event {
                         watcher::Event::InitApply(secret) | watcher::Event::Apply(secret) => {
                             debug!(
-                                msg = "init or apply event for replica cert secret trigger reconcile",
                                 namespace = secret.namespace().unwrap(),
-                                name = secret.name_any()
+                                name = secret.name_any(),
+                                "init or apply event for replica cert secret trigger reconcile"
                             );
                             let _ignore_errors = ctx.insert_repl_cert_exp(&secret).await.map_err(
-                                |e| error!(msg = "failed to get replica cert expiration, automatic certificate renewal may be affected", %e),
+                                |e| error!(error = %e, "failed to get replica cert expiration, automatic certificate renewal may be affected"),
                             );
                         }
                         watcher::Event::Delete(secret) => {
                             debug!(
-                                msg = "delete event for replica cert secret",
                                 namespace = secret.namespace().unwrap(),
-                                name = secret.name_any()
+                                name = secret.name_any(),
+                                "delete event for replica cert secret"
                             );
                             ctx.remove_repl_cert_exp(&ObjectRef::from(&secret))
                                 .await;
@@ -84,7 +84,7 @@ fn create_replica_cert_watcher(
                     }
                 }
                 Err(e) => {
-                    error!(msg = "unexpected error when watching replica cert secrets", %e);
+                    error!(error = %e, "unexpected error when watching replica cert secrets");
                     ctx.kaniop_ctx.metrics.watch_operations_failed_inc();
                 }
             }
@@ -284,7 +284,7 @@ pub async fn run(
     .default_backoff()
     .touched_objects()
     .inspect_err(move |e| {
-        error!(msg = "unexpected error when watching TLS secrets", %e);
+        error!(error = %e, "unexpected error when watching TLS secrets");
         tls_secret_metrics_ctx.metrics.watch_operations_failed_inc();
     });
 
@@ -295,18 +295,16 @@ pub async fn run(
             let ctx = ctx.clone();
             async move {
                 match res {
-                    Ok(event) => {
-                        trace!(msg = format!("receive namespace event: {event:?}"),)
-                    }
+                    Ok(event) => trace!(?event, "received namespace event"),
                     Err(e) => {
-                        error!(msg = "unexpected error when watching namespace".to_string(), %e);
+                        error!(error = %e, "unexpected error when watching namespace");
                         ctx.kaniop_ctx.metrics.watch_operations_failed_inc();
                     }
                 }
             }
         });
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
     let kanidm_watcher = watcher(kanidm_api, watcher::Config::default().any_semantic())
         .default_backoff()
         .reflect(kanidm_r.writer)

--- a/libs/operator/src/kanidm/reconcile/domain_appearance.rs
+++ b/libs/operator/src/kanidm/reconcile/domain_appearance.rs
@@ -33,7 +33,7 @@ async fn delete_domain_image(kanidm_client: &KanidmClient, ctx: &Context) -> Res
             Some(OperationError::NoMatchingEntries),
             _,
         )) => {
-            debug!(msg = "domain image already absent, skipping delete");
+            debug!("domain image already absent, skipping delete");
             ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
                 KANIDM_RESOURCE_DOMAIN,
                 KANIDM_OP_DELETE,
@@ -115,7 +115,7 @@ pub async fn reconcile_domain_appearance(
             clear_domain_appearance_image_status(&kanidm_api, &name, &namespace).await?;
         }
 
-        debug!(msg = "removing domain image from Kanidm");
+        debug!("removing domain image from Kanidm");
         delete_domain_image(&kanidm_client, &ctx).await?;
     }
 
@@ -129,7 +129,7 @@ async fn reconcile_domain_display_name(
     ctx: &Context,
 ) -> Result<()> {
     if let Some(name) = display_name {
-        debug!(msg = format!("setting domain display name to '{}'", name));
+        debug!("setting domain display name to '{}'", name);
         let start = tokio::time::Instant::now();
         let result = kanidm_client.idm_domain_set_display_name(name).await;
         match result {
@@ -146,7 +146,7 @@ async fn reconcile_domain_display_name(
                 Some(OperationError::NoMatchingEntries),
                 _,
             )) => {
-                debug!(msg = "domain display name target is absent, skipping update");
+                debug!("domain display name target is absent, skipping update");
                 ctx.kaniop_ctx.metrics.record_kanidm_sdk_outcome(
                     KANIDM_RESOURCE_DOMAIN,
                     KANIDM_OP_SET_DISPLAY_NAME,
@@ -184,7 +184,7 @@ async fn reconcile_domain_image_with_spec(
 ) -> Result<()> {
     match image_spec {
         None => {
-            debug!(msg = "deleting domain image from Kanidm");
+            debug!("deleting domain image from Kanidm");
 
             if status.domain_appearance_image.is_some() {
                 let namespace = kanidm.namespace().unwrap();
@@ -200,7 +200,7 @@ async fn reconcile_domain_image_with_spec(
             let url = &image_spec.url;
             let namespace = kanidm.namespace().unwrap();
             let name = kanidm.name_any();
-            debug!(msg = format!("checking domain image from {}", url));
+            debug!("checking domain image from {}", url);
 
             let kanidm_client_clone = kanidm_client.clone();
             let namespace_for_error = namespace.clone();

--- a/libs/operator/src/kanidm/reconcile/mail_sender.rs
+++ b/libs/operator/src/kanidm/reconcile/mail_sender.rs
@@ -62,7 +62,7 @@ pub async fn reconcile_mail_sender(
     let kanidm_name = kanidm.name_any();
 
     if let Some(mail_sender_spec) = &kanidm.spec.mail_sender {
-        info!(msg = "reconciling mail sender", namespace, kanidm_name);
+        info!(namespace, kanidm_name, "reconciling mail sender");
 
         let sa_name = mail_sender_service_account_name(&kanidm_name);
         let config_secret_name = mail_sender_config_map_name(&kanidm_name);
@@ -145,8 +145,8 @@ pub async fn reconcile_mail_sender(
         ))
     } else {
         debug!(
-            msg = "mail sender not enabled, cleaning up resources",
-            namespace, kanidm_name
+            namespace,
+            kanidm_name, "mail sender not enabled, cleaning up resources"
         );
         let cleanup_changed = cleanup_mail_sender_resources(kanidm, &ctx).await?;
         Ok((None, cleanup_changed))
@@ -159,7 +159,7 @@ async fn ensure_mail_sender_service_account(
     domain: &str,
     metrics: &crate::metrics::ControllerMetrics,
 ) -> Result<bool> {
-    debug!(msg = "ensuring mail sender service account exists", name);
+    debug!(name, "ensuring mail sender service account exists");
 
     let display_name = format!("Mail Sender ({domain})");
 
@@ -185,7 +185,7 @@ async fn ensure_mail_sender_service_account(
                 KANIDM_OUTCOME_UNCHANGED,
                 start.elapsed(),
             );
-            debug!(msg = "service account already exists, updating", name);
+            debug!(name, "service account already exists, updating");
             let start = tokio::time::Instant::now();
             kanidm_client
                 .idm_service_account_update(name, None, Some(&display_name), None, None)
@@ -230,7 +230,7 @@ async fn ensure_mail_sender_in_group(
     name: &str,
     metrics: &crate::metrics::ControllerMetrics,
 ) -> Result<bool> {
-    debug!(msg = "adding mail sender to message_senders group", name);
+    debug!(name, "adding mail sender to message_senders group");
 
     let start = tokio::time::Instant::now();
     let add_result = kanidm_client
@@ -248,7 +248,7 @@ async fn ensure_mail_sender_in_group(
             Ok(true)
         }
         Err(e) if is_already_member_error(&e) => {
-            debug!(msg = "service account already in group", name);
+            debug!(name, "service account already in group");
             metrics.record_kanidm_sdk_outcome(
                 KANIDM_RESOURCE_MAIL_SENDER,
                 KANIDM_OP_SET_MEMBERS,
@@ -281,11 +281,7 @@ async fn ensure_mail_sender_token(
     current_token_id: Option<String>,
     metrics: &crate::metrics::ControllerMetrics,
 ) -> Result<(String, String, bool)> {
-    debug!(
-        msg = "ensuring mail sender API token exists",
-        name,
-        current_token_id = ?current_token_id
-    );
+    debug!(name, current_token_id = ?current_token_id, "ensuring mail sender API token exists");
 
     let start = tokio::time::Instant::now();
     let existing_tokens_result = kanidm_client.idm_service_account_list_api_token(name).await;
@@ -329,28 +325,15 @@ async fn ensure_mail_sender_token(
 
     if let Some(token) = existing_mail_sender_tokens.first() {
         if current_token_id.as_ref() == Some(&token.token_id.to_string()) {
-            debug!(
-                msg = "mail sender token already exists with matching token_id, reading from existing secret",
-                name,
-                token_id = %token.token_id
-            );
+            debug!(name, token_id = %token.token_id, "mail sender token already exists with matching token_id, reading from existing secret");
             if let Some(existing_token_value) =
                 read_token_from_config_secret(ctx, namespace, config_secret_name).await?
             {
                 return Ok((existing_token_value, token.token_id.to_string(), false));
             }
-            debug!(
-                msg = "existing token value not found in secret, destroying all tokens and regenerating",
-                name,
-                token_id = %token.token_id
-            );
+            debug!(name, token_id = %token.token_id, "existing token value not found in secret, destroying all tokens and regenerating");
         } else {
-            debug!(
-                msg = "mail sender token exists but token_id mismatch, destroying all tokens and regenerating",
-                name,
-                old_token_id = %token.token_id,
-                expected_token_id = ?current_token_id
-            );
+            debug!(name, old_token_id = %token.token_id, expected_token_id = ?current_token_id, "mail sender token exists but token_id mismatch, destroying all tokens and regenerating");
         }
 
         for token in existing_mail_sender_tokens {
@@ -371,10 +354,7 @@ async fn ensure_mail_sender_token(
         }
     }
 
-    debug!(
-        msg = "generating new read-write API token for mail sender",
-        name
-    );
+    debug!(name, "generating new read-write API token for mail sender");
 
     let token_value = record_kanidm_sdk_call(
         metrics,
@@ -434,8 +414,8 @@ async fn read_token_from_config_secret(
         Ok(s) => s,
         Err(kube::Error::Api(e)) if e.code == 404 => {
             debug!(
-                msg = "mail sender config secret not found, will regenerate token",
-                name
+                name,
+                "mail sender config secret not found, will regenerate token"
             );
             return Ok(None);
         }
@@ -474,9 +454,8 @@ async fn read_token_from_config_secret(
         }
         None => {
             debug!(
-                msg =
-                    "mail sender config secret missing mail-sender.toml key, will regenerate token",
-                name
+                name,
+                "mail sender config secret missing mail-sender.toml key, will regenerate token"
             );
             Ok(None)
         }
@@ -490,7 +469,7 @@ fn create_config_secret(
     token: &str,
     smtp_credentials: &SmtpCredentials,
 ) -> Result<Secret> {
-    debug!(msg = "creating config secret", name);
+    debug!(name, "creating config secret");
 
     let domain = &kanidm.spec.domain;
     let default_origin = format!("https://{domain}");
@@ -565,7 +544,7 @@ fn create_deployment(
     spec: &MailSenderSpec,
     config_secret_name: &str,
 ) -> Result<Deployment> {
-    debug!(msg = "creating deployment", name);
+    debug!(name, "creating deployment");
 
     let namespace = kanidm.namespace().unwrap();
     let image = spec.image.clone().unwrap_or_else(|| {
@@ -742,10 +721,7 @@ pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Re
             changed = true;
         }
         Err(kube::Error::Api(e)) if e.code == 404 => {
-            debug!(
-                msg = "mail sender deployment already absent",
-                deployment_name
-            );
+            debug!(deployment_name, "mail sender deployment already absent");
         }
         Err(e) => {
             return Err(Error::kube_error(
@@ -764,8 +740,8 @@ pub async fn cleanup_mail_sender_resources(kanidm: &Kanidm, ctx: &Context) -> Re
         }
         Err(kube::Error::Api(e)) if e.code == 404 => {
             debug!(
-                msg = "mail sender config secret already absent",
-                config_secret_name
+                config_secret_name,
+                "mail sender config secret already absent"
             );
         }
         Err(e) => {
@@ -790,10 +766,7 @@ pub async fn cleanup_mail_sender_in_kanidm(
     let sa_name = mail_sender_service_account_name(kanidm_name);
     let mut changed = false;
 
-    debug!(
-        msg = "removing mail sender from message_senders group",
-        sa_name
-    );
+    debug!(sa_name, "removing mail sender from message_senders group");
     let start = tokio::time::Instant::now();
     let remove_result = kanidm_client
         .idm_group_remove_members(MESSAGE_SENDERS_GROUP, &[&sa_name])
@@ -809,7 +782,7 @@ pub async fn cleanup_mail_sender_in_kanidm(
             changed = true;
         }
         Err(e) if is_not_found_error(&e) || is_not_a_member_error(&e) => {
-            debug!(msg = "mail sender group membership already absent", sa_name);
+            debug!(sa_name, "mail sender group membership already absent");
             metrics.record_kanidm_sdk_outcome(
                 KANIDM_RESOURCE_MAIL_SENDER,
                 KANIDM_OP_REMOVE_MEMBERS,
@@ -831,7 +804,7 @@ pub async fn cleanup_mail_sender_in_kanidm(
         }
     }
 
-    debug!(msg = "deleting mail sender service account", sa_name);
+    debug!(sa_name, "deleting mail sender service account");
     let start = tokio::time::Instant::now();
     let delete_result = kanidm_client.idm_service_account_delete(&sa_name).await;
     match delete_result {
@@ -845,7 +818,7 @@ pub async fn cleanup_mail_sender_in_kanidm(
             changed = true;
         }
         Err(e) if is_not_found_error(&e) => {
-            debug!(msg = "mail sender service account already absent", sa_name);
+            debug!(sa_name, "mail sender service account already absent");
             metrics.record_kanidm_sdk_outcome(
                 KANIDM_RESOURCE_MAIL_SENDER,
                 KANIDM_OP_DELETE,

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -440,10 +440,10 @@ pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<
         .kaniop_ctx
         .metrics
         .reconcile_count_and_measure(&trace_id);
-    info!(msg = "reconciling Kanidm");
+    info!("reconciling Kanidm");
 
     let status = kanidm.update_status(ctx.clone()).await.map_err(|e| {
-        debug!(msg = "failed to reconcile status", %e);
+        debug!(%e, "failed to reconcile status");
         ctx.kaniop_ctx.metrics.status_update_errors_inc();
         e
     })?;
@@ -473,7 +473,7 @@ pub async fn reconcile_kanidm(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<
     .await
     .or_else(|e| match e {
         FinalizerError::RemoveFinalizer(kube::Error::Api(ae)) if ae.code == 404 => {
-            debug!(msg = "resource already removed during finalizer cleanup");
+            debug!("resource already removed during finalizer cleanup");
             Ok(Action::requeue(DEFAULT_RECONCILE_INTERVAL))
         }
         _ => Err(Error::FinalizerError(
@@ -615,11 +615,11 @@ async fn reconcile_service(
                 let current_headless = is_headless_service(&current);
                 if current_headless != desired_headless {
                     info!(
-                        msg = "recreating Service to change headless mode",
                         resource.name = &name,
                         resource.namespace = &namespace,
                         current_headless,
                         desired_headless,
+                        "recreating Service to change headless mode"
                     );
                     kanidm.delete(ctx, &current).await?;
                     ctx.kaniop_ctx
@@ -807,12 +807,7 @@ async fn reconcile_statefulset(
                     validate_statefulset_replacement(&api, &latest_desired, &namespace, &name)
                         .await?;
 
-                    info!(
-                        msg = "recreating StatefulSet because immutable fields changed",
-                        resource.name = %name,
-                        resource.namespace = %namespace,
-                        ?immutable_fields,
-                    );
+                    info!(resource.name = %name, resource.namespace = %namespace, ?immutable_fields, "recreating StatefulSet because immutable fields changed");
                     kanidm.delete(&ctx, &latest_current).await?;
                     ctx.kaniop_ctx
                         .metrics
@@ -968,7 +963,7 @@ async fn reconcile(
                 )
                 .await
                 .map_err(|e| {
-                    warn!(msg = "failed to publish KanidmError event", %e);
+                    warn!(%e, "failed to publish KanidmError event");
                     Error::KubeError("failed to publish event".to_string(), Box::new(e))
                 });
             try_join_all([])
@@ -1174,11 +1169,11 @@ async fn reconcile(
                 if let Err(e) =
                     reconcile_domain_appearance(&kanidm, system_client, &status, ctx.clone()).await
                 {
-                    warn!(msg = "failed to reconcile domain appearance", %e);
+                    warn!(%e, "failed to reconcile domain appearance");
                 }
             }
             Err(e) => {
-                warn!(msg = "failed to create admin client for domain appearance reconciliation", %e);
+                warn!(%e, "failed to create admin client for domain appearance reconciliation");
             }
         }
 
@@ -1195,7 +1190,7 @@ async fn reconcile(
                     reconcile_mail_sender(&kanidm, kanidm_client.clone(), ctx.clone())
                         .await
                         .unwrap_or_else(|e| {
-                            warn!(msg = "failed to reconcile mail sender", %e);
+                            warn!(%e, "failed to reconcile mail sender");
                             (None, false)
                         });
                 if mail_sender_mutated {
@@ -1215,12 +1210,12 @@ async fn reconcile(
                         .patch_status(&name, &PatchParams::default(), &Patch::Merge(&status_patch))
                         .await
                     {
-                        warn!(msg = "failed to patch Kanidm/status for mail sender", %e);
+                        warn!(%e, "failed to patch Kanidm/status for mail sender");
                     }
                 }
             }
             Err(e) => {
-                warn!(msg = "failed to create idm_admin client for mail sender reconciliation", %e);
+                warn!(%e, "failed to create idm_admin client for mail sender reconciliation");
             }
         }
     }
@@ -1229,7 +1224,7 @@ async fn reconcile(
 }
 
 async fn cleanup(kanidm: Arc<Kanidm>, ctx: Arc<Context>) -> Result<(Action, bool)> {
-    debug!(msg = "cleanup");
+    debug!("cleanup");
 
     let mut changed = false;
     let mail_resources_cleaned = cleanup_mail_sender_resources(&kanidm, &ctx).await?;
@@ -1339,11 +1334,9 @@ async fn show_replica_cert_with_retries(
             Ok(cert) => return Ok(cert),
             Err(e) => {
                 info!(
-                    msg = format!(
-                        "show-replication-certificate attempt {}/{} failed for {pod_name}: {e}",
-                        attempt + 1,
-                        max_attempts
-                    )
+                    "show-replication-certificate attempt {}/{} failed for {pod_name}: {e}",
+                    attempt + 1,
+                    max_attempts
                 );
                 last_error = Some(e);
             }
@@ -1531,7 +1524,7 @@ impl Kanidm {
                     if !e.is_retryable() {
                         return Err(e);
                     }
-                    trace!(msg = "pod readiness check failed, retrying", %e);
+                    trace!(%e, "pod readiness check failed, retrying");
                 }
             }
 
@@ -1552,10 +1545,10 @@ impl Kanidm {
     {
         let namespace = &self.get_namespace();
         trace!(
-            msg = "pod exec",
             resource.name = &pod_name,
             resource.namespace = &namespace,
-            ?command
+            ?command,
+            "pod exec"
         );
         let pod = Api::<Pod>::namespaced(ctx.kaniop_ctx.client.clone(), namespace);
         let attached = pod

--- a/libs/operator/src/kanidm/reconcile/secret.rs
+++ b/libs/operator/src/kanidm/reconcile/secret.rs
@@ -100,7 +100,7 @@ impl SecretExt for Kanidm {
     }
 
     async fn update_replica_secret(&self, ctx: Arc<Context>, pod_name: &str) -> Result<Secret> {
-        info!(msg = format!("renewing replica certificate for pod {pod_name}"));
+        info!("renewing replica certificate for pod {pod_name}");
         self.renew_replica_cert(ctx.clone(), pod_name).await?;
         let cert = self.show_replica_cert(ctx.clone(), pod_name).await?;
         Ok(self.build_replica_secret(cert, pod_name))

--- a/libs/operator/src/kanidm/reconcile/status.rs
+++ b/libs/operator/src/kanidm/reconcile/status.rs
@@ -71,7 +71,7 @@ impl StatusExt for Kanidm {
                 )
                 .await
                 .map_err(|e| {
-                    warn!(msg = "failed to publish VersionIncompatible event", %e);
+                    warn!(%e, "failed to publish VersionIncompatible event");
                     Error::KubeError("failed to publish event".to_string(), Box::new(e))
                 });
             VersionCompatibilityResult::Incompatible
@@ -137,18 +137,9 @@ impl StatusExt for Kanidm {
                                     labels.get(SECRET_TYPE_LABEL) == Some(&replica_cert_label)
                                 });
                             if !has_replica_cert_label {
-                                warn!(
-                                    msg = "replica certificate secret is missing the required replica-cert label and will be ignored",
-                                    namespace,
-                                    name = secret_name,
-                                );
+                                warn!(namespace, name = secret_name, "replica certificate secret is missing the required replica-cert label and will be ignored");
                             } else if let Err(e) = ctx.insert_repl_cert_exp(secret).await {
-                                warn!(
-                                    msg = "failed to parse replica certificate secret, automatic certificate renewal may be affected",
-                                    namespace,
-                                    name = secret_name,
-                                    %e
-                                );
+                                warn!(namespace, name = secret_name, %e, "failed to parse replica certificate secret, automatic certificate renewal may be affected");
                             }
                         }
 
@@ -157,12 +148,12 @@ impl StatusExt for Kanidm {
                                 let now = Timestamp::now().as_second();
                                 // 1 month in seconds
                                 let threshold = 30 * 24 * 60 * 60;
-                                trace!(msg = format!("replica cert expiration {exp}, now {now}, threshold {threshold}"));
+                                trace!("replica cert expiration {exp}, now {now}, threshold {threshold}");
                                 exp - now < threshold
                             });
                         let is_certificate_host_valid = ctx.get_repl_cert_host(&secret_ref).await.map(|h| {
                                 let matches = Some(h.clone()) == replication_host;
-                                trace!(msg = format!("replica cert host {h}, expected host {:?}, matches {matches}", replication_host));
+                                trace!("replica cert host {h}, expected host {:?}, matches {matches}", replication_host);
                                 matches
                             });
                         ReplicaInformation {
@@ -221,7 +212,7 @@ impl StatusExt for Kanidm {
                 },
             }
         } else {
-            debug!(msg = "upgrade checks are disabled");
+            debug!("upgrade checks are disabled");
             None
         };
 
@@ -267,8 +258,8 @@ impl StatusExt for Kanidm {
         let new_status_patch = serde_json::json!({
             "status": new_status.clone()
         });
-        debug!(msg = "updating Kanidm status");
-        trace!(msg = format!("new status {:?}", new_status_patch));
+        debug!("updating Kanidm status");
+        trace!("new status {:?}", new_status_patch);
         let patch = PatchParams::default();
         let _o = kanidm_api
             .patch_status(name, &patch, &Patch::Merge(&new_status_patch))
@@ -286,7 +277,7 @@ impl StatusExt for Kanidm {
 impl Kanidm {
     async fn run_upgrade_pre_check(&self, ctx: Arc<Context>) -> KanidmUpgradeCheckResult {
         let upgrade_check = vec!["kanidmd", "domain", "upgrade-check"];
-        debug!(msg = "running kanidmd domain upgrade-check");
+        debug!("running kanidmd domain upgrade-check");
 
         const MAX_RETRIES: u32 = 5;
         const RETRY_DELAY_MS: u64 = 2000;
@@ -295,21 +286,21 @@ impl Kanidm {
             let result = self.exec_any(ctx.clone(), upgrade_check.clone()).await;
             match result {
                 Ok(r) => {
-                    debug!(msg = format!("kanidmd domain upgrade-check passed: {:?}", r));
+                    debug!("kanidmd domain upgrade-check passed: {:?}", r);
                     return KanidmUpgradeCheckResult::Passed;
                 }
                 Err(e) => {
-                    debug!(msg = format!("kanidmd domain upgrade-check failed (attempt {})", attempt + 1), %e);
+                    debug!(%e, "kanidmd domain upgrade-check failed (attempt {})", attempt + 1);
                     if attempt < MAX_RETRIES - 1 {
-                        trace!(msg = "kanidmd domain upgrade-check failed, retrying", %e);
+                        trace!(%e, "kanidmd domain upgrade-check failed, retrying");
                         sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
                     } else {
                         match e {
                             Error::KubeExecError(e_msg) => {
-                                warn!(msg = "`kanidmd domain upgrade-check` failed", %e_msg);
+                                warn!(%e_msg, "`kanidmd domain upgrade-check` failed");
                             }
                             _ => {
-                                warn!(msg = "`kanidmd domain upgrade-check` failed after retries", %e);
+                                warn!(%e, "`kanidmd domain upgrade-check` failed after retries");
                             }
                         }
                         let _ignore_error = ctx
@@ -327,7 +318,7 @@ impl Kanidm {
                             )
                             .await
                             .map_err(|e| {
-                                warn!(msg = "failed to publish KanidmError event", %e);
+                                warn!(%e, "failed to publish KanidmError event");
                                 Error::KubeError("failed to publish event".to_string(), Box::new(e))
                             });
                     }
@@ -393,10 +384,10 @@ fn generate_status(
             statefulset_name: ri.statefulset_name.clone(),
             state: if ri.replica_secret_exists || !is_replication_enabled {
                 if ri.is_certificate_expiring == Some(true) {
-                    debug!(msg = format!("replica cert is expiring for pod {}", ri.pod_name));
+                    debug!("replica cert is expiring for pod {}", ri.pod_name);
                     KanidmReplicaState::CertificateExpiring
                 } else if ri.is_certificate_host_valid == Some(false) {
-                    debug!(msg = format!("replica cert host is invalid for pod {}", ri.pod_name));
+                    debug!("replica cert host is invalid for pod {}", ri.pod_name);
                     KanidmReplicaState::CertificateHostInvalid
                 } else {
                     KanidmReplicaState::Ready

--- a/libs/operator/src/telemetry.rs
+++ b/libs/operator/src/telemetry.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::dispatcher::SetGlobalDefaultError;
 use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, Registry};
 
@@ -52,23 +53,45 @@ pub fn get_trace_id() -> TraceId {
 ///
 /// This enum derives `clap::ValueEnum` for use in command-line argument parsing,
 /// and is serialized in lowercase when used with `serde`.
-#[derive(clap::ValueEnum, Clone, Debug, Serialize)]
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {
-    /// JSON-formatted log output.
+    /// Newline-delimited JSON (NDJSON), with exactly one JSON object per event line.
     Json,
 
-    /// Plain-text log output.
+    /// Compact, human-readable plain-text log output.
     Text,
+}
+
+fn logger_layer<W>(
+    log_format: LogFormat,
+    writer: W,
+) -> Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>
+where
+    W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+{
+    match log_format {
+        // `json()` already emits compact NDJSON. Calling `compact()` after `json()` would switch
+        // the event formatter back to compact text while retaining JSON field formatting.
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .json()
+            .boxed(),
+        LogFormat::Text => tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .compact()
+            .boxed(),
+    }
 }
 
 /// Initializes logging and tracing subsystems.
 ///
 /// This asynchronous function configures and initializes logging and tracing
-/// according to the provided format and filtering parameters. It supports
-/// both JSON and plain-text log formats, as well as OpenTelemetry tracing
-/// when a tracing URL is specified. If OpenTelemetry is enabled, traces are
-/// sent to the given URL using OTLP over gRPC.
+/// according to the provided format and filtering parameters. JSON output uses
+/// newline-delimited JSON (NDJSON): every tracing event is one complete JSON object
+/// on one physical output line. It also supports OpenTelemetry tracing when a tracing
+/// URL is specified. If OpenTelemetry is enabled, traces are sent to the given URL
+/// using OTLP over HTTP.
 ///
 /// # Example
 ///
@@ -77,44 +100,29 @@ pub enum LogFormat {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Initialize tracing with a JSON log format and a log filter of "info".
 ///     let opentelemetry_endpoint_url = std::env::var("OPENTELEMETRY_ENDPOINT_URL").ok();
 ///     init("info", LogFormat::Text, opentelemetry_endpoint_url.as_deref(), 0.1)
 ///         .await?;
-///
-///     // Application logic here...
 ///
 ///     Ok(())
 /// }
 /// ```
 ///
-/// In this example, the logging system is initialized with a plain-text format,
-/// an `info` log level filter, and tracing disabled (as `None` is passed for the `some_tracing_url`).
-///
 /// # OpenTelemetry Integration
 ///
-/// When a tracing URL is provided, OpenTelemetry tracing is configured using
-/// OTLP (OpenTelemetry Protocol) over gRPC. The function creates a tracing pipeline
-/// with a ratio-based trace sampler and a default random trace ID generator.
-/// Traces will be sampled based on the `trace_ratio` provided.
-///
-/// The function sets a global tracing subscriber using the combination of
-/// the [`tracing_subscriber`] logger and optionally the OpenTelemetry tracer if enabled.
-///
-/// If the tracing subsystem is successfully configured, the function returns
-/// `Ok(())`, otherwise an appropriate error is returned.
+/// When a tracing URL is provided, OpenTelemetry tracing is configured using OTLP.
+/// The function creates a tracing pipeline with a ratio-based trace sampler and a
+/// default random trace ID generator. Traces will be sampled based on the
+/// `trace_ratio` provided.
 pub async fn init(
     log_filter: &str,
     log_format: LogFormat,
     tracing_url: Option<&str>,
     trace_ratio: f64,
 ) -> Result<(), Error> {
-    let logger = match log_format {
-        LogFormat::Json => tracing_subscriber::fmt::layer().json().compact().boxed(),
-        LogFormat::Text => tracing_subscriber::fmt::layer().compact().boxed(),
-    };
+    let logger = logger_layer(log_format, std::io::stdout);
 
-    // Safe unwrap: log_filter is a valid filter directive
+    // Safe unwrap: the static directive is valid.
     let filter = EnvFilter::new(log_filter).add_directive("kanidm_client=error".parse().unwrap());
 
     let collector = Registry::default().with(logger).with(filter);
@@ -148,6 +156,98 @@ pub async fn init(
             .map_err(Error::SetGlobalDefaultError)
     } else {
         tracing::subscriber::set_global_default(collector).map_err(Error::SetGlobalDefaultError)
+    }
+}
+
+#[cfg(test)]
+mod format_tests {
+    use super::*;
+
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::Value;
+
+    #[derive(Clone, Default)]
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct TestWriterGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl TestWriter {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for TestWriter {
+        type Writer = TestWriterGuard;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            TestWriterGuard(self.0.clone())
+        }
+    }
+
+    impl Write for TestWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn json_format_is_one_object_per_line_with_canonical_message() {
+        let writer = TestWriter::default();
+        let subscriber = Registry::default().with(logger_layer(LogFormat::Json, writer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(controller = "test", attempts = 3_u64, "starting controller");
+            tracing::warn!(error = "retryable", "controller retry scheduled");
+        });
+
+        let output = writer.contents();
+        let lines = output
+            .lines()
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), 2, "each event must occupy exactly one line");
+
+        let events = lines
+            .iter()
+            .map(|line| serde_json::from_str::<Value>(line).expect("log line must be valid JSON"))
+            .collect::<Vec<_>>();
+
+        for event in &events {
+            assert!(event.is_object());
+            assert!(event.get("timestamp").is_some());
+            assert!(event.get("level").is_some());
+            assert!(event.get("target").is_some());
+            assert!(event.get("fields").is_some_and(Value::is_object));
+            assert!(event["fields"].get("msg").is_none());
+        }
+
+        assert_eq!(events[0]["level"], "INFO");
+        assert_eq!(events[0]["fields"]["message"], "starting controller");
+        assert_eq!(events[0]["fields"]["controller"], "test");
+        assert_eq!(events[0]["fields"]["attempts"], 3);
+    }
+
+    #[test]
+    fn text_format_remains_human_readable() {
+        let writer = TestWriter::default();
+        let subscriber = Registry::default().with(logger_layer(LogFormat::Text, writer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(controller = "test", "starting controller");
+        });
+
+        let output = writer.contents();
+        assert!(output.contains("starting controller"));
+        assert!(serde_json::from_str::<Value>(output.trim()).is_err());
     }
 }
 

--- a/libs/person/src/controller.rs
+++ b/libs/person/src/controller.rs
@@ -81,7 +81,7 @@ pub async fn run(state: State, client: Client) {
 
     let ctx = Arc::new(Context::new(state.to_context(client, CONTROLLER_ID)));
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
     // TODO: watcher::Config::default().streaming_lists() when stabilized in K8s
     // https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
     let person_controller = Controller::new(person, watcher::Config::default().any_semantic())

--- a/libs/person/src/reconcile.rs
+++ b/libs/person/src/reconcile.rs
@@ -58,7 +58,7 @@ pub async fn watched_resource(person: &KanidmPersonAccount, ctx: Arc<Context>) -
     let kanidm = if let Some(k) = ctx.kaniop_ctx.get_kanidm(person) {
         k
     } else {
-        trace!(msg = "no kanidm found");
+        trace!("no kanidm found");
         return false;
     };
 
@@ -83,13 +83,13 @@ pub async fn reconcile_person_account(
         .metrics
         .reconcile_count_and_measure(&trace_id);
     if !ctx.kaniop_ctx.kanidm_write_allowed(&person) {
-        debug!(msg = "Kanidm restore in progress, pausing identity writes");
+        debug!("Kanidm restore in progress, pausing identity writes");
         return Ok((Action::requeue(Duration::from_secs(5)), false));
     }
     let kanidm_client = ctx.get_idm_client(&person).await?;
 
     if !watched_resource(&person, ctx.clone()).await {
-        debug!(msg = "resource not watched, skipping reconcile");
+        debug!("resource not watched, skipping reconcile");
         ctx.kaniop_ctx
             .recorder
             .publish(
@@ -104,19 +104,19 @@ pub async fn reconcile_person_account(
             )
             .await
             .map_err(|e| {
-                warn!(msg = "failed to publish ResourceNotWatched event", %e);
+                warn!(error = %e, "failed to publish ResourceNotWatched event");
                 Error::kube_error("publish", "event", person.get_namespace(), person.name_any(), e)
             })?;
         return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
-    info!(msg = "reconciling person account");
+    info!("reconciling person account");
 
     let namespace = person.get_namespace();
     let status = person
         .update_status(kanidm_client.clone(), ctx.clone())
         .await
         .map_err(|e| {
-            debug!(msg = "failed to reconcile status", %e);
+            debug!(error = %e, "failed to reconcile status");
             ctx.kaniop_ctx.metrics.status_update_errors_inc();
             e
         })?;
@@ -147,7 +147,7 @@ pub async fn reconcile_person_account(
     .await
     .or_else(|e| match e {
         FinalizerError::RemoveFinalizer(kube::Error::Api(ae)) if ae.code == 404 => {
-            debug!(msg = "resource already removed during finalizer cleanup");
+            debug!("resource already removed during finalizer cleanup");
             Ok(Action::requeue(idm_reconcile_interval()))
         }
         _ => Err(Error::FinalizerError(
@@ -194,7 +194,7 @@ impl KanidmPersonAccount {
                         )
                         .await
                         .map_err(|e| {
-                            warn!(msg = "failed to publish KanidmError event", %e);
+                            warn!(error = %e, "failed to publish KanidmError event");
                             Error::kube_error(
                                 "publish",
                                 "event",
@@ -224,10 +224,10 @@ impl KanidmPersonAccount {
         let mut actions = Vec::new();
         if is_person_false(TYPE_EXISTS, status.clone()) {
             debug!(
-                msg = "condition triggered action",
                 condition = TYPE_EXISTS,
                 status = CONDITION_FALSE,
-                action = "create"
+                action = "create",
+                "condition triggered action"
             );
             record_kanidm_sdk_call(
                 metrics,
@@ -243,10 +243,10 @@ impl KanidmPersonAccount {
         }
         if is_person_false(TYPE_UPDATED, status.clone()) {
             debug!(
-                msg = "condition triggered action",
                 condition = TYPE_UPDATED,
                 status = CONDITION_FALSE,
-                action = "update"
+                action = "update",
+                "condition triggered action"
             );
             self.update(&kanidm_client, name, metrics).await?;
             require_status_update = true;
@@ -259,10 +259,10 @@ impl KanidmPersonAccount {
                 && is_person(TYPE_POSIX_UPDATED, status.clone()))
         {
             debug!(
-                msg = "condition triggered action",
                 condition = TYPE_POSIX_UPDATED,
                 status = CONDITION_FALSE,
-                action = "update_posix_attributes"
+                action = "update_posix_attributes",
+                "condition triggered action"
             );
             record_kanidm_sdk_call(
                 metrics,
@@ -280,17 +280,17 @@ impl KanidmPersonAccount {
         if is_person_false(TYPE_CREDENTIAL, status) {
             let create_token = match ctx.internal_cache.read().await.get(&ObjectRef::from(self)) {
                 Some(expiry) if expiry > &OffsetDateTime::now_utc() => {
-                    trace!(msg = "token not expired, skipping creation");
+                    trace!("token not expired, skipping creation");
                     false
                 }
                 _ => true,
             };
             if create_token {
                 debug!(
-                    msg = "condition triggered action",
                     condition = TYPE_CREDENTIAL,
                     status = CONDITION_FALSE,
-                    action = "create_reset_token"
+                    action = "create_reset_token",
+                    "condition triggered action"
                 );
                 record_kanidm_sdk_call(
                     metrics,
@@ -305,16 +305,16 @@ impl KanidmPersonAccount {
         };
 
         if require_status_update {
-            debug!(msg = "requeueing in 500ms after actions", actions = ?actions);
+            debug!(actions = ?actions, "requeueing in 500ms after actions");
             Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
-            debug!(msg = "reconciliation complete, requeueing for next interval");
+            debug!("reconciliation complete, requeueing for next interval");
             Ok((Action::requeue(idm_reconcile_interval()), changed))
         }
     }
 
     async fn create(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "create");
+        debug!("create");
         kanidm_client
             .idm_person_account_create(name, &self.spec.person_attributes.displayname)
             .await
@@ -336,8 +336,8 @@ impl KanidmPersonAccount {
         name: &str,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = "update");
-        trace!(msg = format!("update person attributes {:?}", self.spec.person_attributes));
+        debug!("update");
+        trace!(person_attributes = ?self.spec.person_attributes, "updating person attributes");
         record_kanidm_sdk_call(
             metrics,
             KANIDM_RESOURCE_PERSON,
@@ -404,8 +404,8 @@ impl KanidmPersonAccount {
         kanidm_client: &KanidmClient,
         name: &str,
     ) -> Result<()> {
-        debug!(msg = "update posix attributes");
-        trace!(msg = format!("update posix attributes {:?}", self.spec.posix_attributes));
+        debug!("updating posix attributes");
+        trace!(posix_attributes = ?self.spec.posix_attributes, "updating posix attributes");
         kanidm_client
             .idm_person_account_unix_extend(
                 name,
@@ -437,7 +437,7 @@ impl KanidmPersonAccount {
         name: &str,
         ctx: Arc<Context>,
     ) -> Result<()> {
-        debug!(msg = "create reset token");
+        debug!("create reset token");
         let cu_token = kanidm_client
             .idm_person_account_credential_update_intent(
                 name,
@@ -489,7 +489,7 @@ impl KanidmPersonAccount {
             )
             .await
             .map_err(|e| {
-                warn!(msg = "failed to publish TokenCreated event", %e);
+                warn!(error = %e, "failed to publish TokenCreated event");
                 Error::kube_error("publish", "event", self.get_namespace(), self.name_any(), e)
             })?;
         ctx.internal_cache
@@ -509,7 +509,7 @@ impl KanidmPersonAccount {
         let mut changed = false;
 
         if is_person(TYPE_EXISTS, status.clone()) {
-            debug!(msg = "delete");
+            debug!("delete");
             record_kanidm_sdk_call(
                 &ctx.kaniop_ctx.metrics,
                 KANIDM_RESOURCE_PERSON,
@@ -580,9 +580,9 @@ impl KanidmPersonAccount {
             Ok(cs) => {
                 let present = cs.creds.is_empty().not();
                 trace!(
-                    msg = "credential status",
                     credential_present = present,
-                    creds_count = cs.creds.len()
+                    creds_count = cs.creds.len(),
+                    "credential status"
                 );
                 metrics.record_kanidm_sdk_outcome(
                     KANIDM_RESOURCE_PERSON,
@@ -604,11 +604,11 @@ impl KanidmPersonAccount {
                     Ok((session_token, status)) => {
                         let present = credential_update_status_has_credentials(&status);
                         trace!(
-                            msg = "credential status fallback",
                             credential_present = present,
                             primary_present = status.primary.is_some(),
                             passkeys_count = status.passkeys.len(),
-                            attested_passkeys_count = status.attested_passkeys.len()
+                            attested_passkeys_count = status.attested_passkeys.len(),
+                            "credential status fallback"
                         );
 
                         let cancel_result: std::result::Result<(), ClientError> = kanidm_client
@@ -616,8 +616,8 @@ impl KanidmPersonAccount {
                             .await;
                         if let Err(e) = cancel_result {
                             warn!(
-                                msg = "failed to cancel credential status fallback session",
-                                error = ?e
+                                error = ?e,
+                                "failed to cancel credential status fallback session"
                             );
                         }
 
@@ -630,7 +630,7 @@ impl KanidmPersonAccount {
                         Some(present)
                     }
                     Err(e) => {
-                        trace!(msg = "credential status fallback error", error = ?e);
+                        trace!(error = ?e, "credential status fallback error");
                         metrics.record_kanidm_sdk_outcome(
                             KANIDM_RESOURCE_PERSON,
                             KANIDM_OP_GET_CREDENTIAL_STATUS,
@@ -642,7 +642,7 @@ impl KanidmPersonAccount {
                 }
             }
             Err(e) => {
-                trace!(msg = "credential status error", error = ?e);
+                trace!(error = ?e, "credential status error");
                 metrics.record_kanidm_sdk_outcome(
                     KANIDM_RESOURCE_PERSON,
                     KANIDM_OP_GET_CREDENTIAL_STATUS,
@@ -655,7 +655,7 @@ impl KanidmPersonAccount {
 
         let status = self.generate_status(current_person, credential_present)?;
         if self.status.as_ref() == Some(&status) {
-            trace!(msg = "status unchanged, skipping patch");
+            trace!("status unchanged, skipping patch");
             return Ok(status);
         }
         if let Some(old) = self.status.as_ref() {
@@ -671,16 +671,16 @@ impl KanidmPersonAccount {
                 .flatten()
                 .map(|c| format!("{}={}", c.type_, c.status))
                 .collect();
-            debug!(msg = "status changed", old = ?old_conds, new = ?new_conds, old_ready = old.ready, new_ready = status.ready);
+            debug!(old = ?old_conds, new = ?new_conds, old_ready = old.ready, new_ready = status.ready, "status changed");
         } else {
-            debug!(msg = "initial status patch", conditions = ?status.conditions);
+            debug!(conditions = ?status.conditions, "initial status patch");
         }
         let status_patch = Patch::Apply(KanidmPersonAccount {
             status: Some(status.clone()),
             ..KanidmPersonAccount::default()
         });
-        debug!(msg = "updating status");
-        trace!(msg = format!("status patch {:?}", status_patch));
+        debug!("updating status");
+        trace!(status_patch = ?status_patch, "status patch");
         let patch = PatchParams::apply(PERSON_OPERATOR_NAME).force();
         let kanidm_api =
             Api::<KanidmPersonAccount>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);
@@ -754,7 +754,6 @@ impl KanidmPersonAccount {
                 } else {
                     let spec = &self.spec.person_attributes;
                     debug!(
-                        msg = "person attributes mismatch",
                         displayname_spec = %spec.displayname,
                         displayname_actual = %current_person_attributes.displayname,
                         mail_spec = ?spec.mail,
@@ -765,6 +764,7 @@ impl KanidmPersonAccount {
                         account_valid_from_actual = ?current_person_attributes.account_valid_from,
                         account_expire_spec = ?spec.account_expire,
                         account_expire_actual = ?current_person_attributes.account_expire,
+                        "person attributes mismatch"
                     );
                     Condition {
                         type_: TYPE_UPDATED.to_string(),
@@ -829,11 +829,11 @@ impl KanidmPersonAccount {
                         }
                     } else {
                         debug!(
-                            msg = "posix attributes mismatch",
                             gidnumber_spec = ?posix.gidnumber,
                             gidnumber_actual = ?current_person_posix.gidnumber,
                             loginshell_spec = ?posix.loginshell,
                             loginshell_actual = ?current_person_posix.loginshell,
+                            "posix attributes mismatch"
                         );
                         Condition {
                             type_: TYPE_POSIX_UPDATED.to_string(),

--- a/libs/service-account/src/controller.rs
+++ b/libs/service-account/src/controller.rs
@@ -89,7 +89,7 @@ pub async fn run(state: State, client: Client) {
         kaniop_ctx,
     );
 
-    info!(msg = format!("starting {CONTROLLER_ID} controller"));
+    info!(controller = CONTROLLER_ID, "starting controller");
     // TODO: watcher::Config::default().streaming_lists() when stabilized in K8s
     // https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
     let service_account_controller =

--- a/libs/service-account/src/reconcile/mod.rs
+++ b/libs/service-account/src/reconcile/mod.rs
@@ -53,7 +53,7 @@ pub async fn watched_resource(service_account: &KanidmServiceAccount, ctx: Arc<C
     let kanidm = if let Some(k) = ctx.kaniop_ctx.get_kanidm(service_account) {
         k
     } else {
-        trace!(msg = "no kanidm found");
+        trace!("no kanidm found");
         return false;
     };
 
@@ -78,13 +78,13 @@ pub async fn reconcile_service_account(
         .metrics
         .reconcile_count_and_measure(&trace_id);
     if !ctx.kaniop_ctx.kanidm_write_allowed(&service_account) {
-        debug!(msg = "Kanidm restore in progress, pausing identity writes");
+        debug!("Kanidm restore in progress, pausing identity writes");
         return Ok((Action::requeue(Duration::from_secs(5)), false));
     }
     let kanidm_client = ctx.get_idm_client(&service_account).await?;
 
     if !watched_resource(&service_account, ctx.clone()).await {
-        debug!(msg = "resource not watched, skipping reconcile");
+        debug!("resource not watched, skipping reconcile");
         ctx.kaniop_ctx
             .recorder
             .publish(
@@ -99,7 +99,7 @@ pub async fn reconcile_service_account(
             )
             .await
             .map_err(|e| {
-                warn!(msg = "failed to publish ResourceNotWatched event", %e);
+                warn!(%e, "failed to publish ResourceNotWatched event");
                 Error::kube_error(
                     "publish",
                     "event",
@@ -110,14 +110,14 @@ pub async fn reconcile_service_account(
             })?;
         return Ok((Action::requeue(idm_reconcile_interval()), false));
     }
-    info!(msg = "reconciling service account");
+    info!("reconciling service account");
 
     let namespace = service_account.get_namespace();
     let status = service_account
         .update_status(kanidm_client.clone(), ctx.clone())
         .await
         .map_err(|e| {
-            debug!(msg = "failed to reconcile status", %e);
+            debug!(%e, "failed to reconcile status");
             ctx.kaniop_ctx.metrics.status_update_errors_inc();
             e
         })?;
@@ -154,7 +154,7 @@ pub async fn reconcile_service_account(
     .await
     .or_else(|e| match e {
         FinalizerError::RemoveFinalizer(kube::Error::Api(ae)) if ae.code == 404 => {
-            debug!(msg = "resource already removed during finalizer cleanup");
+            debug!("resource already removed during finalizer cleanup");
             Ok(Action::requeue(idm_reconcile_interval()))
         }
         _ => Err(Error::FinalizerError(
@@ -239,7 +239,7 @@ impl KanidmServiceAccount {
                         )
                         .await
                         .map_err(|e| {
-                            warn!(msg = "failed to publish KanidmError event", %e);
+                            warn!(%e, "failed to publish KanidmError event");
                             Error::kube_error(
                                 "publish",
                                 "event",
@@ -317,7 +317,7 @@ impl KanidmServiceAccount {
 
         if is_service_account_false(TYPE_API_TOKENS, status.clone()) || api_token_needs_rotation {
             if api_token_needs_rotation {
-                info!(msg = "rotating API tokens due to rotation policy");
+                info!("rotating API tokens due to rotation policy");
             }
             self.update_api_tokens(&kanidm_client, name, &status, ctx.clone(), metrics)
                 .await?;
@@ -345,7 +345,7 @@ impl KanidmServiceAccount {
 
         if should_generate_credentials || should_rotate_credentials {
             if should_rotate_credentials {
-                info!(msg = "rotating credentials secret due to rotation policy");
+                info!("rotating credentials secret due to rotation policy");
             }
             let secret = record_kanidm_sdk_call(
                 metrics,
@@ -376,7 +376,7 @@ impl KanidmServiceAccount {
         }
 
         if require_status_update {
-            trace!(msg = "status update required, requeueing in 500ms");
+            trace!("status update required, requeueing in 500ms");
             Ok((Action::requeue(Duration::from_millis(500)), changed))
         } else {
             Ok((Action::requeue(idm_reconcile_interval()), changed))
@@ -384,7 +384,7 @@ impl KanidmServiceAccount {
     }
 
     async fn create(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "create");
+        debug!("create");
         kanidm_client
             .idm_service_account_create(
                 name,
@@ -405,12 +405,10 @@ impl KanidmServiceAccount {
     }
 
     async fn update(&self, kanidm_client: &KanidmClient, name: &str) -> Result<()> {
-        debug!(msg = "update");
+        debug!("update");
         trace!(
-            msg = format!(
-                "update service account attributes {:?}",
-                self.spec.service_account_attributes
-            )
+            "update service account attributes {:?}",
+            self.spec.service_account_attributes
         );
         kanidm_client
             .idm_service_account_update(
@@ -473,8 +471,8 @@ impl KanidmServiceAccount {
         kanidm_client: &KanidmClient,
         name: &str,
     ) -> Result<()> {
-        debug!(msg = "update posix attributes");
-        trace!(msg = format!("update posix attributes {:?}", self.spec.posix_attributes));
+        debug!("update posix attributes");
+        trace!("update posix attributes {:?}", self.spec.posix_attributes);
         kanidm_client
             .idm_service_account_unix_extend(
                 name,
@@ -508,9 +506,9 @@ impl KanidmServiceAccount {
         ctx: Arc<Context>,
         metrics: &kaniop_operator::metrics::ControllerMetrics,
     ) -> Result<()> {
-        debug!(msg = "update API tokens");
+        debug!("update API tokens");
         let api_tokens = self.spec.api_tokens.clone().unwrap_or_default();
-        trace!(msg = format!("API tokens to update: {:?}", api_tokens));
+        trace!("API tokens to update: {:?}", api_tokens);
 
         let tokens_to_rotate = match self
             .spec
@@ -590,7 +588,7 @@ impl KanidmServiceAccount {
             .into_iter()
             .map(KanidmAPIToken::from)
             .collect::<BTreeSet<_>>();
-        trace!(msg = format!("API tokens present: {:?}", &api_tokens_set));
+        trace!("API tokens present: {:?}", &api_tokens_set);
 
         let tokens_to_create = api_tokens
             .difference(&api_tokens_set)
@@ -729,7 +727,7 @@ impl KanidmServiceAccount {
         let mut changed = false;
 
         if is_service_account(TYPE_EXISTS, status.clone()) {
-            debug!(msg = "delete");
+            debug!("delete");
             record_kanidm_sdk_call(
                 &ctx.kaniop_ctx.metrics,
                 KANIDM_RESOURCE_SERVICE_ACCOUNT,

--- a/libs/service-account/src/reconcile/status.rs
+++ b/libs/service-account/src/reconcile/status.rs
@@ -152,7 +152,7 @@ impl StatusExt for KanidmServiceAccount {
         let status =
             self.generate_status(current_service_account, api_tokens, credentials_secret)?;
         if self.status.as_ref() == Some(&status) {
-            trace!(msg = "status unchanged, skipping patch");
+            trace!("status unchanged, skipping patch");
             return Ok(status);
         }
         if let Some(old) = self.status.as_ref() {
@@ -168,16 +168,16 @@ impl StatusExt for KanidmServiceAccount {
                 .flatten()
                 .map(|c| format!("{}={}", c.type_, c.status))
                 .collect();
-            debug!(msg = "status changed", old = ?old_conds, new = ?new_conds, old_ready = old.ready, new_ready = status.ready);
+            debug!(old = ?old_conds, new = ?new_conds, old_ready = old.ready, new_ready = status.ready, "status changed");
         } else {
-            debug!(msg = "initial status patch", conditions = ?status.conditions);
+            debug!(conditions = ?status.conditions, "initial status patch");
         }
         let status_patch = Patch::Apply(KanidmServiceAccount {
             status: Some(status.clone()),
             ..KanidmServiceAccount::default()
         });
-        debug!(msg = "updating status");
-        trace!(msg = format!("status patch {:?}", status_patch));
+        debug!("updating status");
+        trace!("status patch {:?}", status_patch);
         let patch = PatchParams::apply(SERVICE_ACCOUNT_OPERATOR_NAME).force();
         let kanidm_api =
             Api::<KanidmServiceAccount>::namespaced(ctx.kaniop_ctx.client.clone(), &namespace);


### PR DESCRIPTION
Closes #967.

This fixes structured JSON logging so each event is emitted as one NDJSON line, standardizes tracing messages on the trailing message syntax (`fields.message` in JSON), exposes log format and extra args through Helm, and adds regression coverage.

All existing legacy `msg = ...` tracing fields have been migrated repo-wide. The structured-logging checker scans every Rust source and rejects both legacy `msg = ...` and explicit `message = ...` event fields.

CI enforces this in two independent ways:
- it injects a multiline `tracing::info!(msg = ...)` fixture and requires the guard to reject it;
- it runs the checker directly against the real checkout and requires zero violations.

The same checker also remains wired into pre-commit. Runtime tests verify JSON logs parse one physical line at a time and use `fields.message`, and Helm tests cover `logging.format` and extra args for both operator and webhook.

The repo-wide migration itself passed `cargo fmt --all` and the zero-violations checker before being pushed. A PR CI run also proved the negative multiline fixture is rejected and the actual tree passes the structured-logging hook; subsequent CI runs are validating the final housekeeping commits.