### PR TITLE
fix(backup): resolve field-manager conflicts, orphan Jobs, OAuth2 reconcile storms, and backup documentation gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,6 +3282,7 @@ dependencies = [
  "kaniop-crd-migration",
  "kube",
  "rustls",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,9 +3278,12 @@ version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",
+ "k8s-openapi",
  "kaniop-crd-migration",
  "kube",
  "rustls",
+ "serde_json",
+ "serde_yaml",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Documentation/src/usage/backup-restore.md
+++ b/Documentation/src/usage/backup-restore.md
@@ -11,6 +11,158 @@ spec:
 
 Local backups require PVC-backed storage and one `replicaGroup` with `primaryNode: true`. Kaniop intentionally does not claim PITR semantics or a globally atomic point-in-time cut across replicated writable nodes.
 
+## Remote Backups (S3-Compatible Repositories)
+
+Kaniop supports remote backup repositories for disaster recovery. This uses three additional resources:
+
+- **KanidmBackupRepository**: Defines an S3-compatible destination with authentication, encryption, and transport limits.
+- **KanidmBackupSchedule**: The single source of the Kanidm online backup cron, local retention, and remote retention policy. Only one Schedule may target a given Kanidm at a time.
+- **KanidmBackup**: Immutable catalog metadata for a committed remote backup. These are discovered automatically from remote manifests.
+
+### Online Backup Transport: Experimental Status
+
+The `TransportExperimental` condition on `KanidmBackupSchedule` indicates that the online backup transport (moving backups from the Kanidm PVC to the remote repository) is **experimental and not production-supported**.
+
+**What this means:**
+
+- Kanidm has no documented completion contract for online backups. It writes directly to the final filename with no atomic rename, completion marker, or event that an external data mover can use as an unambiguous completion signal.
+- Kaniop's data mover uses file stability heuristics (size, mtime, checksums) to detect when a backup is complete, but these are **not a production completion contract**.
+- Kaniop **does not report production backup success** based on these heuristics alone. A `Ready` condition on the Schedule means the schedule is configured, not that backups are successfully committed to the remote repository.
+
+**What is production-supported:**
+
+- Restore from a committed backup (one with a valid manifest.json) is production-supported.
+- The safety backup created before restore is production-supported.
+- Local backups on the Kanidm PVC are production-supported for single-cluster recovery.
+
+**When will transport become production-supported?**
+
+Online transport becomes production-supported only after Kanidm documents and Kaniop tests a minimum-version completion contract such as:
+
+- Atomic rename from a temporary filename after successful close
+- A completion marker written after close
+- An authenticated event/API returning a completed path
+- Native upstream object-storage shipping with equivalent commit semantics
+
+Until then, use CSI/Velero snapshots as an independent disaster-recovery layer if you require production-grade remote backups.
+
+### Schedule and Retention Immutability
+
+The following fields on `KanidmBackupSchedule` are **immutable after the first backup has been discovered**:
+
+- `kanidmRef`: The target Kanidm instance
+- `repositoryRef`: The target repository
+- `schedule`: The cron schedule
+- `retention`: The remote retention policy
+
+**Why are these fields immutable?**
+
+Once a backup has been discovered, the Schedule is bound to a specific Kanidm instance, repository, and retention policy. Changing these fields would create ambiguity about which backups belong to which Schedule and could lead to orphaned or incorrectly retained backups.
+
+**How to change these fields:**
+
+To change any of these fields, you must **delete the existing KanidmBackupSchedule and create a new one**:
+
+```bash
+# 1. Delete the old schedule
+kubectl delete kanidmbackupschedule <name> -n <namespace>
+
+# 2. Create a new schedule with the desired configuration
+kubectl apply -f - <<EOF
+apiVersion: kaniop.rs/v1alpha1
+kind: KanidmBackupSchedule
+metadata:
+  name: <new-name>
+  namespace: <namespace>
+spec:
+  kanidmRef:
+    name: <kanidm-name>
+  repositoryRef:
+    name: <repository-name>
+  schedule: "0 3 * * *"  # New schedule
+  retention:
+    keepLast: 10
+    daily: 14
+    weekly: 8
+    monthly: 12
+    minAge: "24h"
+EOF
+```
+
+**What happens to existing Backup CRs and S3 data?**
+
+- **Existing KanidmBackup CRs are not deleted** when you delete a Schedule. They remain in the cluster as immutable catalog entries.
+- **Remote S3 data (payloads and manifests) is not deleted** when you delete a Schedule. The data remains in the repository.
+- **Retention policy changes take effect immediately** for the new Schedule. The new Schedule's retention policy is applied to all discovered backups matching the repository and Kanidm UID.
+- **The new Schedule will discover existing backups** in the repository if they match the new Schedule's `kanidmRef` and `repositoryRef`.
+
+**Safety considerations:**
+
+- Before deleting a Schedule, verify that the new Schedule's retention policy will not immediately delete backups you need to keep.
+- If you are changing repositories, ensure the new repository is accessible and properly configured before deleting the old Schedule.
+- The `suspend` field is **mutable** and can be changed at any time to pause or resume the backup schedule without deleting the Schedule.
+
+### Repository Immutability
+
+The following fields on `KanidmBackupRepository` are **immutable after the repository has been used** (after `observedGeneration` is set in status):
+
+- `s3.bucket`: The S3 bucket name
+- `s3.prefix`: The prefix within the bucket
+- `s3.endpoint`: The S3 endpoint URL
+
+**Why are these fields immutable?**
+
+Once a repository has been used, Backup CRs reference it by name. Changing the bucket, prefix, or endpoint would orphan existing backups and create ambiguity about where backups are stored.
+
+**How to change these fields:**
+
+To change any of these fields, you must **delete the existing KanidmBackupRepository and create a new one**:
+
+```bash
+# 1. Delete the old repository
+kubectl delete kanidmbackuprepository <name> -n <namespace>
+
+# 2. Create a new repository with the desired configuration
+kubectl apply -f - <<EOF
+apiVersion: kaniop.rs/v1alpha1
+kind: KanidmBackupRepository
+metadata:
+  name: <new-name>
+  namespace: <namespace>
+spec:
+  s3:
+    bucket: <new-bucket>
+    prefix: <new-prefix>
+    endpoint: <new-endpoint>
+    region: <region>
+  authentication:
+    writer:
+      workloadIdentity: {}
+    reader:
+      workloadIdentity: {}
+    deleter:
+      workloadIdentity: {}
+EOF
+
+# 3. Update the KanidmBackupSchedule to reference the new repository
+# (This requires deleting and recreating the Schedule; see above)
+```
+
+**What happens to existing Backup CRs and S3 data?**
+
+- **Existing KanidmBackup CRs are not deleted** when you delete a Repository. However, they become orphaned and cannot be used for restore because their `repositoryRef` no longer exists.
+- **Remote S3 data remains in the old bucket/prefix** and is accessible only through the old Repository configuration. If you delete the Repository, you lose the ability to restore from those backups unless you recreate a Repository with the same name and configuration.
+- **To migrate to a new repository**, you must:
+  1. Create the new Repository
+  2. Delete and recreate the Schedule to reference the new Repository
+  3. Optionally, manually copy S3 data from the old repository to the new one if you need to retain access to old backups
+
+**Safety considerations:**
+
+- Before deleting a Repository, ensure you have a Schedule that references a valid Repository, or delete the Schedule first.
+- If you need to retain access to old backups, keep the old Repository or document its configuration for potential recreation.
+- The `authentication`, `encryption`, and `limits` fields are **mutable** and can be changed at any time to update credentials or transport limits.
+
 ## Restore
 
 Restore is an explicit destructive operation represented by `KanidmRestore`. Obtain the target UID with `kubectl get kanidm <name> -o jsonpath='{.metadata.uid}'`, select an existing backup basename from `/data/backups`, and use the same pinned Kanidm image as the target. `latest` and untagged images are rejected.

--- a/Documentation/src/usage/backup-restore.md
+++ b/Documentation/src/usage/backup-restore.md
@@ -11,6 +11,39 @@ spec:
 
 Local backups require PVC-backed storage and one `replicaGroup` with `primaryNode: true`. Kaniop intentionally does not claim PITR semantics or a globally atomic point-in-time cut across replicated writable nodes.
 
+### Native Backup Behavior
+
+**Schedule Timing and Time Zone:**
+
+- The `schedule` field uses cron syntax and is interpreted in the `timeZone` field (defaults to UTC).
+- Kaniop renders the schedule into Kanidm's `[online_backup]` configuration block on the primary node only.
+- Backup files are written to `/data/backups` on the Kanidm PVC with filenames like `backup-<timestamp>.json`.
+- Local retention is controlled by `localVersions` (default 7), which keeps the N most recent backup files on the PVC.
+
+**StatefulSet Rolling Behavior:**
+
+- When you change the backup schedule, time zone, or local versions, Kaniop updates the Kanidm StatefulSet's pod template environment variables.
+- The StatefulSet controller performs a rolling update of the pods to apply the new configuration.
+- This means backup configuration changes trigger a pod restart, which may cause a brief interruption to the Kanidm service.
+- The rolling update follows the StatefulSet's update strategy (typically `RollingUpdate` with `partition: 0`).
+
+**Primary Node Selection:**
+
+- Kaniop configures the online backup scheduler only on the node with `primaryNode: true` in the `replicaGroup`.
+- If no node is marked as primary, the backup scheduler is not configured.
+- The primary node is responsible for writing backup files to the shared PVC.
+
+**Kanidm 1.11.1 Scheduling Issues:**
+
+- Kanidm 1.11.1 has a known issue where the online backup scheduler may fail to start if the schedule configuration is invalid or if the backup directory is not writable.
+- Symptoms include the backup scheduler not appearing in Kanidm logs and no backup files being created.
+- Kaniop validates the schedule configuration before applying it, but if you encounter this issue:
+  1. Check Kanidm logs for errors related to `online_backup` configuration.
+  2. Verify the backup directory `/data/backups` exists and is writable by the Kanidm process.
+  3. Ensure the cron schedule syntax is valid (e.g., `"0 2 * * *"` for daily at 2 AM UTC).
+  4. There is no fixed release for this issue in Kanidm; monitor upstream Kanidm release notes for updates.
+- As a workaround, you can suspend the backup schedule (`spec.suspend: true`) and manually create backups using Kanidm's CLI tools.
+
 ## Remote Backups (S3-Compatible Repositories)
 
 Kaniop supports remote backup repositories for disaster recovery. This uses three additional resources:
@@ -318,3 +351,33 @@ metrics:
       KaniopBackupStale:
         disabled: true
 ```
+
+## Orphan Cleanup
+
+When you delete a `KanidmBackupSchedule` or `KanidmBackupRepository`, the associated `KanidmBackup` CRs are not automatically deleted. These become orphaned resources that reference non-existent schedules or repositories.
+
+**Important:** Kaniop does not automatically delete orphaned `KanidmBackup` CRs or their associated S3 data. This is a safety measure to prevent accidental data loss.
+
+### Manual Orphan Cleanup
+
+To safely clean up orphaned `KanidmBackup` CRs, use a selector-based approach to ensure you only delete the intended resources:
+
+```bash
+# List orphaned backups (those referencing a deleted schedule or repository)
+kubectl get kanidmbackup -n <namespace> -o json | \
+  jq -r '.items[] | select(.spec.repositoryRef.name == "<deleted-repo-name>") | .metadata.name'
+
+# Delete specific orphaned backups by name
+kubectl delete kanidmbackup <backup-name> -n <namespace>
+
+# Or delete all orphaned backups for a specific repository (USE WITH CAUTION)
+kubectl delete kanidmbackup -n <namespace> -l "kaniop.rs/repository=<deleted-repo-name>"
+```
+
+**Safety considerations:**
+
+- Always list orphaned backups before deleting to verify you are targeting the correct resources.
+- Orphaned backups cannot be used for restore operations because their `repositoryRef` no longer exists.
+- Remote S3 data (payloads and manifests) is not deleted when you delete `KanidmBackup` CRs. To clean up S3 data, you must manually delete the objects from the S3 bucket.
+- If you need to retain access to old backups, keep the `KanidmBackupRepository` or document its configuration for potential recreation.
+- Do not use blanket deletion commands like `kubectl delete kanidmbackup --all` without first verifying that all backups are truly orphaned and no longer needed.

--- a/Documentation/src/usage/backup-restore.md
+++ b/Documentation/src/usage/backup-restore.md
@@ -33,16 +33,36 @@ Local backups require PVC-backed storage and one `replicaGroup` with `primaryNod
 - If no node is marked as primary, the backup scheduler is not configured.
 - The primary node is responsible for writing backup files to the shared PVC.
 
-**Kanidm 1.11.1 Scheduling Issues:**
+**Troubleshooting Backup Schedule Issues:**
 
-- Kanidm 1.11.1 has a known issue where the online backup scheduler may fail to start if the schedule configuration is invalid or if the backup directory is not writable.
-- Symptoms include the backup scheduler not appearing in Kanidm logs and no backup files being created.
-- Kaniop validates the schedule configuration before applying it, but if you encounter this issue:
-  1. Check Kanidm logs for errors related to `online_backup` configuration.
-  2. Verify the backup directory `/data/backups` exists and is writable by the Kanidm process.
-  3. Ensure the cron schedule syntax is valid (e.g., `"0 2 * * *"` for daily at 2 AM UTC).
-  4. There is no fixed release for this issue in Kanidm; monitor upstream Kanidm release notes for updates.
-- As a workaround, you can suspend the backup schedule (`spec.suspend: true`) and manually create backups using Kanidm's CLI tools.
+If backups are not being created, verify the following:
+
+1. **Check Kanidm logs for online_backup scheduler messages:**
+   ```bash
+   kubectl logs -n <namespace> <kanidm-primary-pod> | grep -i "online_backup\|backup"
+   ```
+   Expected: log lines showing the backup scheduler started with the configured schedule. Absence of these messages indicates the scheduler did not initialize.
+
+2. **Verify the rendered configuration:**
+   Kaniop renders the schedule into Kanidm's `[online_backup]` configuration block via environment variables on the primary pod:
+   ```bash
+   kubectl exec -n <namespace> <kanidm-primary-pod> -- env | grep KANIDM_BACKUP
+   ```
+
+3. **Verify the schedule is correct for the time zone:**
+   The `schedule` field uses cron syntax interpreted in the `timeZone` field (defaults to UTC). A schedule of `"0 2 * * *"` fires at 02:00 UTC daily.
+
+4. **Verify the backup directory is writable:**
+   The Kanidm process writes backup files to `/data/backups` on the PVC. Verify the directory exists and is writable by the container's configured runtime UID:
+   ```bash
+   kubectl exec -n <namespace> <kanidm-primary-pod> -- test -w /data/backups && echo "writable" || echo "not writable"
+   ```
+
+5. **Check pod uptime:**
+   If the Kanidm pod recently restarted, the backup scheduler may not have triggered yet. Verify the pod has been running long enough for at least one schedule interval:
+   ```bash
+   kubectl get pod -n <namespace> <kanidm-primary-pod> -o jsonpath='{.status.startTime}'
+   ```
 
 ## Remote Backups (S3-Compatible Repositories)
 
@@ -363,15 +383,31 @@ When you delete a `KanidmBackupSchedule` or `KanidmBackupRepository`, the associ
 To safely clean up orphaned `KanidmBackup` CRs, use a selector-based approach to ensure you only delete the intended resources:
 
 ```bash
-# List orphaned backups (those referencing a deleted schedule or repository)
-kubectl get kanidmbackup -n <namespace> -o json | \
-  jq -r '.items[] | select(.spec.repositoryRef.name == "<deleted-repo-name>") | .metadata.name'
+# List orphaned backups using jsonpath (no jq required)
+kubectl get kanidmbackup -n <namespace> \
+  -o jsonpath='{range .items[?(@.spec.repositoryRef.name=="<deleted-repo-name>")]}{.metadata.name}{"\n"}{end}'
 
 # Delete specific orphaned backups by name
 kubectl delete kanidmbackup <backup-name> -n <namespace>
 
 # Or delete all orphaned backups for a specific repository (USE WITH CAUTION)
 kubectl delete kanidmbackup -n <namespace> -l "kaniop.rs/repository=<deleted-repo-name>"
+```
+
+### Cleaning Up Orphan Pods
+
+Succeeded pods from backup-discover Jobs may accumulate if Job TTL has not yet expired. To clean up only Succeeded orphan pods safely:
+
+```bash
+# List Succeeded orphan pods from backup-discover Jobs
+kubectl get pods -n <namespace> \
+  -l kaniop.rs/operation=discover \
+  --field-selector=status.phase=Succeeded
+
+# Delete Succeeded orphan pods from backup-discover Jobs
+kubectl delete pods -n <namespace> \
+  -l kaniop.rs/operation=discover \
+  --field-selector=status.phase=Succeeded
 ```
 
 **Safety considerations:**

--- a/charts/kaniop/templates/crd-apply/_helpers.tpl
+++ b/charts/kaniop/templates/crd-apply/_helpers.tpl
@@ -1,0 +1,13 @@
+{{- define "kaniop.crdApply.serviceAccountName" -}}
+{{- printf "%s-crd-applier" (include "kaniop.fullname" .) }}
+{{- end }}
+
+{{- define "kaniop.crdApply.selectorLabels" -}}
+{{- include "kaniop.commonSelectorLabels" . }}
+app.kubernetes.io/component: crd-apply
+{{- end }}
+
+{{- define "kaniop.crdApply.labels" -}}
+{{- include "kaniop.commonLabels" . }}
+{{ include "kaniop.crdApply.selectorLabels" . }}
+{{- end }}

--- a/charts/kaniop/templates/crd-apply/clusterrole.yaml
+++ b/charts/kaniop/templates/crd-apply/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.crdApply.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kaniop.fullname" . }}-crd-applier
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-40"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "kaniop.crdApply.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - create
+      - patch
+{{- end }}

--- a/charts/kaniop/templates/crd-apply/clusterrolebinding.yaml
+++ b/charts/kaniop/templates/crd-apply/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.crdApply.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kaniop.fullname" . }}-crd-applier
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-40"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "kaniop.crdApply.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kaniop.fullname" . }}-crd-applier
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kaniop.crdApply.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/kaniop/templates/crd-apply/job-apply.yaml
+++ b/charts/kaniop/templates/crd-apply/job-apply.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.crdApply.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kaniop.fullname" . }}-crd-apply
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-35"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "kaniop.crdApply.labels" . | nindent 4 }}
+spec:
+  backoffLimit: {{ .Values.crdApply.backoffLimit }}
+  activeDeadlineSeconds: {{ add .Values.crdApply.activeDeadlineSeconds 120 }}
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "kaniop.crdApply.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "kaniop.crdApply.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: apply-crds
+          image: {{ .Values.image.repository }}:{{ include "kaniop.version" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/kaniop-crd-migrator
+          args:
+            - apply-crds
+          env:
+            - name: TIMEOUT_SECONDS
+              value: "{{ .Values.crdApply.activeDeadlineSeconds }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          {{- with .Values.crdApply.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.crdApply.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdApply.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdApply.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kaniop/templates/crd-apply/serviceaccount.yaml
+++ b/charts/kaniop/templates/crd-apply/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.crdApply.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kaniop.crdApply.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-40"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "kaniop.crdApply.labels" . | nindent 4 }}
+automountServiceAccountToken: true
+{{- end }}

--- a/charts/kaniop/tests/crd-apply_test.yaml
+++ b/charts/kaniop/tests/crd-apply_test.yaml
@@ -1,0 +1,511 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test crd apply
+templates:
+  - templates/crd-apply/serviceaccount.yaml
+  - templates/crd-apply/clusterrole.yaml
+  - templates/crd-apply/clusterrolebinding.yaml
+  - templates/crd-apply/job-apply.yaml
+tests:
+  - it: Should not render any crd-apply resources when disabled
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      crdApply.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render one document per template when enabled
+    release:
+      name: kaniop
+      namespace: kaniop
+    set:
+      crdApply.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: Should set correct hook annotations on the apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-35"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: Should not emit native Argo CD hook annotations on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+
+  - it: Should set RBAC hook annotations with weight -40 and no hook-succeeded
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/serviceaccount.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-40"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: Should set RBAC hook annotations on ClusterRole
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-40"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: Should set RBAC hook annotations on ClusterRoleBinding
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrolebinding.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-40"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: Should use release-derived ServiceAccount name
+    release:
+      name: myrelease
+      namespace: kaniop
+    template: templates/crd-apply/serviceaccount.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: myrelease-kaniop-crd-applier
+
+  - it: Should use release-derived apply Job name
+    release:
+      name: myrelease
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: myrelease-kaniop-crd-apply
+
+  - it: Should use release-derived ClusterRole name
+    release:
+      name: myrelease
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: myrelease-kaniop-crd-applier
+
+  - it: Should use chart image for apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      image.repository: ghcr.io/pando85/kaniop
+      image.tag: "0.14.1"
+      image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/pando85/kaniop:0.14.1"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: Should set apply-crds command and args on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/kaniop-crd-migrator
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: apply-crds
+
+  - it: Should set pod security context on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: Should set bounded activeDeadlineSeconds on apply Job with startup buffer
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.activeDeadlineSeconds: 300
+    asserts:
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 420
+
+  - it: Should set bounded backoffLimit on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.backoffLimit: 5
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 5
+
+  - it: Should set restartPolicy OnFailure on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: OnFailure
+
+  - it: Should set TIMEOUT_SECONDS env on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.activeDeadlineSeconds: 300
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TIMEOUT_SECONDS
+            value: "300"
+          any: true
+
+  - it: Should apply resources to apply Job when set
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 256Mi
+
+  - it: Should apply nodeSelector to apply Job when set
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.nodeSelector:
+        disktype: ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: Should apply tolerations to apply Job when set
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+      crdApply.tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "migration"
+          effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+
+  - it: Should have no wildcard verbs in ClusterRole
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - notContains:
+          path: rules[*].verbs
+          content: "*"
+          any: true
+
+  - it: Should have no wildcard resources in ClusterRole
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - notContains:
+          path: rules[*].resources
+          content: "*"
+          any: true
+
+  - it: Should grant only get create patch on CRDs in ClusterRole
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+              - create
+              - patch
+
+  - it: Should not grant delete on CRDs in ClusterRole
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - notContains:
+          path: rules[0].verbs
+          content: "delete"
+          any: true
+
+  - it: Should use the dedicated ServiceAccount in apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kaniop-crd-applier
+
+  - it: Should set crd-apply component label on ServiceAccount
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/serviceaccount.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: crd-apply
+
+  - it: Should set crd-apply component label on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: crd-apply
+
+  - it: Should set crd-apply component label on pod template in apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: crd-apply
+
+  - it: Should render namespaced resources in the release namespace
+    release:
+      name: kaniop
+      namespace: custom-ns
+    template: templates/crd-apply/serviceaccount.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: Should render apply Job in the release namespace
+    release:
+      name: kaniop
+      namespace: custom-ns
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: Should set ttlSecondsAfterFinished on apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 300
+
+  - it: Should automount service account token in apply Job
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: Should bind ClusterRoleBinding to the dedicated ServiceAccount
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrolebinding.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: kaniop-crd-applier
+      - equal:
+          path: roleRef.name
+          value: kaniop-crd-applier
+
+  - it: Should have hook weight lower than crd-migration hooks
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/job-apply.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-35"
+
+  - it: Should have RBAC weight lower than crd-migration RBAC weight
+    release:
+      name: kaniop
+      namespace: kaniop
+    template: templates/crd-apply/clusterrole.yaml
+    set:
+      crdApply.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-40"

--- a/charts/kaniop/values.schema.json
+++ b/charts/kaniop/values.schema.json
@@ -908,7 +908,8 @@
         },
         "activeDeadlineSeconds": {
           "type": "integer",
-          "description": "Maximum duration in seconds for the CRD apply Job. A 120-second buffer is added for pod startup.",
+          "minimum": 60,
+          "description": "Maximum duration in seconds for the CRD apply Job. A 120-second buffer is added for pod startup. Minimum 60 seconds.",
           "default": 300
         },
         "backoffLimit": {

--- a/charts/kaniop/values.schema.json
+++ b/charts/kaniop/values.schema.json
@@ -895,6 +895,50 @@
           }
         }
       }
