### PR TITLE
docs: define operator architecture and safety boundaries

### DIFF
--- a/Documentation/src/SUMMARY.md
+++ b/Documentation/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Introduction](index.md)
+[Architecture](architecture.md)
 
 - [Getting Started](getting-started.md)
   - [Concepts](concepts.md)

--- a/Documentation/src/architecture.md
+++ b/Documentation/src/architecture.md
@@ -1,0 +1,121 @@
+---
+title: Architecture
+weight: 500
+---
+
+# Architecture
+
+Kaniop is a Kubernetes operator for Kanidm. Its role is to turn Kubernetes desired state into safe,
+repeatable operations on Kanidm clusters and identity resources.
+
+The architecture deliberately separates **orchestration policy** from **identity and data-plane
+correctness**. Kubernetes and Kaniop decide what the deployment should look like and reconcile it
+toward that state. Kanidm remains responsible for the semantics and invariants of identity,
+persistence, and replication.
+
+## Responsibility Boundary
+
+| Kaniop and Kubernetes | Kanidm |
+| --- | --- |
+| Desired cluster topology | Identity and authorization semantics |
+| Workload lifecycle and placement | Database correctness |
+| Storage and Kubernetes resource lifecycle | Replication protocol and conflict semantics |
+| Upgrade and replacement sequencing | Replication state and convergence semantics |
+| Maintenance and recovery orchestration | Safe server-side maintenance/recovery primitives |
+| Kubernetes status, events, and conditions | Machine-readable server/data-plane state |
+| Declarative identity-resource reconciliation | Validation and application of identity mutations |
+
+This boundary is a safety property, not only a code-organization preference. Kaniop should not
+reimplement Kanidm's distributed-system invariants, and Kanidm-specific correctness should not be
+inferred from generic Kubernetes state.
+
+## Reconciliation Is the Control Model
+
+A Kaniop reconcile loop may be interrupted, retried, or executed more than once. Workflows must be
+designed around that fact.
+
+Operations initiated by Kaniop should therefore be:
+
+- **idempotent**, or carry an operation identity that makes replay safe;
+- **observable**, so the reconciler can distinguish pending, successful, failed, and retryable
+  states;
+- **restart-safe**, so controller failover does not lose the meaning of an in-progress operation;
+- **convergent**, so repeated reconciliation moves the system toward the declared state rather than
+  depending on a one-shot sequence of imperative commands.
+
+Kubernetes resources and status are the durable control-plane record for orchestration. They are
+not a substitute for server-side evidence about the contents or safety of the identity database.
+
+## Kubernetes Health Is Not Database Correctness
+
+Kubernetes exposes valuable orchestration signals: Pod readiness, EndpointSlice membership,
+StatefulSet rollout state, volume attachment state, events, and object generations. Kaniop uses
+those signals for the questions they can answer.
+
+They do **not**, by themselves, prove distributed data invariants.
+
+For example:
+
+- a `Ready` Pod does not prove that it contains every write known to another replica;
+- a completed StatefulSet rollout does not prove replication convergence;
+- the absence of an error log does not prove that a replica is safe to remove;
+- timestamps and retry delays are not substitutes for replication state;
+- process liveness does not prove that an offline database operation is safe to start.
+
+When a workflow depends on a Kanidm data or replication invariant, Kaniop should prefer an explicit,
+machine-readable server signal or protocol that expresses that invariant. If Kanidm does not expose
+enough state to establish safety, Kaniop should use a conservative workflow rather than inventing a
+heuristic proof.
+
+## Mechanism and Policy
+
+Kaniop should decide **when and in what order** a cluster-level operation happens. The server should
+decide **whether the corresponding data-plane transition is valid and safe**.
+
+Examples include:
+
+- Kaniop may select a replica for maintenance; the server must provide the semantic state needed to
+  know when that replica can be taken out of service safely.
+- Kaniop may orchestrate a recovery; the server must define the rules that distinguish a valid
+  recovery from a conflicting history.
+- Kaniop may coordinate an upgrade; server compatibility and on-disk migration invariants remain
+  server responsibilities.
+
+This keeps generic infrastructure concerns in the Kubernetes control plane while keeping
+Kanidm-specific correctness in Kanidm.
+
+## Compatibility and Conservative Fallbacks
+
+Kaniop only automates an operation when it has a defensible safety model for that operation.
+Capabilities may differ between Kanidm versions, so workflows should discover or validate the
+signals and operations they depend on rather than assuming they exist.
+
+When a native semantic primitive is unavailable, a conservative compatibility workflow is
+acceptable if it preserves correctness. Kaniop should not preserve feature parity by parsing
+human-oriented logs, depending on CLI formatting, guessing from timing, or duplicating
+Kanidm's replication logic inside the operator.
+
+This principle intentionally allows availability or automation to be reduced when the alternative
+would be an unprovable data-safety assumption.
+
+## Non-goals
+
+Kaniop is not intended to:
+
+- implement a second database replication protocol or distributed consensus system;
+- infer replication convergence solely from Kubernetes health or rollout state;
+- use human-oriented logs as a stable control-plane API;
+- encode Kanidm database internals that should instead be expressed by supported server semantics;
+- make unsafe topology or maintenance transitions only to preserve an automated workflow;
+- replace Kubernetes with a separate generic orchestration substrate inside the operator.
+
+## Design Direction
+
+New operational features should preserve this boundary. When an implementation becomes complicated
+because Kaniop cannot observe or request a Kanidm-specific state transition directly, the preferred
+long-term solution is a small, explicit server-side primitive that can be consumed by a reconciler,
+not additional inference in the operator.
+
+The result should be a deliberately boring control loop: Kubernetes stores desired and observed
+orchestration state, Kaniop reconciles policy, and Kanidm provides the semantic guarantees required
+to manipulate identity and replicated data safely.