+    },
+    "crdApply": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CRD apply hook ensures Helm upgrades apply current generated CRD schemas via server-side apply.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the CRD apply hook. When enabled, a pre-install/pre-upgrade hook server-side applies all generated CRDs and waits for them to become Established.",
+          "default": true
+        },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "description": "Maximum duration in seconds for the CRD apply Job. A 120-second buffer is added for pod startup.",
+          "default": 300
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "description": "Number of retries before marking the Job as failed.",
+          "default": 3
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for the CRD apply Job container."
+        },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Node selector for CRD apply Job pods."
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for CRD apply Job pods.",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity settings for CRD apply Job pods."
+        }
+      }
     }
   }
 }

--- a/charts/kaniop/values.yaml
+++ b/charts/kaniop/values.yaml
@@ -439,6 +439,13 @@ crdMigration:
 ## on upgrade, meaning schema changes (e.g. list-map annotations) do not reach existing
 ## installations. The hook server-side applies all CRDs before each install/upgrade and
 ## waits for them to become Established. It never deletes CRDs or custom resources.
+##
+## Caveats:
+## - The hook uses server-side apply with force=true, which can overwrite conflicting fields.
+## - Downgrading Kaniop may leave newer CRD schema fields in place; this is safe but may
+##   cause validation warnings for removed fields.
+## - The hook adds a 120-second buffer to activeDeadlineSeconds for pod startup overhead.
+## - Minimum activeDeadlineSeconds is 60 seconds to ensure sufficient time for CRD establishment.
 crdApply:
   enabled: true
   activeDeadlineSeconds: 300

--- a/charts/kaniop/values.yaml
+++ b/charts/kaniop/values.yaml
@@ -433,3 +433,17 @@ crdMigration:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+
+## CRD apply hook ensures Helm upgrades apply current generated CRD schemas.
+## Without this hook, Helm only installs CRDs on first install and never updates them
+## on upgrade, meaning schema changes (e.g. list-map annotations) do not reach existing
+## installations. The hook server-side applies all CRDs before each install/upgrade and
+## waits for them to become Established. It never deletes CRDs or custom resources.
+crdApply:
+  enabled: true
+  activeDeadlineSeconds: 300
+  backoffLimit: 3
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -17,8 +17,11 @@ path = "src/main.rs"
 [dependencies]
 kaniop-crd-migration = { workspace = true }
 clap = { workspace = true, features = ["cargo", "env"] }
+k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cmd/crd-migrator/Cargo.toml
+++ b/cmd/crd-migrator/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true, features = ["cargo", "env"] }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
 rustls = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }

--- a/cmd/crd-migrator/src/apply_crds.rs
+++ b/cmd/crd-migrator/src/apply_crds.rs
@@ -6,6 +6,7 @@ use kube::{
     Api, Client,
     api::{Patch, PatchParams},
 };
+use serde::Deserialize;
 
 const CRDS_YAML: &str = include_str!("../../../charts/kaniop/crds/crds.yaml");
 const FIELD_MANAGER: &str = "kaniop-helm-crds";
@@ -15,11 +16,9 @@ fn strip_unsupported_integer_formats(value: &mut serde_yaml::Value) {
     match value {
         serde_yaml::Value::Mapping(mapping) => {
             let format_key = serde_yaml::Value::String("format".to_string());
-            if let Some(fmt_val) = mapping.get(&format_key) {
-                if let serde_yaml::Value::String(ref s) = fmt_val {
-                    if s == "uint32" || s == "uint64" {
-                        mapping.remove(&format_key);
-                    }
+            if let Some(serde_yaml::Value::String(s)) = mapping.get(&format_key) {
+                if s == "uint32" || s == "uint64" {
+                    mapping.remove(&format_key);
                 }
             }
             for value in mapping.values_mut() {
@@ -38,8 +37,8 @@ fn strip_unsupported_integer_formats(value: &mut serde_yaml::Value) {
 fn parse_crds() -> Result<Vec<CustomResourceDefinition>> {
     let mut crds = Vec::new();
     for doc in serde_yaml::Deserializer::from_str(CRDS_YAML) {
-        let mut value = serde_yaml::Value::deserialize(doc)
-            .context("failed to deserialize CRD YAML document")?;
+        let mut value = <serde_yaml::Value as Deserialize>::deserialize(doc)
+            .map_err(|e| anyhow::anyhow!("failed to deserialize CRD YAML document: {e}"))?;
         strip_unsupported_integer_formats(&mut value);
         let json_value =
             serde_json::to_value(&value).context("failed to convert YAML value to JSON")?;

--- a/cmd/crd-migrator/src/apply_crds.rs
+++ b/cmd/crd-migrator/src/apply_crds.rs
@@ -1,0 +1,174 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use kube::{
+    Api, Client,
+    api::{Patch, PatchParams},
+};
+
+const CRDS_YAML: &str = include_str!("../../../charts/kaniop/crds/crds.yaml");
+const FIELD_MANAGER: &str = "kaniop-helm-crds";
+const ESTABLISH_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+fn strip_unsupported_integer_formats(value: &mut serde_yaml::Value) {
+    match value {
+        serde_yaml::Value::Mapping(mapping) => {
+            let format_key = serde_yaml::Value::String("format".to_string());
+            if let Some(fmt_val) = mapping.get(&format_key) {
+                if let serde_yaml::Value::String(ref s) = fmt_val {
+                    if s == "uint32" || s == "uint64" {
+                        mapping.remove(&format_key);
+                    }
+                }
+            }
+            for value in mapping.values_mut() {
+                strip_unsupported_integer_formats(value);
+            }
+        }
+        serde_yaml::Value::Sequence(seq) => {
+            for value in seq.iter_mut() {
+                strip_unsupported_integer_formats(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_crds() -> Result<Vec<CustomResourceDefinition>> {
+    let mut crds = Vec::new();
+    for doc in serde_yaml::Deserializer::from_str(CRDS_YAML) {
+        let mut value = serde_yaml::Value::deserialize(doc)
+            .context("failed to deserialize CRD YAML document")?;
+        strip_unsupported_integer_formats(&mut value);
+        let json_value =
+            serde_json::to_value(&value).context("failed to convert YAML value to JSON")?;
+        let crd: CustomResourceDefinition =
+            serde_json::from_value(json_value).context("failed to deserialize CRD from JSON")?;
+        crds.push(crd);
+    }
+    Ok(crds)
+}
+
+fn crd_name(crd: &CustomResourceDefinition) -> &str {
+    crd.metadata.name.as_deref().unwrap_or("<unknown>")
+}
+
+fn is_established(crd: &CustomResourceDefinition) -> bool {
+    crd.status.as_ref().is_some_and(|s| {
+        s.conditions.as_ref().is_some_and(|conds| {
+            conds
+                .iter()
+                .any(|c| c.type_ == "Established" && c.status == "True")
+        })
+    })
+}
+
+pub async fn apply_crds(timeout: Duration) -> Result<()> {
+    let client = Client::try_default()
+        .await
+        .context("failed to create Kubernetes client")?;
+
+    let crd_api: Api<CustomResourceDefinition> = Api::all(client);
+    let crds = parse_crds().context("failed to parse embedded CRDs")?;
+
+    tracing::info!(count = crds.len(), "applying CRDs via server-side apply");
+
+    let pp = PatchParams::apply(FIELD_MANAGER).force();
+
+    for crd in &crds {
+        let name = crd_name(crd);
+        tracing::info!(crd = name, "server-side applying CRD");
+        crd_api
+            .patch(name, &pp, &Patch::Apply(crd))
+            .await
+            .with_context(|| format!("failed to server-side apply CRD {name}"))?;
+    }
+
+    let deadline = Instant::now() + timeout;
+
+    for crd in &crds {
+        let name = crd_name(crd);
+        loop {
+            let current = crd_api
+                .get(name)
+                .await
+                .with_context(|| format!("failed to get CRD {name} after apply"))?;
+            if is_established(&current) {
+                tracing::info!(crd = name, "CRD is Established");
+                break;
+            }
+            if Instant::now() >= deadline {
+                bail!("timed out waiting for CRD {name} to become Established");
+            }
+            tracing::debug!(crd = name, "waiting for CRD to become Established");
+            tokio::time::sleep(ESTABLISH_POLL_INTERVAL).await;
+        }
+    }
+
+    tracing::info!(count = crds.len(), "all CRDs applied and Established");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_embedded_crds_succeeds() {
+        let crds = parse_crds().unwrap();
+        assert!(!crds.is_empty(), "embedded CRDs should not be empty");
+    }
+
+    #[test]
+    fn all_embedded_crds_have_names() {
+        let crds = parse_crds().unwrap();
+        for crd in &crds {
+            let name = crd.metadata.name.as_deref();
+            assert!(name.is_some(), "every CRD must have a metadata.name");
+            assert!(
+                name.unwrap().ends_with(".kaniop.rs"),
+                "CRD name should end with .kaniop.rs, got: {}",
+                name.unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_crds_count_matches_expected() {
+        let crds = parse_crds().unwrap();
+        assert_eq!(crds.len(), 9, "expected 9 CRDs embedded");
+    }
+
+    #[test]
+    fn strip_unsupported_integer_formats_removes_uint32() {
+        let mut value: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+properties:
+  field:
+    type: integer
+    format: uint32
+"#,
+        )
+        .unwrap();
+        strip_unsupported_integer_formats(&mut value);
+        let yaml = serde_yaml::to_string(&value).unwrap();
+        assert!(!yaml.contains("uint32"));
+    }
+
+    #[test]
+    fn strip_unsupported_integer_formats_preserves_int32() {
+        let mut value: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+properties:
+  field:
+    type: integer
+    format: int32
+"#,
+        )
+        .unwrap();
+        strip_unsupported_integer_formats(&mut value);
+        let yaml = serde_yaml::to_string(&value).unwrap();
+        assert!(yaml.contains("int32"));
+    }
+}

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -63,18 +63,17 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let config = MigrationConfig {
-        namespace: args.namespace,
-        operator_namespace: args.operator_namespace,
-        operator_deployment: args.operator_deployment,
-        marker_name: args.marker_name,
-        timeout: Duration::from_secs(args.timeout_seconds),
-    };
-
-    let client = kube::Client::try_default().await?;
-
     match args.command {
         Command::MigratePersonAccount => {
+            let config = MigrationConfig {
+                namespace: args.namespace,
+                operator_namespace: args.operator_namespace,
+                operator_deployment: args.operator_deployment,
+                marker_name: args.marker_name,
+                timeout: Duration::from_secs(args.timeout_seconds),
+            };
+            let client = kube::Client::try_default().await?;
+
             tracing::info!("Starting persist_original_operator_replicas_for_presync");
             persist_original_operator_replicas_for_presync(&client, &config).await?;
             tracing::info!("Completed persist_original_operator_replicas_for_presync");
@@ -88,6 +87,15 @@ async fn main() -> Result<()> {
             tracing::info!("Completed run_presync");
         }
         Command::VerifyPersonAccount => {
+            let config = MigrationConfig {
+                namespace: args.namespace,
+                operator_namespace: args.operator_namespace,
+                operator_deployment: args.operator_deployment,
+                marker_name: args.marker_name,
+                timeout: Duration::from_secs(args.timeout_seconds),
+            };
+            let client = kube::Client::try_default().await?;
+
             tracing::info!("Starting restore_operator_for_postsync");
             restore_operator_for_postsync(&client, &config).await?;
             tracing::info!("Completed restore_operator_for_postsync");

--- a/cmd/crd-migrator/src/main.rs
+++ b/cmd/crd-migrator/src/main.rs
@@ -1,3 +1,8 @@
+mod apply_crds;
+
+use std::time::Duration;
+
+use anyhow::Result;
 use clap::{Parser, Subcommand, crate_authors, crate_description, crate_version};
 use kaniop_crd_migration::{
     migration::{MigrationConfig, run_postsync, run_presync},
@@ -42,10 +47,11 @@ struct Args {
 enum Command {
     MigratePersonAccount,
     VerifyPersonAccount,
+    ApplyCrds,
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<()> {
     default_provider().install_default().unwrap();
 
     let args = Args::parse();
@@ -62,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
         operator_namespace: args.operator_namespace,
         operator_deployment: args.operator_deployment,
         marker_name: args.marker_name,
-        timeout: std::time::Duration::from_secs(args.timeout_seconds),
+        timeout: Duration::from_secs(args.timeout_seconds),
     };
 
     let client = kube::Client::try_default().await?;
@@ -106,6 +112,9 @@ async fn main() -> anyhow::Result<()> {
                 );
                 std::process::exit(1);
             }
+        }
+        Command::ApplyCrds => {
+            apply_crds::apply_crds(Duration::from_secs(args.timeout_seconds)).await?;
         }
     }
 

--- a/cmd/webhook/src/backup_validator.rs
+++ b/cmd/webhook/src/backup_validator.rs
@@ -54,13 +54,13 @@ pub fn validate_repository_immutable_after_use(
     }
 
     if old.spec.s3.bucket != new.spec.s3.bucket {
-        return Err("s3.bucket is immutable after repository has been used".to_string());
+        return Err("s3.bucket is immutable after repository has been used. To use a different bucket, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data in the old bucket remains accessible only through the old Repository.".to_string());
     }
     if old.spec.s3.prefix != new.spec.s3.prefix {
-        return Err("s3.prefix is immutable after repository has been used".to_string());
+        return Err("s3.prefix is immutable after repository has been used. To use a different prefix, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data under the old prefix remains accessible only through the old Repository.".to_string());
     }
     if old.spec.s3.endpoint != new.spec.s3.endpoint {
-        return Err("s3.endpoint is immutable after repository has been used".to_string());
+        return Err("s3.endpoint is immutable after repository has been used. To use a different endpoint, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data at the old endpoint remains accessible only through the old Repository.".to_string());
     }
 
     Ok(())
@@ -113,18 +113,18 @@ pub fn validate_schedule_immutable_after_discovery(
     }
 
     if old.spec.kanidm_ref != new.spec.kanidm_ref {
-        return Err("kanidmRef is immutable after first backup has been discovered".to_string());
+        return Err("kanidmRef is immutable after first backup has been discovered. To target a different Kanidm, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.".to_string());
     }
     if old.spec.repository_ref != new.spec.repository_ref {
         return Err(
-            "repositoryRef is immutable after first backup has been discovered".to_string(),
+            "repositoryRef is immutable after first backup has been discovered. To use a different repository, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.".to_string(),
         );
     }
     if old.spec.schedule != new.spec.schedule {
-        return Err("schedule is immutable after first backup has been discovered".to_string());
+        return Err("schedule is immutable after first backup has been discovered. To change the cron schedule, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.".to_string());
     }
     if old.spec.retention != new.spec.retention {
-        return Err("retention is immutable after first backup has been discovered".to_string());
+        return Err("retention is immutable after first backup has been discovered. To change retention policy, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion; retention is applied at discovery time based on the current Schedule spec.".to_string());
     }
 
     Ok(())

--- a/examples/backup-repository.yaml
+++ b/examples/backup-repository.yaml
@@ -5,14 +5,33 @@ metadata:
   name: offsite
   namespace: identity-prod
 spec:
+  #  S3-compatible storage configuration. The bucket, prefix, and endpoint fields are immutable after the repository has
+  #  been used.
   s3:
+    #  S3 bucket name. Must not be empty.
+    #
+    #  This field is immutable after the repository has been used. To use a different bucket, delete this Repository and
+    #  create a new one.
     bucket: corp-kaniop-backups
+    #  Prefix within the bucket. Must not contain path traversal segments (..).
+    #
+    #  This field is immutable after the repository has been used. To use a different prefix, delete this Repository and
+    #  create a new one.
     prefix: prod
+    # # AWS region. Optional for S3-compatible providers that do not require region specification.
     # region: eu-west-1
+    # # S3 endpoint URL. Must use HTTPS unless insecure is enabled.
+    # #
+    # # This field is immutable after the repository has been used. To use a different endpoint, delete this Repository
+    # # and create a new one.
     # endpoint: https://s3.eu-west-1.amazonaws.com
+    # # Use path-style addressing (http://endpoint/bucket) instead of virtual-hosted-style (http://bucket.endpoint).
     # forcePathStyle: false
+    # # Allow HTTP endpoints. Not recommended for production use.
     # insecure: false
 
+  #  Authentication configuration for writer, reader, and deleter roles. These fields are mutable and can be updated to
+  #  rotate credentials.
   authentication:
     writer:
       # workloadIdentity: {}
@@ -21,10 +40,12 @@ spec:
     deleter:
       # workloadIdentity: {}
 
+  # # Encryption configuration for server-side encryption. This field is mutable.
   # encryption:
   #   mode: providerKms
   #   keyId: alias/kaniop-backups
 
+  # # Transport limits and safety retention. This field is mutable.
   # limits:
   #   maxUploadBytesPerSecond: 52428800
   #   maxDownloadBytesPerSecond: 104857600

--- a/examples/backup-schedule.yaml
+++ b/examples/backup-schedule.yaml
@@ -5,24 +5,52 @@ metadata:
   name: corp-idm-standard
   namespace: identity-prod
 spec:
+  #  Reference to the Kanidm instance to back up. Only one KanidmBackupSchedule may target a given Kanidm at a time.
+  #
+  #  This field is immutable after creation. To target a different Kanidm, delete this Schedule and create a new one.
+  #  Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
   kanidmRef:
     name: corp-idm
 
+  #  Reference to the KanidmBackupRepository where backups will be stored.
+  #
+  #  This field is immutable after creation. To use a different repository, delete this Schedule and create a new one.
+  #  Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
   repositoryRef:
     name: offsite
 
+  #  Cron schedule for Kanidm's online backup. Kaniop renders this into Kanidm's [online_backup] configuration.
+  #
+  #  This field is immutable after creation. To change the schedule, delete this KanidmBackupSchedule and create a new
+  #  one.
+  #  Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
+  #
+  #  The online backup transport is experimental (see TransportExperimental condition). Kanidm has no documented
+  #  completion contract; Kaniop does not report production backup success based on file stability heuristics alone.
   schedule: 3 */6 * * *
 
+  # # Time zone for the cron schedule. Defaults to UTC.
   # timeZone: UTC
 
+  # # Suspend the backup schedule. When true, Kaniop pauses the online backup configuration on the Kanidm primary.
+  # # This field is mutable and can be changed at any time.
   # suspend: false
 
+  # # Concurrency policy. Must be 'Forbid'.
   # concurrencyPolicy: Forbid
 
+  # # Random jitter in seconds added to the schedule to avoid thundering herd.
   # jitterSeconds: 300
 
+  # # Number of local backup versions to retain on the Kanidm PVC under /data/backups.
   # localVersions: 7
 
+  # # Retention policy for remote backups in the repository. Applied at discovery time based on the current Schedule
+  # # spec.
+  # #
+  # # This field is immutable after creation. To change retention policy, delete this Schedule and create a new one.
+  # # Existing Backup CRs and remote S3 data are not affected by Schedule deletion; retention is applied at discovery
+  # # time based on the current Schedule spec.
   # retention:
   #   keepLast: 8
   #   daily: 7

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -10,15 +10,15 @@ use serde::{Deserialize, Serialize};
     feature = "schemars",
     schemars(extend("x-kubernetes-validations" = [
         {
-            "message": "s3.bucket is immutable",
+            "message": "s3.bucket is immutable after creation. To use a different bucket, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data in the old bucket remains accessible only through the old Repository.",
             "rule": "self.s3.bucket == oldSelf.s3.bucket"
         },
         {
-            "message": "s3.prefix is immutable",
+            "message": "s3.prefix is immutable after creation. To use a different prefix, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data under the old prefix remains accessible only through the old Repository.",
             "rule": "self.s3.prefix == oldSelf.s3.prefix"
         },
         {
-            "message": "s3.endpoint is immutable",
+            "message": "s3.endpoint is immutable after creation. To use a different endpoint, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data at the old endpoint remains accessible only through the old Repository.",
             "rule": "!has(oldSelf.s3.endpoint) || self.s3.endpoint == oldSelf.s3.endpoint"
         }
     ]))
@@ -40,10 +40,14 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct KanidmBackupRepositorySpec {
+    /// S3-compatible storage configuration. The bucket, prefix, and endpoint fields are immutable after the repository has been used.
     pub s3: S3Config,
+    /// Authentication configuration for writer, reader, and deleter roles. These fields are mutable and can be updated to rotate credentials.
     pub authentication: RepositoryAuthentication,
+    /// Encryption configuration for server-side encryption. This field is mutable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption: Option<RepositoryEncryption>,
+    /// Transport limits and safety retention. This field is mutable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limits: Option<RepositoryLimits>,
 }
@@ -61,18 +65,31 @@ pub struct KanidmBackupRepositorySpec {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct S3Config {
+    /// S3 bucket name. Must not be empty.
+    ///
+    /// This field is immutable after the repository has been used. To use a different bucket, delete this Repository and create a new one.
     #[schemars(extend("x-kubernetes-validations" = [{"message": "bucket must not be empty", "rule": "self.size() > 0"}]))]
     pub bucket: String,
+    /// Prefix within the bucket. Must not contain path traversal segments (..).
+    ///
+    /// This field is immutable after the repository has been used. To use a different prefix, delete this Repository and create a new one.
     #[schemars(extend("x-kubernetes-validations" = [{"message": "prefix must not contain path traversal segments", "rule": "!self.contains('..')"}]))]
     pub prefix: String,
+    /// AWS region. Optional for S3-compatible providers that do not require region specification.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
+    /// S3 endpoint URL. Must use HTTPS unless insecure is enabled.
+    ///
+    /// This field is immutable after the repository has been used. To use a different endpoint, delete this Repository and create a new one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+    /// Use path-style addressing (http://endpoint/bucket) instead of virtual-hosted-style (http://bucket.endpoint).
     #[serde(default)]
     pub force_path_style: bool,
+    /// Reference to a ConfigMap or Secret containing a CA bundle for TLS verification.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_bundle_ref: Option<String>,
+    /// Allow HTTP endpoints. Not recommended for production use.
     #[serde(default)]
     pub insecure: bool,
 }
@@ -189,19 +206,19 @@ pub struct KanidmBackupRepositoryStatus {
     feature = "schemars",
     schemars(extend("x-kubernetes-validations" = [
         {
-            "message": "kanidmRef is immutable",
+            "message": "kanidmRef is immutable after creation. To target a different Kanidm, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.",
             "rule": "self.kanidmRef == oldSelf.kanidmRef"
         },
         {
-            "message": "repositoryRef is immutable",
+            "message": "repositoryRef is immutable after creation. To use a different repository, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.",
             "rule": "self.repositoryRef == oldSelf.repositoryRef"
         },
         {
-            "message": "schedule is immutable",
+            "message": "schedule is immutable after creation. To change the cron schedule, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion.",
             "rule": "self.schedule == oldSelf.schedule"
         },
         {
-            "message": "retention is immutable",
+            "message": "retention is immutable after creation. To change retention policy, delete this KanidmBackupSchedule and create a new one. Existing Backup CRs and remote S3 data are not affected by Schedule deletion; retention is applied at discovery time based on the current Schedule spec.",
             "rule": "!has(oldSelf.retention) || self.retention == oldSelf.retention"
         },
         {
@@ -232,19 +249,45 @@ pub struct KanidmBackupRepositoryStatus {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct KanidmBackupScheduleSpec {
+    /// Reference to the Kanidm instance to back up. Only one KanidmBackupSchedule may target a given Kanidm at a time.
+    ///
+    /// This field is immutable after creation. To target a different Kanidm, delete this Schedule and create a new one.
+    /// Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
     pub kanidm_ref: ScheduleKanidmRef,
+    /// Reference to the KanidmBackupRepository where backups will be stored.
+    ///
+    /// This field is immutable after creation. To use a different repository, delete this Schedule and create a new one.
+    /// Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
     pub repository_ref: ScheduleRepositoryRef,
+    /// Cron schedule for Kanidm's online backup. Kaniop renders this into Kanidm's [online_backup] configuration.
+    ///
+    /// This field is immutable after creation. To change the schedule, delete this KanidmBackupSchedule and create a new one.
+    /// Existing Backup CRs and remote S3 data are not affected by Schedule deletion.
+    ///
+    /// The online backup transport is experimental (see TransportExperimental condition). Kanidm has no documented
+    /// completion contract; Kaniop does not report production backup success based on file stability heuristics alone.
     pub schedule: String,
+    /// Time zone for the cron schedule. Defaults to UTC.
     #[serde(default = "default_timezone")]
     pub time_zone: String,
+    /// Suspend the backup schedule. When true, Kaniop pauses the online backup configuration on the Kanidm primary.
+    /// This field is mutable and can be changed at any time.
     #[serde(default)]
     pub suspend: bool,
+    /// Concurrency policy. Must be 'Forbid'.
     #[serde(default = "default_concurrency_policy")]
     pub concurrency_policy: String,
+    /// Random jitter in seconds added to the schedule to avoid thundering herd.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jitter_seconds: Option<u32>,
+    /// Number of local backup versions to retain on the Kanidm PVC under /data/backups.
     #[serde(default = "default_local_versions")]
     pub local_versions: u32,
+    /// Retention policy for remote backups in the repository. Applied at discovery time based on the current Schedule spec.
+    ///
+    /// This field is immutable after creation. To change retention policy, delete this Schedule and create a new one.
+    /// Existing Backup CRs and remote S3 data are not affected by Schedule deletion; retention is applied at discovery
+    /// time based on the current Schedule spec.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retention: Option<RetentionPolicySpec>,
 }

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -384,7 +384,8 @@ pub struct DiscoveryStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_successful_scan_time: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_discovered_count: Option<i32>,
+    #[cfg_attr(feature = "schemars", schemars(extend("x-kubernetes-validations" = [{"message": "lastDiscoveredCount must be non-negative", "rule": "self >= 0"}])))]
+    pub last_discovered_count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -378,6 +378,26 @@ fn default_min_age() -> String {
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
+pub struct DiscoveryStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_scan_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_successful_scan_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_discovered_count: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))
+    )]
+    pub conditions: Vec<Condition>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct KanidmBackupScheduleStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
@@ -391,6 +411,8 @@ pub struct KanidmBackupScheduleStatus {
         schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["type"]))
     )]
     pub conditions: Vec<Condition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery: Option<DiscoveryStatus>,
 }
 
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -1,7 +1,7 @@
 use crate::controller::{
-    RESULT_PATH, build_data_mover_wrapper, data_mover_image, default_resource_requirements,
-    extract_termination_message, hardened_pod_security_context, hardened_security_context,
-    select_succeeded_pod,
+    BACKUP_JOB_TTL_SECONDS, RESULT_PATH, background_delete_params, build_data_mover_wrapper,
+    data_mover_image, default_resource_requirements, extract_termination_message,
+    hardened_pod_security_context, hardened_security_context, select_succeeded_pod,
 };
 use crate::crd::{
     BackupKanidmRef, BackupRepositoryRef, KanidmBackup, KanidmBackupPhase, KanidmBackupRepository,
@@ -182,6 +182,7 @@ pub fn build_validation_job(
         },
         spec: Some(JobSpec {
             backoff_limit: Some(0),
+            ttl_seconds_after_finished: Some(BACKUP_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
@@ -300,6 +301,7 @@ pub fn build_deletion_job(
         },
         spec: Some(JobSpec {
             backoff_limit: Some(0),
+            ttl_seconds_after_finished: Some(BACKUP_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
@@ -561,7 +563,7 @@ async fn handle_discovering(
 
             let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
             job_api
-                .delete(&job.name_any(), &Default::default())
+                .delete(&job.name_any(), &background_delete_params())
                 .await
                 .ok();
 
@@ -614,7 +616,7 @@ async fn handle_discovering(
 
                     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
                     job_api
-                        .delete(&job.name_any(), &Default::default())
+                        .delete(&job.name_any(), &background_delete_params())
                         .await
                         .ok();
 
@@ -651,7 +653,7 @@ async fn handle_discovering(
 
                     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
                     job_api
-                        .delete(&job.name_any(), &Default::default())
+                        .delete(&job.name_any(), &background_delete_params())
                         .await
                         .ok();
 
@@ -773,7 +775,7 @@ async fn handle_deletion(
             );
             let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
             job_api
-                .delete(&job.name_any(), &Default::default())
+                .delete(&job.name_any(), &background_delete_params())
                 .await
                 .ok();
             patch_backup_status(ctx, namespace, name, status).await?;
@@ -786,7 +788,7 @@ async fn handle_deletion(
         if job_is_complete(&job) {
             let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
             job_api
-                .delete(&job.name_any(), &Default::default())
+                .delete(&job.name_any(), &background_delete_params())
                 .await
                 .ok();
 
@@ -1053,6 +1055,33 @@ mod tests {
         assert_eq!(caps.drop, Some(vec!["ALL".to_string()]));
 
         assert!(container.resources.is_some());
+    }
+
+    #[test]
+    fn validation_job_sets_ttl_seconds_after_finished() {
+        let backup = make_backup(
+            "019c7c76-f423-7a12-8f41-2bea7588a303",
+            "prod/v1/tenants/ns/clusters/k/backups/019c7c76/manifest.json",
+        );
+        let repository = make_repository_with_auth(Some("w"), Some("r"), Some("d"));
+        let job = build_validation_job(&backup, &repository, "default");
+        let job_spec = job.spec.unwrap();
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(BACKUP_JOB_TTL_SECONDS)
+        );
+    }
+
+    #[test]
+    fn deletion_job_sets_ttl_seconds_after_finished() {
+        let repository = make_repository_with_auth(Some("w"), Some("r"), Some("d"));
+        let keys = vec!["p/v1/manifest.json".to_string()];
+        let job = build_deletion_job(&repository, "default", "kb-test", &keys);
+        let job_spec = job.spec.unwrap();
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(BACKUP_JOB_TTL_SECONDS)
+        );
     }
 
     #[test]

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -1,5 +1,5 @@
 use crate::controller::{
-    BACKUP_JOB_TTL_SECONDS, RESULT_PATH, SCHEDULE_CONTROLLER_ID, background_delete_params,
+    BACKUP_JOB_TTL_SECONDS, DISCOVERY_CONTROLLER_ID, RESULT_PATH, background_delete_params,
     build_data_mover_wrapper, data_mover_image, default_resource_requirements,
     extract_termination_message, hardened_pod_security_context, hardened_security_context,
     select_succeeded_pod,
@@ -402,7 +402,7 @@ async fn process_discovery_for_schedule(
                 .delete(&job.name_any(), &background_delete_params())
                 .await
                 .ok();
-            update_schedule_condition(
+            update_discovery_status(
                 client,
                 namespace,
                 schedule,
@@ -445,7 +445,7 @@ async fn process_discovery_for_schedule(
                         "discovered {} manifest(s); created {} new, reconciled {} existing",
                         discovery.total_found, new_count, reconciled_count
                     );
-                    update_schedule_condition(
+                    update_discovery_status(
                         client,
                         namespace,
                         schedule,
@@ -494,7 +494,7 @@ async fn process_discovery_for_schedule(
                         .await
                         .ok();
 
-                    update_schedule_condition(
+                    update_discovery_status(
                         client,
                         namespace,
                         schedule,
@@ -525,9 +525,11 @@ async fn process_discovery_for_schedule(
     }
 
     let last_discovery = schedule.status.as_ref().and_then(|s| {
-        s.conditions
-            .iter()
-            .find(|c| c.type_ == "Discovered" || c.type_ == "DiscoveryFailed")
+        s.discovery.as_ref().and_then(|d| {
+            d.conditions
+                .iter()
+                .find(|c| c.type_ == "Discovered" || c.type_ == "DiscoveryFailed")
+        })
     });
 
     let is_stale = last_discovery
@@ -582,7 +584,7 @@ async fn process_discovery_for_schedule(
         }
     }
 
-    update_schedule_condition(
+    update_discovery_status(
         client,
         namespace,
         schedule,
@@ -958,7 +960,7 @@ fn merge_conditions(existing: &[Condition], new_conds: &[Condition]) -> Vec<Cond
     merged
 }
 
-async fn update_schedule_condition(
+async fn update_discovery_status(
     client: &Client,
     namespace: &str,
     schedule: &KanidmBackupSchedule,
@@ -979,31 +981,41 @@ async fn update_schedule_condition(
         message: message.to_string(),
     };
 
-    let existing_conditions = schedule
+    let mut discovery_status = schedule
         .status
         .as_ref()
-        .map(|s| s.conditions.as_slice())
-        .unwrap_or(&[]);
+        .and_then(|s| s.discovery.clone())
+        .unwrap_or_default();
+
+    let existing_conditions = discovery_status.conditions.as_slice();
     let merged_conditions = merge_conditions(existing_conditions, &[condition]);
+    discovery_status.conditions = merged_conditions;
+
+    if condition_type == "Discovered" && condition_status == "True" {
+        discovery_status.last_successful_scan_time = Some(Timestamp::now().to_string());
+    }
+    if condition_type == "DiscoveryFailed" && condition_status == "True" {
+        discovery_status.last_error = Some(message.to_string());
+    }
+    discovery_status.last_scan_time = Some(Timestamp::now().to_string());
 
     let patch = serde_json::json!({
         "apiVersion": "kaniop.rs/v1alpha1",
         "kind": "KanidmBackupSchedule",
         "status": {
-            "conditions": merged_conditions,
-            "observedGeneration": schedule.metadata.generation,
+            "discovery": discovery_status,
         }
     });
 
     api.patch_status(
         &name,
-        &PatchParams::apply(SCHEDULE_CONTROLLER_ID).force(),
+        &PatchParams::apply(DISCOVERY_CONTROLLER_ID).force(),
         &Patch::Apply(patch),
     )
     .await
     .map_err(|e| {
         Error::KubeError(
-            format!("failed to patch schedule status for {namespace}/{name}"),
+            format!("failed to patch discovery status for {namespace}/{name}"),
             Box::new(e),
         )
     })?;
@@ -1612,5 +1624,59 @@ mod tests {
             .find(|c| c.type_ == "DiscoveryFailed")
             .unwrap();
         assert_eq!(failed.status, "False");
+    }
+
+    #[test]
+    fn discovery_status_subobject_is_independent_from_schedule_conditions() {
+        use crate::crd::DiscoveryStatus;
+
+        let mut schedule = KanidmBackupSchedule {
+            metadata: ObjectMeta {
+                name: Some("test-schedule".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: KanidmBackupScheduleSpec {
+                kanidm_ref: crate::crd::ScheduleKanidmRef {
+                    name: "test-kanidm".to_string(),
+                },
+                repository_ref: crate::crd::ScheduleRepositoryRef {
+                    name: "test-repo".to_string(),
+                },
+                schedule: "0 2 * * *".to_string(),
+                time_zone: "UTC".to_string(),
+                suspend: false,
+                concurrency_policy: "Forbid".to_string(),
+                jitter_seconds: None,
+                local_versions: 7,
+                retention: None,
+            },
+            status: None,
+        };
+
+        let discovery_status = DiscoveryStatus {
+            last_scan_time: Some("2024-01-01T00:00:00Z".to_string()),
+            last_successful_scan_time: Some("2024-01-01T00:00:00Z".to_string()),
+            last_discovered_count: Some(5),
+            last_error: None,
+            conditions: vec![make_condition("Discovered", "True")],
+        };
+
+        schedule.status = Some(crate::crd::KanidmBackupScheduleStatus {
+            observed_generation: Some(1),
+            last_discovered_backup_ref: None,
+            last_successful_backup_time: None,
+            conditions: vec![make_condition("Ready", "True")],
+            discovery: Some(discovery_status),
+        });
+
+        let status = schedule.status.as_ref().unwrap();
+        assert_eq!(status.conditions.len(), 1);
+        assert_eq!(status.conditions[0].type_, "Ready");
+
+        let discovery = status.discovery.as_ref().unwrap();
+        assert_eq!(discovery.conditions.len(), 1);
+        assert_eq!(discovery.conditions[0].type_, "Discovered");
+        assert_eq!(discovery.last_discovered_count, Some(5));
     }
 }

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -1023,7 +1023,7 @@ async fn update_discovery_status(
     }
     discovery_status.last_scan_time = Some(Timestamp::now().to_string());
     if let Some(count) = discovered_count {
-        discovery_status.last_discovered_count = Some(count as i32);
+        discovery_status.last_discovered_count = Some(count);
     }
 
     let patch = serde_json::json!({

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -1,7 +1,7 @@
 use crate::controller::{
-    RESULT_PATH, build_data_mover_wrapper, data_mover_image, default_resource_requirements,
-    extract_termination_message, hardened_pod_security_context, hardened_security_context,
-    select_succeeded_pod,
+    BACKUP_JOB_TTL_SECONDS, RESULT_PATH, background_delete_params, build_data_mover_wrapper,
+    data_mover_image, default_resource_requirements, extract_termination_message,
+    hardened_pod_security_context, hardened_security_context, select_succeeded_pod,
 };
 use crate::crd::{
     BackupKanidmRef, BackupRepositoryRef, KanidmBackup, KanidmBackupRepository,
@@ -398,7 +398,7 @@ async fn process_discovery_for_schedule(
             );
             let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
             job_api
-                .delete(&job.name_any(), &Default::default())
+                .delete(&job.name_any(), &background_delete_params())
                 .await
                 .ok();
             update_schedule_condition(
@@ -436,7 +436,7 @@ async fn process_discovery_for_schedule(
 
                     let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
                     job_api
-                        .delete(&job.name_any(), &Default::default())
+                        .delete(&job.name_any(), &background_delete_params())
                         .await
                         .ok();
 
@@ -489,7 +489,7 @@ async fn process_discovery_for_schedule(
 
                     let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
                     job_api
-                        .delete(&job.name_any(), &Default::default())
+                        .delete(&job.name_any(), &background_delete_params())
                         .await
                         .ok();
 
@@ -686,6 +686,7 @@ fn build_discover_job(
         },
         spec: Some(JobSpec {
             backoff_limit: Some(0),
+            ttl_seconds_after_finished: Some(BACKUP_JOB_TTL_SECONDS),
             template: PodTemplateSpec {
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
@@ -1116,6 +1117,17 @@ mod tests {
         assert_eq!(sec.allow_privilege_escalation, Some(false));
         let caps = sec.capabilities.as_ref().unwrap();
         assert_eq!(caps.drop, Some(vec!["ALL".to_string()]));
+    }
+
+    #[test]
+    fn build_discover_job_sets_ttl_seconds_after_finished() {
+        let repo = make_repository("offsite");
+        let job = build_discover_job(&repo, "default", "daily", "ns-uid", "k-uid");
+        let job_spec = job.spec.unwrap();
+        assert_eq!(
+            job_spec.ttl_seconds_after_finished,
+            Some(BACKUP_JOB_TTL_SECONDS)
+        );
     }
 
     #[test]

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -1,7 +1,8 @@
 use crate::controller::{
-    BACKUP_JOB_TTL_SECONDS, RESULT_PATH, background_delete_params, build_data_mover_wrapper,
-    data_mover_image, default_resource_requirements, extract_termination_message,
-    hardened_pod_security_context, hardened_security_context, select_succeeded_pod,
+    BACKUP_JOB_TTL_SECONDS, RESULT_PATH, SCHEDULE_CONTROLLER_ID, background_delete_params,
+    build_data_mover_wrapper, data_mover_image, default_resource_requirements,
+    extract_termination_message, hardened_pod_security_context, hardened_security_context,
+    select_succeeded_pod,
 };
 use crate::crd::{
     BackupKanidmRef, BackupRepositoryRef, KanidmBackup, KanidmBackupRepository,
@@ -946,6 +947,17 @@ fn build_backup_cr(
     }
 }
 
+fn merge_conditions(existing: &[Condition], new_conds: &[Condition]) -> Vec<Condition> {
+    let new_types: HashSet<&str> = new_conds.iter().map(|c| c.type_.as_str()).collect();
+    let mut merged: Vec<Condition> = existing
+        .iter()
+        .filter(|c| !new_types.contains(c.type_.as_str()))
+        .cloned()
+        .collect();
+    merged.extend(new_conds.iter().cloned());
+    merged
+}
+
 async fn update_schedule_condition(
     client: &Client,
     namespace: &str,
@@ -967,18 +979,25 @@ async fn update_schedule_condition(
         message: message.to_string(),
     };
 
+    let existing_conditions = schedule
+        .status
+        .as_ref()
+        .map(|s| s.conditions.as_slice())
+        .unwrap_or(&[]);
+    let merged_conditions = merge_conditions(existing_conditions, &[condition]);
+
     let patch = serde_json::json!({
         "apiVersion": "kaniop.rs/v1alpha1",
         "kind": "KanidmBackupSchedule",
         "status": {
-            "conditions": [condition],
+            "conditions": merged_conditions,
             "observedGeneration": schedule.metadata.generation,
         }
     });
 
     api.patch_status(
         &name,
-        &PatchParams::apply(CONTROLLER_ID),
+        &PatchParams::apply(SCHEDULE_CONTROLLER_ID).force(),
         &Patch::Apply(patch),
     )
     .await
@@ -1497,5 +1516,101 @@ mod tests {
         assert!(!s.spec.suspend);
         s.spec.suspend = true;
         assert!(s.spec.suspend);
+    }
+
+    fn make_condition(type_: &str, status: &str) -> Condition {
+        Condition {
+            type_: type_.to_string(),
+            status: status.to_string(),
+            observed_generation: Some(1),
+            last_transition_time: Time(Timestamp::now()),
+            reason: "TestReason".to_string(),
+            message: "test message".to_string(),
+        }
+    }
+
+    #[test]
+    fn merge_conditions_adds_new_type_to_existing() {
+        let existing = vec![
+            make_condition("Ready", "True"),
+            make_condition("TransportExperimental", "True"),
+        ];
+        let new_conds = vec![make_condition("Discovered", "True")];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 3);
+        assert!(merged.iter().any(|c| c.type_ == "Ready"));
+        assert!(merged.iter().any(|c| c.type_ == "TransportExperimental"));
+        assert!(merged.iter().any(|c| c.type_ == "Discovered"));
+    }
+
+    #[test]
+    fn merge_conditions_replaces_same_type() {
+        let existing = vec![
+            make_condition("Ready", "True"),
+            make_condition("Discovered", "False"),
+        ];
+        let new_conds = vec![make_condition("Discovered", "True")];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 2);
+        let discovered = merged.iter().find(|c| c.type_ == "Discovered").unwrap();
+        assert_eq!(discovered.status, "True");
+        assert!(merged.iter().any(|c| c.type_ == "Ready"));
+    }
+
+    #[test]
+    fn merge_conditions_preserves_existing_when_no_overlap() {
+        let existing = vec![
+            make_condition("Ready", "True"),
+            make_condition("Suspended", "False"),
+            make_condition("TransportExperimental", "True"),
+        ];
+        let new_conds = vec![make_condition("DiscoveryFailed", "False")];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 4);
+        assert!(merged.iter().any(|c| c.type_ == "Ready"));
+        assert!(merged.iter().any(|c| c.type_ == "Suspended"));
+        assert!(merged.iter().any(|c| c.type_ == "TransportExperimental"));
+        assert!(merged.iter().any(|c| c.type_ == "DiscoveryFailed"));
+    }
+
+    #[test]
+    fn merge_conditions_empty_existing_returns_new() {
+        let existing: Vec<Condition> = vec![];
+        let new_conds = vec![make_condition("Discovered", "True")];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].type_, "Discovered");
+    }
+
+    #[test]
+    fn merge_conditions_empty_new_returns_existing() {
+        let existing = vec![make_condition("Ready", "True")];
+        let new_conds: Vec<Condition> = vec![];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].type_, "Ready");
+    }
+
+    #[test]
+    fn merge_conditions_multiple_new_replace_multiple_existing() {
+        let existing = vec![
+            make_condition("Ready", "True"),
+            make_condition("Discovered", "False"),
+            make_condition("DiscoveryFailed", "True"),
+        ];
+        let new_conds = vec![
+            make_condition("Discovered", "True"),
+            make_condition("DiscoveryFailed", "False"),
+        ];
+        let merged = merge_conditions(&existing, &new_conds);
+        assert_eq!(merged.len(), 3);
+        assert!(merged.iter().any(|c| c.type_ == "Ready"));
+        let discovered = merged.iter().find(|c| c.type_ == "Discovered").unwrap();
+        assert_eq!(discovered.status, "True");
+        let failed = merged
+            .iter()
+            .find(|c| c.type_ == "DiscoveryFailed")
+            .unwrap();
+        assert_eq!(failed.status, "False");
     }
 }

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -410,6 +410,7 @@ async fn process_discovery_for_schedule(
                 "False",
                 "DiscoverJobFailed",
                 &format!("Discover Job failed: {failure_message}; will retry"),
+                None,
             )
             .await?;
             return Ok(());
@@ -453,6 +454,7 @@ async fn process_discovery_for_schedule(
                         "True",
                         "DiscoveryComplete",
                         &msg,
+                        Some(discovery.total_found),
                     )
                     .await?;
 
@@ -502,6 +504,7 @@ async fn process_discovery_for_schedule(
                         "False",
                         "DiscoverResultInvalid",
                         &format!("Discover result invalid: {error_msg}"),
+                        None,
                     )
                     .await?;
                 }
@@ -592,6 +595,7 @@ async fn process_discovery_for_schedule(
         "False",
         "Discovering",
         "Discover Job created",
+        None,
     )
     .await?;
 
@@ -960,6 +964,20 @@ fn merge_conditions(existing: &[Condition], new_conds: &[Condition]) -> Vec<Cond
     merged
 }
 
+fn transition_time(
+    existing: &[Condition],
+    type_: &str,
+    new_status: &str,
+    new_reason: &str,
+) -> Time {
+    existing
+        .iter()
+        .find(|c| c.type_ == type_ && c.status == new_status && c.reason == new_reason)
+        .map(|c| c.last_transition_time.clone())
+        .unwrap_or_else(|| Time(Timestamp::now()))
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn update_discovery_status(
     client: &Client,
     namespace: &str,
@@ -968,24 +986,30 @@ async fn update_discovery_status(
     condition_status: &str,
     reason: &str,
     message: &str,
+    discovered_count: Option<u32>,
 ) -> Result<()> {
     let api: Api<KanidmBackupSchedule> = Api::namespaced(client.clone(), namespace);
     let name = schedule.name_any();
-
-    let condition = Condition {
-        type_: condition_type.to_string(),
-        status: condition_status.to_string(),
-        observed_generation: schedule.metadata.generation,
-        last_transition_time: Time(Timestamp::now()),
-        reason: reason.to_string(),
-        message: message.to_string(),
-    };
 
     let mut discovery_status = schedule
         .status
         .as_ref()
         .and_then(|s| s.discovery.clone())
         .unwrap_or_default();
+
+    let condition = Condition {
+        type_: condition_type.to_string(),
+        status: condition_status.to_string(),
+        observed_generation: schedule.metadata.generation,
+        last_transition_time: transition_time(
+            &discovery_status.conditions,
+            condition_type,
+            condition_status,
+            reason,
+        ),
+        reason: reason.to_string(),
+        message: message.to_string(),
+    };
 
     let existing_conditions = discovery_status.conditions.as_slice();
     let merged_conditions = merge_conditions(existing_conditions, &[condition]);
@@ -998,6 +1022,9 @@ async fn update_discovery_status(
         discovery_status.last_error = Some(message.to_string());
     }
     discovery_status.last_scan_time = Some(Timestamp::now().to_string());
+    if let Some(count) = discovered_count {
+        discovery_status.last_discovered_count = Some(count as i32);
+    }
 
     let patch = serde_json::json!({
         "apiVersion": "kaniop.rs/v1alpha1",

--- a/libs/backup/src/controller/mod.rs
+++ b/libs/backup/src/controller/mod.rs
@@ -12,7 +12,7 @@ use k8s_openapi::api::core::v1::{
     Capabilities, Pod, PodSecurityContext, ResourceRequirements, SeccompProfile, SecurityContext,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::PropagationPolicy;
+use kube::api::PropagationPolicy;
 
 pub const RESULT_PATH: &str = "/kaniop-result/result.json";
 pub const TERMINATION_MESSAGE_LIMIT: usize = 4096;
@@ -343,12 +343,12 @@ mod tests {
         let dp = background_delete_params();
         assert_eq!(
             dp.propagation_policy,
-            Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::PropagationPolicy::Background)
+            Some(kube::api::PropagationPolicy::Background)
         );
     }
 
     #[test]
     fn backup_job_ttl_is_positive() {
-        assert!(BACKUP_JOB_TTL_SECONDS > 0);
+        const { assert!(BACKUP_JOB_TTL_SECONDS > 0) };
     }
 }

--- a/libs/backup/src/controller/mod.rs
+++ b/libs/backup/src/controller/mod.rs
@@ -12,9 +12,18 @@ use k8s_openapi::api::core::v1::{
     Capabilities, Pod, PodSecurityContext, ResourceRequirements, SeccompProfile, SecurityContext,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::PropagationPolicy;
 
 pub const RESULT_PATH: &str = "/kaniop-result/result.json";
 pub const TERMINATION_MESSAGE_LIMIT: usize = 4096;
+pub const BACKUP_JOB_TTL_SECONDS: i32 = 600;
+
+pub fn background_delete_params() -> kube::api::DeleteParams {
+    kube::api::DeleteParams {
+        propagation_policy: Some(PropagationPolicy::Background),
+        ..Default::default()
+    }
+}
 
 pub fn data_mover_image() -> String {
     std::env::var("DATA_MOVER_IMAGE")
@@ -327,5 +336,19 @@ mod tests {
         };
         let message = extract_termination_message(&pod, "probe");
         assert!(message.is_none());
+    }
+
+    #[test]
+    fn background_delete_params_uses_background_propagation() {
+        let dp = background_delete_params();
+        assert_eq!(
+            dp.propagation_policy,
+            Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::PropagationPolicy::Background)
+        );
+    }
+
+    #[test]
+    fn backup_job_ttl_is_positive() {
+        assert!(BACKUP_JOB_TTL_SECONDS > 0);
     }
 }

--- a/libs/backup/src/controller/schedule.rs
+++ b/libs/backup/src/controller/schedule.rs
@@ -269,7 +269,7 @@ async fn reconcile_schedule(
     });
     api.patch_status(
         &name,
-        &kube::api::PatchParams::apply(CONTROLLER_ID),
+        &kube::api::PatchParams::apply(CONTROLLER_ID).force(),
         &kube::api::Patch::Apply(patch),
     )
     .await

--- a/libs/backup/src/controller/schedule.rs
+++ b/libs/backup/src/controller/schedule.rs
@@ -19,6 +19,7 @@ use kube::client::Client;
 use kube::runtime::controller::{self, Controller};
 use kube::runtime::watcher::Config;
 use kube::{Api, ResourceExt};
+use serde::Serialize;
 use tokio::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -124,6 +125,32 @@ fn is_repository_config_accepted(repo: &KanidmBackupRepository) -> bool {
         .is_some_and(|c| c.status == "True" && c.reason == "Accepted")
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScheduleStatusPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observed_generation: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_discovered_backup_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_successful_backup_time: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    conditions: Vec<Condition>,
+}
+
+fn transition_time(
+    existing: &[Condition],
+    type_: &str,
+    new_status: &str,
+    new_reason: &str,
+) -> Time {
+    existing
+        .iter()
+        .find(|c| c.type_ == type_ && c.status == new_status && c.reason == new_reason)
+        .map(|c| c.last_transition_time.clone())
+        .unwrap_or_else(|| Time(Timestamp::now()))
+}
+
 async fn reconcile_schedule(
     obj: Arc<KanidmBackupSchedule>,
     ctx: Arc<kaniop_operator::controller::context::Context<KanidmBackupSchedule>>,
@@ -172,6 +199,7 @@ async fn reconcile_schedule(
         );
     }
 
+    let existing_conditions = status.conditions.clone();
     let mut conditions_to_set: Vec<Condition> = Vec::new();
 
     if kanidm.is_none() {
@@ -179,7 +207,12 @@ async fn reconcile_schedule(
             type_: "Ready".to_string(),
             status: "False".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(
+                &existing_conditions,
+                "Ready",
+                "False",
+                "KanidmNotFound",
+            ),
             reason: "KanidmNotFound".to_string(),
             message: format!(
                 "Referenced Kanidm '{}' does not exist in namespace '{}'",
@@ -191,7 +224,12 @@ async fn reconcile_schedule(
             type_: "Ready".to_string(),
             status: "False".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(
+                &existing_conditions,
+                "Ready",
+                "False",
+                "RepositoryNotFound",
+            ),
             reason: "RepositoryNotFound".to_string(),
             message: format!(
                 "Referenced repository '{}' does not exist in namespace '{}'",
@@ -203,7 +241,12 @@ async fn reconcile_schedule(
             type_: "Ready".to_string(),
             status: "False".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(
+                &existing_conditions,
+                "Ready",
+                "False",
+                "RepositoryConfigNotAccepted",
+            ),
             reason: "RepositoryConfigNotAccepted".to_string(),
             message: format!(
                 "Referenced repository '{}' configuration has not been accepted in namespace '{}'",
@@ -225,7 +268,7 @@ async fn reconcile_schedule(
             type_: "Ready".to_string(),
             status: "False".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(&existing_conditions, "Ready", "False", reason),
             reason: reason.to_string(),
             message: message.to_string(),
         });
@@ -233,7 +276,12 @@ async fn reconcile_schedule(
             type_: "Suspended".to_string(),
             status: "True".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(
+                &existing_conditions,
+                "Suspended",
+                "True",
+                reason,
+            ),
             reason: reason.to_string(),
             message: message.to_string(),
         });
@@ -242,7 +290,7 @@ async fn reconcile_schedule(
             type_: "Ready".to_string(),
             status: "True".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(&existing_conditions, "Ready", "True", "Configured"),
             reason: "Configured".to_string(),
             message: "Schedule is configured; online transport is rendered into Kanidm [online_backup] configuration only. No backup completion is claimed without an atomic commit contract.".to_string(),
         });
@@ -250,7 +298,7 @@ async fn reconcile_schedule(
             type_: "TransportExperimental".to_string(),
             status: "True".to_string(),
             observed_generation: obj.metadata.generation,
-            last_transition_time: Time(Timestamp::now()),
+            last_transition_time: transition_time(&existing_conditions, "TransportExperimental", "True", "NoCompletionContract"),
             reason: "NoCompletionContract".to_string(),
             message: "Online backup transport is experimental. Kanidm has no documented completion contract; Kaniop does not report production backup success.".to_string(),
         });
@@ -261,24 +309,39 @@ async fn reconcile_schedule(
     }
     status.conditions.extend(conditions_to_set);
 
-    let api: Api<KanidmBackupSchedule> = Api::namespaced(ctx.client.clone(), &namespace);
-    let patch = serde_json::json!({
-        "apiVersion": "kaniop.rs/v1alpha1",
-        "kind": "KanidmBackupSchedule",
-        "status": status
+    let status_changed = obj.status.as_ref().is_none_or(|s| {
+        s.observed_generation != status.observed_generation
+            || s.conditions != status.conditions
+            || s.last_discovered_backup_ref != status.last_discovered_backup_ref
+            || s.last_successful_backup_time != status.last_successful_backup_time
     });
-    api.patch_status(
-        &name,
-        &kube::api::PatchParams::apply(CONTROLLER_ID).force(),
-        &kube::api::Patch::Apply(patch),
-    )
-    .await
-    .map_err(|e| {
-        Error::KubeError(
-            format!("failed to patch status for {namespace}/{name}"),
-            Box::new(e),
+
+    if status_changed {
+        let patch_payload = ScheduleStatusPatch {
+            observed_generation: status.observed_generation,
+            last_discovered_backup_ref: status.last_discovered_backup_ref.clone(),
+            last_successful_backup_time: status.last_successful_backup_time.clone(),
+            conditions: status.conditions.clone(),
+        };
+        let api: Api<KanidmBackupSchedule> = Api::namespaced(ctx.client.clone(), &namespace);
+        let patch = serde_json::json!({
+            "apiVersion": "kaniop.rs/v1alpha1",
+            "kind": "KanidmBackupSchedule",
+            "status": patch_payload
+        });
+        api.patch_status(
+            &name,
+            &kube::api::PatchParams::apply(CONTROLLER_ID).force(),
+            &kube::api::Patch::Apply(patch),
         )
-    })?;
+        .await
+        .map_err(|e| {
+            Error::KubeError(
+                format!("failed to patch status for {namespace}/{name}"),
+                Box::new(e),
+            )
+        })?;
+    }
 
     let requeue = if effective_suspend {
         REQUEUE_SUSPENDED
@@ -438,6 +501,7 @@ mod tests {
         AuthMethod, KanidmBackupRepositorySpec, RepositoryAuthentication, S3Config, SecretRef,
     };
     use kube::api::ObjectMeta;
+    use std::str::FromStr;
 
     fn make_repo_with_condition(
         status: Option<crate::crd::KanidmBackupRepositoryStatus>,
@@ -646,6 +710,79 @@ mod tests {
         let policy = RetentionPolicy::default();
         let result = select_deletion_candidates(&[], &policy, &now);
         assert!(result.delete.is_empty());
+    }
+
+    #[test]
+    fn schedule_status_patch_excludes_discovery() {
+        let patch = ScheduleStatusPatch {
+            observed_generation: Some(1),
+            last_discovered_backup_ref: Some("kb-abc123".to_string()),
+            last_successful_backup_time: Some("2024-01-01T00:00:00Z".to_string()),
+            conditions: vec![Condition {
+                type_: "Ready".to_string(),
+                status: "True".to_string(),
+                observed_generation: Some(1),
+                last_transition_time: Time(Timestamp::now()),
+                reason: "Configured".to_string(),
+                message: "test".to_string(),
+            }],
+        };
+        let json = serde_json::to_value(&patch).unwrap();
+        assert!(
+            json.get("discovery").is_none(),
+            "schedule status patch must not include discovery; found keys: {:?}",
+            json.as_object().unwrap().keys().collect::<Vec<_>>()
+        );
+        assert!(json.get("observedGeneration").is_some());
+        assert!(json.get("conditions").is_some());
+        assert!(json.get("lastDiscoveredBackupRef").is_some());
+        assert!(json.get("lastSuccessfulBackupTime").is_some());
+    }
+
+    #[test]
+    fn schedule_status_patch_omits_none_fields() {
+        let patch = ScheduleStatusPatch {
+            observed_generation: Some(1),
+            last_discovered_backup_ref: None,
+            last_successful_backup_time: None,
+            conditions: vec![],
+        };
+        let json = serde_json::to_value(&patch).unwrap();
+        assert!(json.get("discovery").is_none());
+        assert!(json.get("lastDiscoveredBackupRef").is_none());
+        assert!(json.get("lastSuccessfulBackupTime").is_none());
+    }
+
+    #[test]
+    fn transition_time_preserves_when_unchanged() {
+        let existing = vec![Condition {
+            type_: "Ready".to_string(),
+            status: "True".to_string(),
+            observed_generation: Some(1),
+            last_transition_time: Time(Timestamp::from_str("2024-01-01T00:00:00Z").unwrap()),
+            reason: "Configured".to_string(),
+            message: "old message".to_string(),
+        }];
+        let result = transition_time(&existing, "Ready", "True", "Configured");
+        assert_eq!(
+            result,
+            Time(Timestamp::from_str("2024-01-01T00:00:00Z").unwrap())
+        );
+    }
+
+    #[test]
+    fn transition_time_updates_when_status_changes() {
+        let existing = vec![Condition {
+            type_: "Ready".to_string(),
+            status: "True".to_string(),
+            observed_generation: Some(1),
+            last_transition_time: Time(Timestamp::from_str("2024-01-01T00:00:00Z").unwrap()),
+            reason: "Configured".to_string(),
+            message: "old".to_string(),
+        }];
+        let before = Timestamp::now();
+        let result = transition_time(&existing, "Ready", "False", "KanidmNotFound");
+        assert!(result.0 >= before);
     }
 
     #[test]

--- a/libs/oauth2/src/crd.rs
+++ b/libs/oauth2/src/crd.rs
@@ -439,7 +439,7 @@ impl KanidmClaimMapJoinStrategy {
 /// Most recent observed status of the Kanidm Group. Read-only.
 /// More info:
 /// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct KanidmOAuth2ClientStatus {

--- a/libs/oauth2/src/reconcile/status.rs
+++ b/libs/oauth2/src/reconcile/status.rs
@@ -158,6 +158,27 @@ impl StatusExt for KanidmOAuth2Client {
             secret_data.as_ref(),
             current_image_status,
         )?;
+        if self.status.as_ref() == Some(&status) {
+            trace!("status unchanged, skipping patch");
+            return Ok(status);
+        }
+        if let Some(old) = self.status.as_ref() {
+            let old_conds: Vec<_> = old
+                .conditions
+                .iter()
+                .flatten()
+                .map(|c| format!("{}={}", c.type_, c.status))
+                .collect();
+            let new_conds: Vec<_> = status
+                .conditions
+                .iter()
+                .flatten()
+                .map(|c| format!("{}={}", c.type_, c.status))
+                .collect();
+            debug!(old = ?old_conds, new = ?new_conds, old_ready = old.ready, new_ready = status.ready, "status changed");
+        } else {
+            debug!(conditions = ?status.conditions, "initial status patch");
+        }
         let status_patch = Patch::Apply(KanidmOAuth2Client {
             status: Some(status.clone()),
             ..KanidmOAuth2Client::default()
@@ -177,6 +198,23 @@ impl StatusExt for KanidmOAuth2Client {
     }
 }
 
+fn last_transition_time(
+    current_conditions: Option<&Vec<Condition>>,
+    type_: &str,
+    new_status: &str,
+    new_reason: &str,
+) -> Time {
+    let now_time = Time(Timestamp::now());
+    if let Some(conditions) = current_conditions {
+        for c in conditions {
+            if c.type_ == type_ && c.status == new_status && c.reason == new_reason {
+                return c.last_transition_time.clone();
+            }
+        }
+    }
+    now_time
+}
+
 impl KanidmOAuth2Client {
     fn generate_status(
         &self,
@@ -186,7 +224,8 @@ impl KanidmOAuth2Client {
         secret_data: Option<&std::collections::BTreeMap<String, k8s_openapi::ByteString>>,
         current_image_status: Option<OAuth2ClientImageStatus>,
     ) -> Result<KanidmOAuth2ClientStatus> {
-        let now = Timestamp::now();
+        let current_conditions = self.status.as_ref().and_then(|s| s.conditions.as_ref());
+
         let conditions = match oauth2_opt.clone() {
             Some(oauth2) => {
                 let exist_condition = Condition {
@@ -194,7 +233,12 @@ impl KanidmOAuth2Client {
                     status: CONDITION_TRUE.to_string(),
                     reason: "Exists".to_string(),
                     message: "OAuth2 client exists.".to_string(),
-                    last_transition_time: Time(now),
+                    last_transition_time: last_transition_time(
+                        current_conditions,
+                        TYPE_EXISTS,
+                        CONDITION_TRUE,
+                        "Exists",
+                    ),
                     observed_generation: self.metadata.generation,
                 };
 
@@ -206,7 +250,12 @@ impl KanidmOAuth2Client {
                         status: CONDITION_TRUE.to_string(),
                         reason: "SecretExists".to_string(),
                         message: "Secret exists.".to_string(),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_SECRET_INITIALIZED,
+                            CONDITION_TRUE,
+                            "SecretExists",
+                        ),
                         observed_generation: self.metadata.generation,
                     })
                 } else {
@@ -215,7 +264,12 @@ impl KanidmOAuth2Client {
                         status: CONDITION_FALSE.to_string(),
                         reason: "SecretNotExists".to_string(),
                         message: "Secret does not exist.".to_string(),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_SECRET_INITIALIZED,
+                            CONDITION_FALSE,
+                            "SecretNotExists",
+                        ),
                         observed_generation: self.metadata.generation,
                     })
                 };
@@ -242,7 +296,12 @@ impl KanidmOAuth2Client {
                                 status: CONDITION_TRUE.to_string(),
                                 reason: REASON_ATTRIBUTE_MATCH.to_string(),
                                 message: "Secret metadata matches secretTemplate.".to_string(),
-                                last_transition_time: Time(now),
+                                last_transition_time: last_transition_time(
+                                    current_conditions,
+                                    TYPE_SECRET_TEMPLATE_SYNCED,
+                                    CONDITION_TRUE,
+                                    REASON_ATTRIBUTE_MATCH,
+                                ),
                                 observed_generation: self.metadata.generation,
                             }
                         } else {
@@ -252,7 +311,12 @@ impl KanidmOAuth2Client {
                                 reason: REASON_ATTRIBUTE_NOT_MATCH.to_string(),
                                 message: "Secret metadata does not match secretTemplate."
                                     .to_string(),
-                                last_transition_time: Time(now),
+                                last_transition_time: last_transition_time(
+                                    current_conditions,
+                                    TYPE_SECRET_TEMPLATE_SYNCED,
+                                    CONDITION_FALSE,
+                                    REASON_ATTRIBUTE_NOT_MATCH,
+                                ),
                                 observed_generation: self.metadata.generation,
                             }
                         })
@@ -269,26 +333,34 @@ impl KanidmOAuth2Client {
                             secret_data,
                             self.spec.secret_key_aliases.as_ref(),
                         );
+                    let cond_status = if aliases_in_sync {
+                        CONDITION_TRUE.to_string()
+                    } else {
+                        CONDITION_FALSE.to_string()
+                    };
+                    let cond_reason = if aliases_in_sync {
+                        REASON_ALIASES_MATCH.to_string()
+                    } else {
+                        REASON_ALIASES_NOT_MATCH.to_string()
+                    };
+                    let cond_message = if aliases_in_sync {
+                        "Secret keys match secretKeyAliases.".to_string()
+                    } else if secret.is_some() {
+                        "Secret keys do not match secretKeyAliases.".to_string()
+                    } else {
+                        "Secret not found in store.".to_string()
+                    };
                     Some(Condition {
                         type_: TYPE_SECRET_KEY_ALIASES_SYNCED.to_string(),
-                        status: if aliases_in_sync {
-                            CONDITION_TRUE.to_string()
-                        } else {
-                            CONDITION_FALSE.to_string()
-                        },
-                        reason: if aliases_in_sync {
-                            REASON_ALIASES_MATCH.to_string()
-                        } else {
-                            REASON_ALIASES_NOT_MATCH.to_string()
-                        },
-                        message: if aliases_in_sync {
-                            "Secret keys match secretKeyAliases.".to_string()
-                        } else if secret.is_some() {
-                            "Secret keys do not match secretKeyAliases.".to_string()
-                        } else {
-                            "Secret not found in store.".to_string()
-                        },
-                        last_transition_time: Time(now),
+                        status: cond_status.clone(),
+                        reason: cond_reason.clone(),
+                        message: cond_message,
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_SECRET_KEY_ALIASES_SYNCED,
+                            &cond_status,
+                            &cond_reason,
+                        ),
                         observed_generation: self.metadata.generation,
                     })
                 };
@@ -304,7 +376,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "Secret rotation forced via {FORCE_SECRET_ROTATION_ANNOTATION}."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_SECRET_ROTATED,
+                                CONDITION_FALSE,
+                                REASON_FORCE_ROTATION_REQUESTED,
+                            ),
                             observed_generation: self.metadata.generation,
                         }),
                         _ => self.spec.secret_rotation.as_ref().and_then(|config| {
@@ -320,7 +397,12 @@ impl KanidmOAuth2Client {
                                             reason: REASON_ROTATION_NEEDED.to_string(),
                                             message: "Secret rotation period has elapsed."
                                                 .to_string(),
-                                            last_transition_time: Time(now),
+                                            last_transition_time: last_transition_time(
+                                                current_conditions,
+                                                TYPE_SECRET_ROTATED,
+                                                CONDITION_FALSE,
+                                                REASON_ROTATION_NEEDED,
+                                            ),
                                             observed_generation: self.metadata.generation,
                                         })
                                     } else {
@@ -330,12 +412,16 @@ impl KanidmOAuth2Client {
                                             reason: REASON_ROTATION_NOT_NEEDED.to_string(),
                                             message: "Secret is within rotation period."
                                                 .to_string(),
-                                            last_transition_time: Time(now),
+                                            last_transition_time: last_transition_time(
+                                                current_conditions,
+                                                TYPE_SECRET_ROTATED,
+                                                CONDITION_TRUE,
+                                                REASON_ROTATION_NOT_NEEDED,
+                                            ),
                                             observed_generation: self.metadata.generation,
                                         })
                                     }
                                 }
-                                // Secret doesn't exist yet, will be created with rotation annotations
                                 None => None,
                             }
                         }),
@@ -352,7 +438,12 @@ impl KanidmOAuth2Client {
                         status: CONDITION_TRUE.to_string(),
                         reason: REASON_ATTRIBUTES_MATCH.to_string(),
                         message: "OAuth2 client exists with desired attributes.".to_string(),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_UPDATED,
+                            CONDITION_TRUE,
+                            REASON_ATTRIBUTES_MATCH,
+                        ),
                         observed_generation: self.metadata.generation,
                     }
                 } else {
@@ -361,7 +452,12 @@ impl KanidmOAuth2Client {
                         status: CONDITION_FALSE.to_string(),
                         reason: REASON_ATTRIBUTES_NOT_MATCH.to_string(),
                         message: "OAuth2 client exists with different attributes.".to_string(),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_UPDATED,
+                            CONDITION_FALSE,
+                            REASON_ATTRIBUTES_NOT_MATCH,
+                        ),
                         observed_generation: self.metadata.generation,
                     }
                 };
@@ -380,7 +476,12 @@ impl KanidmOAuth2Client {
                         message: format!(
                             "OAuth2 client exists with desired {ATTR_OAUTH2_RS_ORIGIN} attribute."
                         ),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_REDIRECT_URL_UPDATED,
+                            CONDITION_TRUE,
+                            REASON_ATTRIBUTE_MATCH,
+                        ),
                         observed_generation: self.metadata.generation,
                     }
                 } else {
@@ -391,7 +492,12 @@ impl KanidmOAuth2Client {
                         message: format!(
                             "OAuth2 client exists with different {ATTR_OAUTH2_RS_ORIGIN} attribute."
                         ),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_REDIRECT_URL_UPDATED,
+                            CONDITION_FALSE,
+                            REASON_ATTRIBUTE_NOT_MATCH,
+                        ),
                         observed_generation: self.metadata.generation,
                     }
                 };
@@ -409,7 +515,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_RS_SCOPE_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_SCOPE_MAP_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -420,7 +531,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_RS_SCOPE_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_SCOPE_MAP_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -439,7 +555,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_RS_SUP_SCOPE_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_SUP_SCOPE_MAP_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -450,7 +571,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_RS_SUP_SCOPE_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_SUP_SCOPE_MAP_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -469,7 +595,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_RS_CLAIM_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_CLAIMS_MAP_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -480,7 +611,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_RS_CLAIM_MAP} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_CLAIMS_MAP_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -496,7 +632,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_STRICT_REDIRECT_URI} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_STRICT_REDIRECT_URL_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -507,7 +648,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_STRICT_REDIRECT_URI} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_STRICT_REDIRECT_URL_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -523,7 +669,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_DISABLE_PKCE_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -534,7 +685,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_DISABLE_PKCE_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -550,7 +706,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_PREFER_SHORT_USERNAME} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_PREFER_SHORT_NAME_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -561,7 +722,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_PREFER_SHORT_USERNAME} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_PREFER_SHORT_NAME_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -577,7 +743,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_ALLOW_LOCALHOST_REDIRECT_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -588,7 +759,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_ALLOW_LOCALHOST_REDIRECT_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -604,7 +780,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_LEGACY_CRYPTO_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -615,7 +796,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_LEGACY_CRYPTO_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -631,7 +817,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with desired {ATTR_OAUTH2_CONSENT_PROMPT_ENABLE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_DISABLE_CONSENT_PROMPT_UPDATED,
+                                CONDITION_TRUE,
+                                REASON_ATTRIBUTE_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     } else {
@@ -642,7 +833,12 @@ impl KanidmOAuth2Client {
                             message: format!(
                                 "OAuth2 client exists with different {ATTR_OAUTH2_CONSENT_PROMPT_ENABLE} attribute."
                             ),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_DISABLE_CONSENT_PROMPT_UPDATED,
+                                CONDITION_FALSE,
+                                REASON_ATTRIBUTE_NOT_MATCH,
+                            ),
                             observed_generation: self.metadata.generation,
                         }
                     }
@@ -653,7 +849,12 @@ impl KanidmOAuth2Client {
                         status: CONDITION_TRUE.to_string(),
                         reason: "NoImageRequired".to_string(),
                         message: "No image URL specified in spec.".to_string(),
-                        last_transition_time: Time(now),
+                        last_transition_time: last_transition_time(
+                            current_conditions,
+                            TYPE_IMAGE_UPDATED,
+                            CONDITION_TRUE,
+                            "NoImageRequired",
+                        ),
                         observed_generation: self.metadata.generation,
                     }),
                     Some(image_spec) => match &current_image_status {
@@ -662,7 +863,12 @@ impl KanidmOAuth2Client {
                             status: CONDITION_TRUE.to_string(),
                             reason: "ImageSynced".to_string(),
                             message: "Image URL matches cached status.".to_string(),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_IMAGE_UPDATED,
+                                CONDITION_TRUE,
+                                "ImageSynced",
+                            ),
                             observed_generation: self.metadata.generation,
                         }),
                         _ => Some(Condition {
@@ -670,7 +876,12 @@ impl KanidmOAuth2Client {
                             status: CONDITION_FALSE.to_string(),
                             reason: "ImageNeedsUpdate".to_string(),
                             message: "Image URL has changed or not yet synced.".to_string(),
-                            last_transition_time: Time(now),
+                            last_transition_time: last_transition_time(
+                                current_conditions,
+                                TYPE_IMAGE_UPDATED,
+                                CONDITION_FALSE,
+                                "ImageNeedsUpdate",
+                            ),
                             observed_generation: self.metadata.generation,
                         }),
                     },
@@ -698,7 +909,12 @@ impl KanidmOAuth2Client {
                 status: CONDITION_FALSE.to_string(),
                 reason: "NotExists".to_string(),
                 message: "OAuth2 client is not present.".to_string(),
-                last_transition_time: Time(now),
+                last_transition_time: last_transition_time(
+                    current_conditions,
+                    TYPE_EXISTS,
+                    CONDITION_FALSE,
+                    "NotExists",
+                ),
                 observed_generation: self.metadata.generation,
             }],
         };
@@ -724,5 +940,100 @@ impl KanidmOAuth2Client {
             kanidm_ref: self.kanidm_ref(),
             image: current_image_status,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::jiff::Timestamp;
+
+    fn make_condition(type_: &str, status: &str, reason: &str, time: Time) -> Condition {
+        Condition {
+            type_: type_.to_string(),
+            status: status.to_string(),
+            reason: reason.to_string(),
+            message: String::new(),
+            last_transition_time: time,
+            observed_generation: Some(1),
+        }
+    }
+
+    #[test]
+    fn test_last_transition_time_preserves_when_unchanged() {
+        let old_time = Time(Timestamp::from_second(1_000_000).unwrap());
+        let conditions = vec![make_condition(
+            TYPE_EXISTS,
+            CONDITION_TRUE,
+            "Exists",
+            old_time.clone(),
+        )];
+
+        let result = last_transition_time(Some(&conditions), TYPE_EXISTS, CONDITION_TRUE, "Exists");
+
+        assert_eq!(result, old_time);
+    }
+
+    #[test]
+    fn test_last_transition_time_updates_when_status_changes() {
+        let old_time = Time(Timestamp::from_second(1_000_000).unwrap());
+        let conditions = vec![make_condition(
+            TYPE_EXISTS,
+            CONDITION_TRUE,
+            "Exists",
+            old_time.clone(),
+        )];
+
+        let result =
+            last_transition_time(Some(&conditions), TYPE_EXISTS, CONDITION_FALSE, "NotExists");
+
+        assert_ne!(result, old_time);
+    }
+
+    #[test]
+    fn test_last_transition_time_updates_when_reason_changes() {
+        let old_time = Time(Timestamp::from_second(1_000_000).unwrap());
+        let conditions = vec![make_condition(
+            TYPE_UPDATED,
+            CONDITION_TRUE,
+            "AttributesMatch",
+            old_time.clone(),
+        )];
+
+        let result = last_transition_time(
+            Some(&conditions),
+            TYPE_UPDATED,
+            CONDITION_TRUE,
+            "DifferentReason",
+        );
+
+        assert_ne!(result, old_time);
+    }
+
+    #[test]
+    fn test_last_transition_time_new_when_no_previous_conditions() {
+        let result = last_transition_time(None, TYPE_EXISTS, CONDITION_TRUE, "Exists");
+
+        assert!(result.0.as_second() > 1_000_000);
+    }
+
+    #[test]
+    fn test_last_transition_time_new_when_type_not_found() {
+        let old_time = Time(Timestamp::from_second(1_000_000).unwrap());
+        let conditions = vec![make_condition(
+            TYPE_EXISTS,
+            CONDITION_TRUE,
+            "Exists",
+            old_time.clone(),
+        )];
+
+        let result = last_transition_time(
+            Some(&conditions),
+            TYPE_UPDATED,
+            CONDITION_TRUE,
+            "AttributesMatch",
+        );
+
+        assert_ne!(result, old_time);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the six symptoms reported in #972 arising from the backup system introduced in 0.14.0. This PR does **not** add new backup features; it resolves operational issues discovered on live clusters running the existing implementation.

Closes #972.

---

## Changes by area

### 1. Orphan Job/pod cleanup (`7ff8e36`)

- All 8 backup Job deletion paths (3 discovery, 5 backup controller) now use explicit **Background propagation** so Kubernetes GC deletes dependent pods when the Job is removed.
- All 3 backup Job builders (discover, validation, deletion) set `ttlSecondsAfterFinished: 600` as defense-in-depth so completed Jobs are auto-cleaned by the TTL controller even if explicit deletion is missed.
- Introduced `BACKUP_JOB_TTL_SECONDS` named constant and `background_delete_params()` helper for reuse.

### 2. Race-free discovery status and CRD upgrade path (`72235e4`, `ad273c9`, `420dbf9`, `f92b999`)

**Field-manager conflict (409):** `backup-discovery` and `backup-schedule` previously used separate SSA field managers on `KanidmBackupSchedule.status.conditions`. On clusters upgraded without CRD replacement (Helm skips `crds/`), the conditions list lacks `x-kubernetes-list-type=map`, making it atomic under SSA — the two managers clobbered each other on every write.

- Discovery now patches schedule status under the `backup-schedule` field manager (`SCHEDULE_CONTROLLER_ID`) instead of `backup-discovery`.
- Discovery performs read-modify-write: reads existing conditions, merges its own via `merge_conditions()`, sends the full merged list — preserving `Ready`, `Suspended`, `TransportExperimental` set by the schedule controller.
- Both controllers use `force()` to reclaim ownership from the stale `backup-discovery` manager left behind after upgrade.
- Schedule status patch uses a deliberately partial `ScheduleStatusPatch` that omits `status.discovery` entirely so `backup-schedule` never owns or overwrites `backup-discovery` fields.
- `DiscoveryStatus.last_discovered_count` changed from `i32` to `u32` with CEL validation.

**CRD upgrade gap:** Helm only installs CRDs from `crds/` on first install and never updates them on upgrade. Schema changes (e.g. list-map annotations from #963) never reached existing installations.

- New `crd-apply` Helm hook server-side applies all generated CRDs before each install/upgrade via `kaniop-crd-migrator` with a new `apply-crds` subcommand.
- Embeds `crds.yaml` at compile time, uses dedicated `kaniop-helm-crds` field manager, waits for Established condition, never deletes CRDs or resources.
- Configurable via `crdApply.enabled` (default: true), includes dedicated RBAC, runs at hook weight -40/-35 before CRD migration hooks.

### 3. Intentional experimental/immutability documentation (`ab9c351`, `0c3e5f2`)

- `TransportExperimental` condition: documented that Kanidm has no documented online-backup completion contract; Kaniop cannot report production backup success. This is intentional, not a bug.
- Schedule/retention immutability: documented rationale and the delete/recreate change workflow with guidance on what happens to existing Backup CRs and S3 data.
- Repository immutability: same treatment.
- CEL validation and webhook messages improved to explain *why* fields are immutable and *how* to change them.

### 4. OAuth2 no-op status patch reduction (`f059201`)

The OAuth2 controller unconditionally refreshed `lastTransitionTime` to `now()` on every status patch, even when condition semantics had not changed. Combined with the periodic `Action::requeue`, every reconcile produced a different status object, triggering a watch event and another reconcile — a self-amplifying loop.

- `last_transition_time()` helper preserves existing timestamp when type+status+reason are unchanged (matching person/service-account pattern).
- No-op guard: skips the status patch entirely when generated status equals current status.
- `KanidmOAuth2ClientStatus` now derives `PartialEq`.

### 5. Native backup troubleshooting documentation (`0c3e5f2`)

Added comprehensive troubleshooting section to `backup-restore.md`:
- StatefulSet rolling update behavior when backup config changes (pods pick up env on restart).
- UTC schedule timing expectations.
- Rendered config.toml verification via container runtime UID.
- Kanidm 1.11.1 scheduler behavioral notes with evidence-based troubleshooting (log messages, writable path, pod uptime) — no unsafe workarounds suggested.

### 6. Why discovery remains an ephemeral credential-isolated Job

The design intentionally keeps backup discovery as a short-lived Kubernetes Job with its own S3 credential mount rather than moving S3 access in-process into the operator. This preserves the security boundary: the operator process never holds S3 credentials, and each discovery run gets a fresh, time-limited credential scope. The orphan cleanup (item 1) and TTL (item 1) address the operational cost of this design without compromising isolation.

---

## Verification

- **Local:** `make lint` passed (per user request, no other local verification performed).
- **CI:** Full test suite (`make test`, e2e shards) will run on this PR.
- **Live cluster (grigri):** Read-only observation only. Existing orphan Jobs/pods on grigri were **not** cleaned up as part of this work.

## Commits (9)

| Commit | Area |
|--------|------|
| `7ff8e36` | Orphan Job/pod cleanup — Background propagation + TTL |
| `72235e4` | Unify schedule status field-manager to eliminate 409 conflicts |
| `ad273c9` | Helm CRD apply hook for upgrade path |
| `ab9c351` | Immutability and TransportExperimental documentation |
| `0c3e5f2` | Review findings: SSA redesign, native backup docs, orphan cleanup guidance |
| `f059201` | OAuth2 lastTransitionTime preservation + no-op patch guard |
| `420dbf9` | Review findings: schedule SSA partial patch, discovery wiring, transition time |
| `4a80a12` | Regenerate example YAML |
| `f92b999` | `i32` → `u32` for `last_discovered_count` |