--- a/Documentation/src/index.md
+++ b/Documentation/src/index.md
@@ -5,24 +5,45 @@ weight: 0
 
 # Introduction
 
-Kaniop is a Kubernetes operator for managing [Kanidm](https://kanidm.com) clusters. By leveraging GitOps, it delivers a declarative way to handle identity management resources—such as persons, groups, OAuth2 integrations and more—through familiar Kubernetes manifests.
+Kaniop is a Kubernetes operator for managing [Kanidm](https://kanidm.com) clusters. By leveraging
+GitOps, it provides a declarative way to manage identity resources—such as persons, groups, OAuth2
+integrations, and more—through familiar Kubernetes manifests.
 
-This approach empowers teams to manage identity infrastructure with the same tools and workflows they already use for application deployments, ensuring consistency, scalability, and ease of use.
+Kaniop treats Kubernetes as the control plane for deployment and lifecycle orchestration. The
+operator continuously reconciles declared topology, configuration, workloads, storage, and identity
+resources while Kanidm remains responsible for identity, database, and replication semantics.
+
+This separation allows teams to manage identity infrastructure with the same reviewed, versioned,
+and observable workflows they use for other Kubernetes workloads without asking Kubernetes state
+to stand in for Kanidm's own correctness guarantees.
 
 ## What is Kanidm?
 
-Kanidm is a simple yet secure identity management platform, designed to act as a complete identity provider. It covers a broad spectrum of authentication and directory requirements, so you can offload user and resource management to Kanidm without needing extra components.
+Kanidm is a secure identity management platform designed to act as a complete identity provider. It
+covers a broad spectrum of authentication and directory requirements, allowing applications and
+systems to offload identity and authorization concerns to a dedicated service.
 
-By relying on strict defaults, self-healing mechanisms, and straightforward configuration, Kanidm can comfortably run anywhere—from small home labs to large enterprises.
+Kaniop manages the Kubernetes lifecycle around Kanidm; it does not replace Kanidm's responsibility
+for the safety and correctness of its persisted and replicated identity state.
 
-## Why Choose Kaniop?
+## Why Kaniop?
 
-Kaniop takes the complexity out of managing identity infrastructure by combining the power of Kanidm with Kubernetes' declarative and scalable nature.
+Operating a stateful identity service requires both generic infrastructure orchestration and
+application-specific knowledge. Kubernetes already provides a mature desired-state and
+reconciliation model for workloads, storage, placement, health signals, and extensible APIs. Kaniop
+adds the Kanidm-specific policy required to use those facilities safely.
 
-Whether you're deploying a single Kanidm cluster or managing multiple environments, Kaniop ensures a seamless experience with features like GitOps integration, multi-cluster support, and automated resource reconciliation.
+Kaniop therefore favors explicit reconciliation over imperative runbooks and explicit server
+semantics over heuristics. Kubernetes readiness, rollout state, timestamps, and logs remain useful
+operational signals, but workflows that depend on database or replication safety must use the best
+available Kanidm-specific evidence and fall back conservatively when that evidence is unavailable.
 
-It's the perfect solution for teams looking to modernize their identity management workflows while maintaining security and reliability.
+See [Architecture](architecture.md) for the responsibility boundary and design principles that guide
+new operational features.
 
 ## LLM and Automation Entry Point
 
-For LLM agents and automation that need a source-oriented operations map, use the published [`llm.txt`](https://pando85.github.io/llm.txt). It points to generated CRD schemas, generated examples, Helm values, and troubleshooting workflows so agents can prefer current authoritative sources over stale copied snippets.
+For LLM agents and automation that need a source-oriented operations map, use the published
+[`llm.txt`](https://pando85.github.io/llm.txt). It points to generated CRD schemas, generated
+examples, Helm values, and troubleshooting workflows so agents can prefer current authoritative
+sources over stale copied snippets.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ Kaniop is a Kubernetes operator for managing [Kanidm](https://kanidm.com).
 [Kanidm](https://kanidm.com) is a modern, secure identity management system that provides
 authentication and authorization services with support for POSIX accounts, OAuth2, and more.
 
-Kaniop automates deployment and management of Kanidm clusters to provide self-managing,
-self-scaling, and self-healing identity services. The Kaniop operator does this by building on
-Kubernetes resources to deploy, configure, provision, scale, upgrade, and monitor Kanidm clusters.
+Kaniop treats Kubernetes as the orchestration control plane for Kanidm deployments. It continuously
+reconciles desired cluster topology, workload lifecycle, storage, configuration, upgrades, and
+identity resources through standard Kubernetes APIs, while Kanidm remains responsible for identity,
+persistence, and replication semantics.
+
+Kaniop automates deployment and management of Kanidm clusters to provide declaratively managed,
+automatically reconciled, and observable identity services. The operator builds on Kubernetes
+resources to deploy, configure, provision, scale, upgrade, and monitor Kanidm clusters.
+
+When an operation depends on database or replication correctness, Kaniop prefers explicit,
+machine-readable server state and conservative workflows. Pod readiness, StatefulSet rollout state,
+log messages, and timestamps are useful orchestration signals, but they are not treated as proofs of
+data safety.
 
 The operator enables **declarative identity management** through GitOps workflows, allowing you to
 manage users, groups, OAuth2 clients, and other identity resources using familiar Kubernetes
@@ -20,12 +30,17 @@ manifests.
 
 Key capabilities include:
 
-- **Kanidm Cluster Management**: Deploy and manage high-availability Kanidm clusters with automatic
-  replication
+- **Kanidm Cluster Management**: Deploy and manage Kanidm clusters, including high-availability
+  topologies and replication configuration
 - **Identity Resources**: Declaratively manage persons, groups, OAuth2 clients, and service accounts
 - **GitOps Ready**: Full integration with Git-based workflows for infrastructure-as-code
-- **Kubernetes Native**: Built using Custom Resources and standard Kubernetes patterns
-- **Production Ready**: Comprehensive testing, monitoring, and observability features
+- **Kubernetes Native**: Built using Custom Resources and standard Kubernetes reconciliation
+  patterns
+- **Operational Safety**: Conservative stateful workflows with testing, monitoring, and
+  observability support
+
+For the design principles behind this separation of responsibilities, see the
+[Architecture](Documentation/src/architecture.md) documentation.
 
 ## Getting Started and Documentation
 


### PR DESCRIPTION
## Summary

Document the architectural boundary that already guides Kaniop's safer stateful workflows without changing Kaniop's public positioning as a Kubernetes operator for Kanidm.

This PR:

- adds a dedicated **Architecture** page describing the responsibility split between Kaniop/Kubernetes and Kanidm;
- defines reconciliation requirements: idempotency, restart safety, observability, and convergence;
- makes an explicit distinction between Kubernetes orchestration signals and database/replication correctness;
- documents the preference for semantic, machine-readable server state and conservative fallbacks over heuristics;
- states non-goals such as reimplementing replication/consensus or parsing human-oriented logs as a control-plane API;
- updates the README and documentation introduction to reflect those principles;
- replaces broad `self-managing`, `self-scaling`, and `self-healing` wording with more precise reconciliation-oriented language.

## Motivation

Kaniop increasingly orchestrates operations where generic Kubernetes state is not sufficient to establish data safety. A Pod can be `Ready` without proving replication convergence; a StatefulSet rollout can complete without proving that a surviving replica contains another replica's acknowledged history; logs and timestamps are useful diagnostics but are not distributed-system proofs.

Those ideas already appear in concrete design work such as maintenance and recovery, but they are currently local implementation decisions rather than project-level architecture. That makes it too easy for future features to solve a missing server semantic by adding timing assumptions, log parsing, or replicated-state logic to the operator.

This PR makes the boundary durable and reviewable:

> Kubernetes stores desired/observed orchestration state, Kaniop reconciles cluster policy, and Kanidm remains authoritative for identity, persistence, replication, and the semantic conditions that make data-plane transitions safe.

## Design principles introduced

### Orchestration policy vs. data-plane correctness

Kaniop decides *when and in what order* a cluster-level operation should happen. Kanidm decides whether the corresponding identity/database/replication transition is valid.

### Kubernetes health is not database correctness

Pod readiness, EndpointSlices, StatefulSet status, events, timestamps, and volume state remain important inputs, but Kaniop must not elevate them into proofs for invariants they cannot express.

### Reconciler-friendly operations

Long-running workflows must tolerate controller restart and request replay. Native operations should therefore be idempotent or carry stable operation identities and expose machine-readable progress.

### Conservative compatibility

If a required semantic primitive is unavailable, a conservative workflow with reduced availability is preferable to an optimistic heuristic. Kaniop should not preserve automation parity by duplicating Kanidm internals in controller code.

## Scope and non-goals

This is intentionally a documentation-only architecture PR.

It does **not**:

- introduce or advertise another identity-server distribution;
- change Kaniop's public positioning as an operator for Kanidm;
- change CRDs, controller behavior, compatibility, or runtime code;
- require new Kanidm APIs today;
- claim that Kubernetes itself proves application-level correctness.

The goal is to establish principles that future implementations can be evaluated against without forcing a product-direction decision now.

## Validation

- Documentation navigation updated to include the new Architecture page.
- README and docs introduction reviewed for consistency with the new boundary.
- No generated files, CRDs, examples, or runtime code are changed.
