### PR TITLE
fix: make KanidmBackupSchedule the backup source of truth

### DIFF
--- a/Documentation/src/usage/backup-restore.md
+++ b/Documentation/src/usage/backup-restore.md
@@ -3,14 +3,7 @@
 > [!WARNING]
 > **Experimental and incomplete.** Kaniop's backup and restore subsystem is still under active development. APIs and behavior may change, some workflows are not yet fully implemented or hardened, and the feature is **not yet production-supported**. Do not rely on it as the sole backup or disaster-recovery mechanism. See the [production backup and restore implementation plan](https://github.com/pando85/kaniop/blob/master/docs/plans/production-kanidm-backup-and-restore.md) for the remaining production gates.
 
-Kaniop uses Kanidm's native logical backup format. The operator configures the online backup scheduler on exactly one primary node and stores local artifacts under `/data/backups` on the Kanidm PVC.
-
-```yaml
-spec:
-  backup:
-    schedule: "0 2 * * *"
-    versions: 7
-```
+Kaniop uses Kanidm's native logical backup format. `KanidmBackupSchedule` is the single source of truth for the native online backup schedule, local retention, remote repository, and remote retention. The operator configures the online backup scheduler on exactly one primary node and stores local artifacts under `/data/backups` on the Kanidm PVC.
 
 Local backups require PVC-backed storage and one `replicaGroup` with `primaryNode: true`. Kaniop intentionally does not claim PITR semantics or a globally atomic point-in-time cut across replicated writable nodes.
 
@@ -269,7 +262,7 @@ Backup IDs are derived deterministically (UUIDv7 seeded from the embedded timest
 
 ### Local pruning
 
-The transport never deletes local backup files. Kanidm's `versions` setting (configured via `spec.backup.versions` on the Kanidm CR or `spec.localVersions` on the Schedule) owns local retention on the PVC.
+The transport never deletes local backup files. Kanidm's `versions` setting is rendered exclusively from `KanidmBackupSchedule.spec.localVersions` and owns local retention on the PVC.
 
 ### Discovery cadence
 

--- a/cmd/examples/src/kanidm.rs
+++ b/cmd/examples/src/kanidm.rs
@@ -15,7 +15,7 @@ use k8s_openapi::{
 use kaniop_operator::kanidm::{
     crd::{
         DomainAppearanceImageSpec, DomainAppearanceSpec, ExternalReplicationNode, IpFamily, Kanidm,
-        KanidmBackendTLSPolicy, KanidmBackendTLSPolicyValidation, KanidmBackupSpec, KanidmGateway,
+        KanidmBackendTLSPolicy, KanidmBackendTLSPolicyValidation, KanidmGateway,
         KanidmGatewayParentRef, KanidmIngress, KanidmLogLevel, KanidmRegionIngress,
         KanidmReplicaGroupServices, KanidmServerRole, KanidmService, KanidmSpec, KanidmStorage,
         MailSenderCredentialsSecret, MailSenderSpec, PersistentVolumeClaimTemplate, ReplicaGroup,
@@ -163,10 +163,6 @@ pub fn example() -> Kanidm {
             group_namespace_selector: Some(Default::default()),
             person_namespace_selector: Some(Default::default()),
             service_account_namespace_selector: Some(Default::default()),
-            backup: Some(KanidmBackupSpec {
-                schedule: "0 2 * * *".to_string(),
-                versions: 7,
-            }),
             storage: Some(KanidmStorage {
                 empty_dir: None,
                 ephemeral: None,

--- a/examples/kanidm.yaml
+++ b/examples/kanidm.yaml
@@ -325,16 +325,6 @@ spec:
   # # Example for all namespaces: `serviceAccountNamespaceSelector: {}`
   # serviceAccountNamespaceSelector: {}
 
-  # # Configures Kanidm-native online logical backups.
-  # #
-  # # Backups are written to `/data/backups` on the single replica group marked as the
-  # # primary node. Local backup configuration requires persistent PVC-backed storage.
-  # backup:
-  #   # Cron expression passed to Kanidm's native online backup scheduler.
-  #   schedule: 0 2 * * *
-  #   # Number of completed local backups retained by Kanidm.
-  #   versions: 7
-
   # # StorageSpec defines the configured storage for a group Kanidm servers.
   # # If no storage option is specified, then by default an
   # # [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will be used.

--- a/libs/backup/src/controller/schedule.rs
+++ b/libs/backup/src/controller/schedule.rs
@@ -6,6 +6,7 @@ use kaniop_backup_core::retention::{
 use kaniop_operator::backoff_reconciler;
 use kaniop_operator::controller::{ControllerId, State, check_api_queryable, error_policy};
 use kaniop_operator::kanidm::crd::Kanidm;
+use kaniop_operator::kanidm::reconcile::transport::backup_target_validation_error;
 use kaniop_operator::kanidm::restore::RESTORE_ANNOTATION;
 
 use std::sync::Arc;
@@ -189,6 +190,7 @@ async fn reconcile_schedule(
     status.observed_generation = obj.metadata.generation;
 
     let restore_active = kanidm.as_ref().is_some_and(|k| is_restore_in_progress(k));
+    let backup_target_error = kanidm.as_deref().and_then(backup_target_validation_error);
 
     let effective_suspend = spec.suspend || restore_active;
 
@@ -218,6 +220,20 @@ async fn reconcile_schedule(
                 "Referenced Kanidm '{}' does not exist in namespace '{}'",
                 spec.kanidm_ref.name, namespace
             ),
+        });
+    } else if let Some(message) = backup_target_error.as_ref() {
+        conditions_to_set.push(Condition {
+            type_: "Ready".to_string(),
+            status: "False".to_string(),
+            observed_generation: obj.metadata.generation,
+            last_transition_time: transition_time(
+                &existing_conditions,
+                "Ready",
+                "False",
+                "InvalidKanidmBackupTarget",
+            ),
+            reason: "InvalidKanidmBackupTarget".to_string(),
+            message: message.clone(),
         });
     } else if repository.is_none() {
         conditions_to_set.push(Condition {
@@ -349,7 +365,7 @@ async fn reconcile_schedule(
         REQUEUE_NORMAL
     };
 
-    if !effective_suspend && repo_config_accepted {
+    if !effective_suspend && repo_config_accepted && backup_target_error.is_none() {
         if let (Some(repo), Some(kanidm_obj)) = (&repository, &kanidm) {
             let kanidm_uid = &kanidm_obj.metadata.uid.clone().unwrap_or_default();
             if let Err(e) = reconcile_retention(&ctx, &obj, repo, kanidm_uid, &namespace).await {

--- a/libs/operator/src/kanidm/crd.rs
+++ b/libs/operator/src/kanidm/crd.rs
@@ -21,19 +21,6 @@ use serde::{Deserialize, Serialize};
 /// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(
-    feature = "schemars",
-    schemars(extend("x-kubernetes-validations" = [
-        {
-            "message": "backup requires PVC-backed storage",
-            "rule": "!has(self.backup) || (has(self.storage) && has(self.storage.volumeClaimTemplate) && !has(self.storage.emptyDir) && !has(self.storage.ephemeral))"
-        },
-        {
-            "message": "backup requires exactly one primary replica group",
-            "rule": "!has(self.backup) || self.replicaGroups.filter(r, r.primaryNode == true).size() == 1"
-        }
-    ]))
-)]
 // workaround: '`' character is not allowed in the kube `doc` attribute during doctests
 #[cfg_attr(
     not(doctest),
@@ -184,13 +171,6 @@ pub struct KanidmSpec {
     /// Example for all namespaces: `serviceAccountNamespaceSelector: {}`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_account_namespace_selector: Option<LabelSelector>,
-
-    /// Configures Kanidm-native online logical backups.
-    ///
-    /// Backups are written to `/data/backups` on the single replica group marked as the
-    /// primary node. Local backup configuration requires persistent PVC-backed storage.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub backup: Option<KanidmBackupSpec>,
 
     /// StorageSpec defines the configured storage for a group Kanidm servers.
     /// If no storage option is specified, then by default an
@@ -724,33 +704,6 @@ impl PersistentVolumeClaimTemplate {
             ..Default::default()
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "camelCase")]
-pub struct KanidmBackupSpec {
-    /// Cron expression passed to Kanidm's native online backup scheduler.
-    #[schemars(extend("x-kubernetes-validations" = [{"message": "backup.schedule cannot be empty", "rule": "self.size() > 0"}]))]
-    pub schedule: String,
-
-    /// Number of completed local backups retained by Kanidm.
-    #[serde(default = "default_backup_versions")]
-    #[schemars(extend("x-kubernetes-validations" = [{"message": "backup.versions must be greater than zero", "rule": "self > 0"}]))]
-    pub versions: u32,
-}
-
-impl Default for KanidmBackupSpec {
-    fn default() -> Self {
-        Self {
-            schedule: "0 2 * * *".to_string(),
-            versions: default_backup_versions(),
-        }
-    }
-}
-
-fn default_backup_versions() -> u32 {
-    7
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/libs/operator/src/kanidm/reconcile/mod.rs
+++ b/libs/operator/src/kanidm/reconcile/mod.rs
@@ -24,7 +24,7 @@ use self::statefulset::{
 };
 use self::status::StatusExt;
 use self::status::{is_kanidm_available, is_kanidm_initialized};
-use self::transport::resolve_transport_config;
+use self::transport::resolve_backup_config;
 
 use crate::controller::context::KubeOperations;
 use crate::controller::{INSTANCE_LABEL, MANAGED_BY_LABEL, NAME_LABEL};
@@ -939,7 +939,7 @@ async fn reconcile(
                 .await
                 .map_err(|e| {
                     Error::KubeError(
-                        "failed to list KanidmBackupSchedules for transport sidecar resolution"
+                        "failed to list KanidmBackupSchedules for backup configuration resolution"
                             .to_string(),
                         Box::new(e),
                     )
@@ -953,14 +953,13 @@ async fn reconcile(
                 .await
                 .map_err(|e| {
                     Error::KubeError(
-                        "failed to list KanidmBackupRepositories for transport sidecar resolution"
+                        "failed to list KanidmBackupRepositories for backup configuration resolution"
                             .to_string(),
                         Box::new(e),
                     )
                 })?
                 .items;
-
-            let transport_config = resolve_transport_config(&kanidm, &schedules, &repositories);
+            let backup_config = resolve_backup_config(&kanidm, &schedules, &repositories);
 
             kanidm
                 .spec
@@ -970,7 +969,7 @@ async fn reconcile(
                     let sts = kanidm.create_statefulset(
                         rg,
                         tls_secret_hash.as_deref(),
-                        transport_config.as_ref(),
+                        backup_config.as_ref(),
                     )?;
                     Ok(reconcile_statefulset(kanidm.clone(), ctx.clone(), sts))
                 })

--- a/libs/operator/src/kanidm/reconcile/statefulset.rs
+++ b/libs/operator/src/kanidm/reconcile/statefulset.rs
@@ -1,6 +1,6 @@
 use super::secret::{REPLICA_SECRET_KEY, SecretExt};
 use super::service::ServiceExt;
-use crate::kanidm::reconcile::transport::TransportSidecarConfig;
+use crate::kanidm::reconcile::transport::{BackupConfig, TransportSidecarConfig};
 
 use crate::controller::cluster_domain;
 use crate::kanidm::crd::{IpFamily, Kanidm, KanidmServerRole, ReplicaGroup, ReplicationType};
@@ -257,7 +257,7 @@ pub trait StatefulSetExt {
         &self,
         replica_group: &ReplicaGroup,
         tls_secret_hash: Option<&str>,
-        transport_config: Option<&TransportSidecarConfig>,
+        backup_config: Option<&BackupConfig>,
     ) -> Result<StatefulSet>;
 }
 
@@ -281,17 +281,24 @@ impl StatefulSetExt for Kanidm {
         &self,
         replica_group: &ReplicaGroup,
         tls_secret_hash: Option<&str>,
-        transport_config: Option<&TransportSidecarConfig>,
+        backup_config: Option<&BackupConfig>,
     ) -> Result<StatefulSet> {
         let pod_labels = self.generate_pod_labels(replica_group);
         let labels = self.generate_sts_labels(&pod_labels);
         let env = self.generate_env_vars(replica_group);
-        let init_containers = self.generate_init_containers(replica_group)?;
+        let init_containers = self.generate_init_containers(replica_group, backup_config)?;
         let ports = self.generate_container_ports();
         let probe = self.generate_probe();
-        let volume_mounts = self.generate_volume_mounts();
-        let mut containers =
-            self.generate_containers(&env, &volume_mounts, &ports, &probe, replica_group)?;
+        let volume_mounts = self.generate_volume_mounts(backup_config);
+        let mut containers = self.generate_containers(
+            &env,
+            &volume_mounts,
+            &ports,
+            &probe,
+            replica_group,
+            backup_config,
+        )?;
+        let transport_config = backup_config.and_then(|config| config.transport.as_ref());
 
         if replica_group.primary_node {
             if let Some(config) = transport_config {
@@ -305,7 +312,7 @@ impl StatefulSetExt for Kanidm {
         }
 
         let dns_policy = self.generate_dns_policy();
-        let (mut volumes, volume_claim_templates) = self.generate_volumes();
+        let (mut volumes, volume_claim_templates) = self.generate_volumes(backup_config);
 
         if let Some(config) = transport_config {
             let auth_volumes = build_auth_volumes(&config.auth_method);
@@ -381,8 +388,8 @@ impl StatefulSetExt for Kanidm {
 }
 
 impl Kanidm {
-    fn uses_generated_config(&self) -> bool {
-        self.is_replication_enabled() || self.spec.backup.is_some()
+    fn uses_generated_config(&self, backup_config: Option<&BackupConfig>) -> bool {
+        self.is_replication_enabled() || backup_config.is_some()
     }
 
     fn generate_pod_labels(&self, replica_group: &ReplicaGroup) -> BTreeMap<String, String> {
@@ -482,7 +489,7 @@ impl Kanidm {
         }
     }
 
-    fn generate_volume_mounts(&self) -> Vec<VolumeMount> {
+    fn generate_volume_mounts(&self, backup_config: Option<&BackupConfig>) -> Vec<VolumeMount> {
         self.spec
             .volume_mounts
             .clone()
@@ -502,14 +509,18 @@ impl Kanidm {
                 },
             ])
             .chain(
-                self.uses_generated_config()
+                self.uses_generated_config(backup_config)
                     .then(|| self.generate_config_volume_mount()),
             )
             .collect()
     }
 
-    fn generate_init_containers(&self, replica_group: &ReplicaGroup) -> Result<Vec<Container>> {
-        if self.uses_generated_config() {
+    fn generate_init_containers(
+        &self,
+        replica_group: &ReplicaGroup,
+        backup_config: Option<&BackupConfig>,
+    ) -> Result<Vec<Container>> {
+        if self.uses_generated_config(backup_config) {
             let external_replica_nodes_envs = self
                 .spec
                 .external_replication_nodes
@@ -659,11 +670,11 @@ impl Kanidm {
                     },
                     EnvVar {
                         name: "KANIOP_BACKUP_ENABLED".to_string(),
-                        value: Some(self.spec.backup.is_some().to_string()),
+                        value: Some(backup_config.is_some().to_string()),
                         ..EnvVar::default()
                     },
                 ])
-                .chain(self.spec.backup.as_ref().into_iter().flat_map(|backup| {
+                .chain(backup_config.into_iter().flat_map(|backup| {
                     [
                         EnvVar {
                             name: "KANIOP_BACKUP_SCHEDULE".to_string(),
@@ -672,7 +683,7 @@ impl Kanidm {
                         },
                         EnvVar {
                             name: "KANIOP_BACKUP_VERSIONS".to_string(),
-                            value: Some(backup.versions.to_string()),
+                            value: Some(backup.local_versions.to_string()),
                             ..EnvVar::default()
                         },
                     ]
@@ -757,11 +768,12 @@ impl Kanidm {
         ports: &[ContainerPort],
         probe: &Probe,
         replica_group: &ReplicaGroup,
+        backup_config: Option<&BackupConfig>,
     ) -> Result<Vec<Container>> {
         let command = vec!["kanidmd".to_string(), "server".to_string()]
             .into_iter()
             .chain(
-                self.uses_generated_config()
+                self.uses_generated_config(backup_config)
                     .then(|| vec!["-c".to_string(), KANIDM_CONFIG_PATH.to_string()])
                     .into_iter()
                     .flatten(),
@@ -791,7 +803,10 @@ impl Kanidm {
         }
     }
 
-    fn generate_volumes(&self) -> (Vec<Volume>, Option<Vec<PersistentVolumeClaim>>) {
+    fn generate_volumes(
+        &self,
+        backup_config: Option<&BackupConfig>,
+    ) -> (Vec<Volume>, Option<Vec<PersistentVolumeClaim>>) {
         let secret_name = self.effective_tls_secret_name();
 
         self.expand_storage(
@@ -809,7 +824,7 @@ impl Kanidm {
                     }),
                     ..Volume::default()
                 }))
-                .chain(self.uses_generated_config().then(|| Volume {
+                .chain(self.uses_generated_config(backup_config).then(|| Volume {
                     name: VOLUME_CONFIG_NAME.to_string(),
                     empty_dir: Some(EmptyDirVolumeSource {
                         medium: None,
@@ -2213,18 +2228,21 @@ consumer_cert = "dummy-cert-read-replica-1"
     }
     #[test]
     fn backup_enables_generated_config_and_native_online_backup_stanza() {
-        use crate::kanidm::crd::{KanidmBackupSpec, KanidmStorage, PersistentVolumeClaimTemplate};
+        use crate::kanidm::crd::{KanidmStorage, PersistentVolumeClaimTemplate};
         use k8s_openapi::api::core::v1::PersistentVolumeClaimSpec;
+
+        use crate::kanidm::reconcile::transport::BackupConfig;
 
         use super::StatefulSetExt;
 
         let (mut kanidm, mut replica_group) = super::tests::create_kanidm_with_replica_group();
         replica_group.primary_node = true;
         kanidm.spec.replica_groups = vec![replica_group.clone()];
-        kanidm.spec.backup = Some(KanidmBackupSpec {
+        let backup_config = BackupConfig {
             schedule: "0 2 * * *".to_string(),
-            versions: 7,
-        });
+            local_versions: 7,
+            transport: None,
+        };
         kanidm.spec.storage = Some(KanidmStorage {
             volume_claim_template: Some(PersistentVolumeClaimTemplate {
                 metadata: None,
@@ -2234,7 +2252,7 @@ consumer_cert = "dummy-cert-read-replica-1"
         });
 
         let sts = kanidm
-            .create_statefulset(&replica_group, None, None)
+            .create_statefulset(&replica_group, None, Some(&backup_config))
             .unwrap();
         let pod = sts.spec.unwrap().template.spec.unwrap();
         let init = pod
@@ -2265,7 +2283,7 @@ consumer_cert = "dummy-cert-read-replica-1"
     #[test]
     fn transport_sidecar_present_for_primary_group_with_config() {
         use super::StatefulSetExt;
-        use crate::kanidm::reconcile::transport::TransportSidecarConfig;
+        use crate::kanidm::reconcile::transport::{BackupConfig, TransportSidecarConfig};
         use kaniop_backup_core::crd::{AuthMethod, SecretRef};
 
         use super::tests::create_kanidm_with_replica_group;
@@ -2273,15 +2291,19 @@ consumer_cert = "dummy-cert-read-replica-1"
         replica_group.primary_node = true;
         kanidm.spec.replica_groups = vec![replica_group.clone()];
 
-        let config = TransportSidecarConfig {
-            operation_doc_json: r#"{"operation":"transport","bucket":"test"}"#.to_string(),
-            auth_method: AuthMethod {
-                workload_identity: None,
-                secret_ref: Some(SecretRef {
-                    name: "writer-secret".to_string(),
-                }),
-            },
-            ca_bundle_ref: None,
+        let config = BackupConfig {
+            schedule: "0 2 * * *".to_string(),
+            local_versions: 7,
+            transport: Some(TransportSidecarConfig {
+                operation_doc_json: r#"{"operation":"transport","bucket":"test"}"#.to_string(),
+                auth_method: AuthMethod {
+                    workload_identity: None,
+                    secret_ref: Some(SecretRef {
+                        name: "writer-secret".to_string(),
+                    }),
+                },
+                ca_bundle_ref: None,
+            }),
         };
 
         let sts = kanidm
@@ -2349,7 +2371,7 @@ consumer_cert = "dummy-cert-read-replica-1"
     #[test]
     fn transport_sidecar_absent_for_non_primary_group() {
         use super::StatefulSetExt;
-        use crate::kanidm::reconcile::transport::TransportSidecarConfig;
+        use crate::kanidm::reconcile::transport::{BackupConfig, TransportSidecarConfig};
         use kaniop_backup_core::crd::{AuthMethod, SecretRef};
 
         use super::tests::create_kanidm_with_replica_group;
@@ -2357,15 +2379,19 @@ consumer_cert = "dummy-cert-read-replica-1"
         replica_group.primary_node = false;
         kanidm.spec.replica_groups = vec![replica_group.clone()];
 
-        let config = TransportSidecarConfig {
-            operation_doc_json: r#"{"operation":"transport"}"#.to_string(),
-            auth_method: AuthMethod {
-                workload_identity: None,
-                secret_ref: Some(SecretRef {
-                    name: "writer-secret".to_string(),
-                }),
-            },
-            ca_bundle_ref: None,
+        let config = BackupConfig {
+            schedule: "0 2 * * *".to_string(),
+            local_versions: 7,
+            transport: Some(TransportSidecarConfig {
+                operation_doc_json: r#"{"operation":"transport"}"#.to_string(),
+                auth_method: AuthMethod {
+                    workload_identity: None,
+                    secret_ref: Some(SecretRef {
+                        name: "writer-secret".to_string(),
+                    }),
+                },
+                ca_bundle_ref: None,
+            }),
         };
 
         let sts = kanidm
@@ -2399,7 +2425,7 @@ consumer_cert = "dummy-cert-read-replica-1"
     #[test]
     fn transport_sidecar_with_ca_bundle() {
         use super::StatefulSetExt;
-        use crate::kanidm::reconcile::transport::TransportSidecarConfig;
+        use crate::kanidm::reconcile::transport::{BackupConfig, TransportSidecarConfig};
         use kaniop_backup_core::crd::{AuthMethod, SecretRef};
 
         use super::tests::create_kanidm_with_replica_group;
@@ -2407,15 +2433,19 @@ consumer_cert = "dummy-cert-read-replica-1"
         replica_group.primary_node = true;
         kanidm.spec.replica_groups = vec![replica_group.clone()];
 
-        let config = TransportSidecarConfig {
-            operation_doc_json: r#"{"operation":"transport"}"#.to_string(),
-            auth_method: AuthMethod {
-                workload_identity: None,
-                secret_ref: Some(SecretRef {
-                    name: "writer-secret".to_string(),
-                }),
-            },
-            ca_bundle_ref: Some("ca-config-map".to_string()),
+        let config = BackupConfig {
+            schedule: "0 2 * * *".to_string(),
+            local_versions: 7,
+            transport: Some(TransportSidecarConfig {
+                operation_doc_json: r#"{"operation":"transport"}"#.to_string(),
+                auth_method: AuthMethod {
+                    workload_identity: None,
+                    secret_ref: Some(SecretRef {
+                        name: "writer-secret".to_string(),
+                    }),
+                },
+                ca_bundle_ref: Some("ca-config-map".to_string()),
+            }),
         };
 
         let sts = kanidm

--- a/libs/operator/src/kanidm/reconcile/transport.rs
+++ b/libs/operator/src/kanidm/reconcile/transport.rs
@@ -3,6 +3,7 @@ use kube::ResourceExt;
 use tracing::debug;
 
 use crate::kanidm::crd::Kanidm;
+use crate::kanidm::restore::RESTORE_ANNOTATION;
 
 pub const TRANSPORT_SIDECAR_NAME: &str = "data-mover-transport";
 
@@ -13,13 +14,83 @@ pub struct TransportSidecarConfig {
     pub ca_bundle_ref: Option<String>,
 }
 
-pub fn resolve_transport_config(
+#[derive(Debug, Clone)]
+pub struct BackupConfig {
+    pub schedule: String,
+    pub local_versions: u32,
+    pub transport: Option<TransportSidecarConfig>,
+}
+
+pub fn backup_target_validation_error(kanidm: &Kanidm) -> Option<String> {
+    let pvc_backed = kanidm.spec.storage.as_ref().is_some_and(|storage| {
+        storage.volume_claim_template.is_some()
+            && storage.empty_dir.is_none()
+            && storage.ephemeral.is_none()
+    });
+    if !pvc_backed {
+        return Some("backup requires PVC-backed storage".to_string());
+    }
+
+    let primary_count = kanidm
+        .spec
+        .replica_groups
+        .iter()
+        .filter(|group| group.primary_node)
+        .count();
+    if primary_count != 1 {
+        return Some(format!(
+            "backup requires exactly one primary replica group; found {primary_count}"
+        ));
+    }
+
+    None
+}
+
+pub fn resolve_backup_config(
     kanidm: &Kanidm,
     schedules: &[KanidmBackupSchedule],
     repositories: &[KanidmBackupRepository],
+) -> Option<BackupConfig> {
+    let kanidm_name = kanidm.name_any();
+    let matching_schedules: Vec<_> = schedules
+        .iter()
+        .filter(|schedule| schedule.spec.kanidm_ref.name == kanidm_name)
+        .collect();
+
+    if matching_schedules.len() != 1 {
+        if matching_schedules.len() > 1 {
+            debug!(
+                kanidm = %kanidm_name,
+                schedules = matching_schedules.len(),
+                "multiple KanidmBackupSchedules target Kanidm; backup configuration is disabled"
+            );
+        }
+        return None;
+    }
+
+    let schedule = matching_schedules[0];
+    if schedule.spec.suspend || kanidm.annotations().contains_key(RESTORE_ANNOTATION) {
+        return None;
+    }
+
+    if let Some(reason) = backup_target_validation_error(kanidm) {
+        debug!(kanidm = %kanidm_name, %reason, "invalid Kanidm backup target");
+        return None;
+    }
+
+    Some(BackupConfig {
+        schedule: schedule.spec.schedule.clone(),
+        local_versions: schedule.spec.local_versions,
+        transport: resolve_transport_sidecar_config(kanidm, schedule, repositories),
+    })
+}
+
+fn resolve_transport_sidecar_config(
+    kanidm: &Kanidm,
+    schedule: &KanidmBackupSchedule,
+    repositories: &[KanidmBackupRepository],
 ) -> Option<TransportSidecarConfig> {
     let kanidm_name = kanidm.name_any();
-
     if kanidm.status.is_none() {
         debug!(
             kanidm = %kanidm_name,
@@ -31,10 +102,9 @@ pub fn resolve_transport_config(
     let kanidm_version = kanidm
         .status
         .as_ref()
-        .and_then(|s| s.version.as_ref())
-        .map(|v| v.image_tag.clone())
+        .and_then(|status| status.version.as_ref())
+        .map(|version| version.image_tag.clone())
         .unwrap_or_default();
-
     if kanidm_version.is_empty() {
         debug!(
             kanidm = %kanidm_name,
@@ -43,25 +113,15 @@ pub fn resolve_transport_config(
         return None;
     }
 
-    let matching_schedules: Vec<_> = schedules
-        .iter()
-        .filter(|s| !s.spec.suspend && s.spec.kanidm_ref.name == kanidm_name)
-        .collect();
-
-    if matching_schedules.len() != 1 {
-        return None;
-    }
-
-    let schedule = matching_schedules[0];
     let repo_name = &schedule.spec.repository_ref.name;
-    let repository = repositories.iter().find(|r| r.name_any() == *repo_name)?;
-
+    let repository = repositories
+        .iter()
+        .find(|repo| repo.name_any() == *repo_name)?;
     if !is_repository_ready(repository) {
         return None;
     }
 
     let operation_doc_json = build_transport_operation_doc(kanidm, repository)?;
-
     Some(TransportSidecarConfig {
         operation_doc_json,
         auth_method: repository.spec.authentication.writer.clone(),
@@ -72,11 +132,12 @@ pub fn resolve_transport_config(
 fn is_repository_ready(repo: &KanidmBackupRepository) -> bool {
     repo.status
         .as_ref()
-        .and_then(|s| {
-            s.conditions
+        .and_then(|status| {
+            status
+                .conditions
                 .iter()
-                .find(|c| c.type_ == "Ready")
-                .map(|c| c.status == "True" && c.reason == "Accepted")
+                .find(|condition| condition.type_ == "Ready")
+                .map(|condition| condition.status == "True" && condition.reason == "Accepted")
         })
         .unwrap_or(false)
 }
@@ -92,13 +153,12 @@ fn build_transport_operation_doc(
     let kanidm_version = kanidm
         .status
         .as_ref()
-        .and_then(|s| s.version.as_ref())
-        .map(|v| v.image_tag.clone())
+        .and_then(|status| status.version.as_ref())
+        .map(|version| version.image_tag.clone())
         .unwrap_or_default();
 
     let s3 = &repository.spec.s3;
     let encryption = repository.spec.encryption.as_ref();
-
     let doc = serde_json::json!({
         "apiVersion": "backup.kaniop.rs/v1alpha1",
         "kind": "OperationDocument",
@@ -123,8 +183,8 @@ fn build_transport_operation_doc(
         "imageDigest": null,
         "consistency": "kanidm-online",
         "reason": "scheduled",
-        "encryptionMode": encryption.map(|e| serde_json::json!(e.mode)),
-        "encryptionKeyId": encryption.and_then(|e| e.key_id.clone()),
+        "encryptionMode": encryption.map(|value| serde_json::json!(value.mode)),
+        "encryptionKeyId": encryption.and_then(|value| value.key_id.clone()),
         "maxConcurrentParts": 4,
         "maxRetries": 3
     });
@@ -141,9 +201,9 @@ mod tests {
     };
     use kube::api::ObjectMeta;
 
-    fn make_kanidm(name: &str, namespace: &str) -> Kanidm {
-        make_kanidm_with_status(name, namespace, None)
-    }
+    use crate::kanidm::crd::{
+        KanidmSpec, KanidmStorage, PersistentVolumeClaimTemplate, ReplicaGroup,
+    };
 
     fn make_kanidm_with_status(name: &str, namespace: &str, version_tag: Option<&str>) -> Kanidm {
         let status = version_tag.map(|tag| crate::kanidm::crd::KanidmStatus {
@@ -161,8 +221,18 @@ mod tests {
                 uid: Some("kanidm-uid-123".to_string()),
                 ..Default::default()
             },
-            spec: crate::kanidm::crd::KanidmSpec {
+            spec: KanidmSpec {
                 domain: "idm.example.com".to_string(),
+                storage: Some(KanidmStorage {
+                    volume_claim_template: Some(PersistentVolumeClaimTemplate::default()),
+                    ..Default::default()
+                }),
+                replica_groups: vec![ReplicaGroup {
+                    name: "default".to_string(),
+                    replicas: 1,
+                    primary_node: true,
+                    ..Default::default()
+                }],
                 ..Default::default()
             },
             status,
@@ -201,6 +271,12 @@ mod tests {
     }
 
     fn make_repository(name: &str, ready: bool) -> KanidmBackupRepository {
+        let method = AuthMethod {
+            workload_identity: None,
+            secret_ref: Some(SecretRef {
+                name: "backup-secret".to_string(),
+            }),
+        };
         let mut repo = KanidmBackupRepository {
             metadata: ObjectMeta {
                 name: Some(name.to_string()),
@@ -218,31 +294,15 @@ mod tests {
                     insecure: false,
                 },
                 authentication: RepositoryAuthentication {
-                    writer: AuthMethod {
-                        workload_identity: None,
-                        secret_ref: Some(SecretRef {
-                            name: "writer-secret".to_string(),
-                        }),
-                    },
-                    reader: AuthMethod {
-                        workload_identity: None,
-                        secret_ref: Some(SecretRef {
-                            name: "reader-secret".to_string(),
-                        }),
-                    },
-                    deleter: AuthMethod {
-                        workload_identity: None,
-                        secret_ref: Some(SecretRef {
-                            name: "deleter-secret".to_string(),
-                        }),
-                    },
+                    writer: method.clone(),
+                    reader: method.clone(),
+                    deleter: method,
                 },
                 encryption: None,
                 limits: None,
             },
             status: None,
         };
-
         if ready {
             repo.status = Some(kaniop_backup_core::crd::KanidmBackupRepositoryStatus {
                 observed_generation: Some(1),
@@ -258,95 +318,70 @@ mod tests {
                 }],
             });
         }
-
         repo
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_no_schedule() {
-        let kanidm = make_kanidm("test-kanidm", "default");
-        let config = resolve_transport_config(&kanidm, &[], &[]);
-        assert!(config.is_none());
+    fn no_schedule_means_no_backup_config() {
+        let kanidm = make_kanidm_with_status("test-kanidm", "default", None);
+        assert!(resolve_backup_config(&kanidm, &[], &[]).is_none());
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_schedule_suspended() {
-        let kanidm = make_kanidm("test-kanidm", "default");
+    fn suspended_schedule_disables_native_backup_and_transport() {
+        let kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
         let schedule = make_schedule("sched", "test-kanidm", "repo", true);
         let repo = make_repository("repo", true);
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_none());
+        assert!(resolve_backup_config(&kanidm, &[schedule], &[repo]).is_none());
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_repo_not_ready() {
+    fn schedule_drives_native_backup_even_when_repository_is_not_ready() {
         let kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
         let schedule = make_schedule("sched", "test-kanidm", "repo", false);
         let repo = make_repository("repo", false);
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_none());
+        let config = resolve_backup_config(&kanidm, &[schedule], &[repo]).unwrap();
+        assert_eq!(config.schedule, "0 2 * * *");
+        assert_eq!(config.local_versions, 7);
+        assert!(config.transport.is_none());
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_status_none() {
-        let kanidm = make_kanidm("test-kanidm", "default");
+    fn native_backup_does_not_wait_for_kanidm_status() {
+        let kanidm = make_kanidm_with_status("test-kanidm", "default", None);
         let schedule = make_schedule("sched", "test-kanidm", "repo", false);
         let repo = make_repository("repo", true);
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_none());
+        let config = resolve_backup_config(&kanidm, &[schedule], &[repo]).unwrap();
+        assert!(config.transport.is_none());
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_version_empty() {
-        let kanidm = make_kanidm_with_status("test-kanidm", "default", Some(""));
-        let schedule = make_schedule("sched", "test-kanidm", "repo", false);
-        let repo = make_repository("repo", true);
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_none());
-    }
-
-    #[test]
-    fn resolve_transport_config_returns_none_when_ready_reason_not_accepted() {
-        let kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
-        let schedule = make_schedule("sched", "test-kanidm", "repo", false);
-        let mut repo = make_repository("repo", false);
-        repo.status = Some(kaniop_backup_core::crd::KanidmBackupRepositoryStatus {
-            observed_generation: Some(1),
-            conditions: vec![k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition {
-                type_: "Ready".to_string(),
-                status: "True".to_string(),
-                observed_generation: Some(1),
-                last_transition_time: k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
-                    k8s_openapi::jiff::Timestamp::new(1704067200, 0).unwrap(),
-                ),
-                reason: "SomeOtherReason".to_string(),
-                message: "not accepted".to_string(),
-            }],
-        });
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_none());
-    }
-
-    #[test]
-    fn resolve_transport_config_returns_config_when_valid() {
+    fn ready_repository_adds_transport() {
         let kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
         let schedule = make_schedule("sched", "test-kanidm", "repo", false);
         let repo = make_repository("repo", true);
-        let config = resolve_transport_config(&kanidm, &[schedule], &[repo]);
-        assert!(config.is_some());
-        let config = config.unwrap();
-        assert!(config.operation_doc_json.contains("transport"));
-        assert!(config.operation_doc_json.contains("test-bucket"));
+        let config = resolve_backup_config(&kanidm, &[schedule], &[repo]).unwrap();
+        let transport = config.transport.expect("transport should be configured");
+        assert!(transport.operation_doc_json.contains("transport"));
+        assert!(transport.operation_doc_json.contains("test-bucket"));
     }
 
     #[test]
-    fn resolve_transport_config_returns_none_when_multiple_schedules() {
+    fn multiple_schedules_fail_closed_even_if_one_is_suspended() {
         let kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
         let schedule1 = make_schedule("sched1", "test-kanidm", "repo1", false);
-        let schedule2 = make_schedule("sched2", "test-kanidm", "repo2", false);
+        let schedule2 = make_schedule("sched2", "test-kanidm", "repo2", true);
         let repo1 = make_repository("repo1", true);
         let repo2 = make_repository("repo2", true);
-        let config = resolve_transport_config(&kanidm, &[schedule1, schedule2], &[repo1, repo2]);
-        assert!(config.is_none());
+        assert!(resolve_backup_config(&kanidm, &[schedule1, schedule2], &[repo1, repo2]).is_none());
+    }
+
+    #[test]
+    fn invalid_backup_target_fails_closed() {
+        let mut kanidm = make_kanidm_with_status("test-kanidm", "default", Some("1.0.0"));
+        kanidm.spec.storage = None;
+        let schedule = make_schedule("sched", "test-kanidm", "repo", false);
+        let repo = make_repository("repo", true);
+        assert!(resolve_backup_config(&kanidm, &[schedule], &[repo]).is_none());
     }
 }

--- a/tests/e2e/test/kanidm/backup_transport.rs
+++ b/tests/e2e/test/kanidm/backup_transport.rs
@@ -143,12 +143,7 @@ e2e_test!(
         merge(&mut spec_json, &STORAGE_VOLUME_CLAIM_TEMPLATE_JSON.clone());
         merge(
             &mut spec_json,
-            &json!({
-                "backup": {
-                    "schedule": "*/2 * * * *",
-                    "versions": 3
-                },
-                "replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 1, "primaryNode": true}]
+            &json!({"replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 1, "primaryNode": true}]
             }),
         );
         let kanidm = Kanidm::new(kanidm_name, serde_json::from_value(spec_json).unwrap());

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -834,9 +834,9 @@ e2e_test!(
                 "storage": {
                     "emptyDir": {}
                 },
-                "backup": {
-                    "schedule": "0 0 * * *"
-                }
+                "replicaGroups": [
+                    {"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 2, "primaryNode": true}
+                ]
             }),
         );
 
@@ -846,7 +846,7 @@ e2e_test!(
         let result = kanidm_api.create(&PostParams::default(), &kanidm).await;
         assert!(
             result.is_err(),
-            "ephemeral storage with primary_node should be rejected"
+            "ephemeral storage with replication should be rejected"
         );
     }
 );


### PR DESCRIPTION
## Summary

Make `KanidmBackupSchedule` the single source of truth for Kanidm backup configuration.

This removes the duplicate backup API from `Kanidm` and makes the Schedule own the complete native backup configuration (`schedule` + `localVersions`) while continuing to select the remote repository and retention policy.

## Changes

- remove `Kanidm.spec.backup` from `KanidmSpec`
- remove the operator-side `KanidmBackupSpec`
- resolve a single `BackupConfig` from `KanidmBackupSchedule`
- render Kanidm `[online_backup]` exclusively from:
  - `KanidmBackupSchedule.spec.schedule`
  - `KanidmBackupSchedule.spec.localVersions`
- keep native backups independent from repository readiness; an unavailable repository disables only the transport sidecar
- disable native backup configuration when the Schedule is suspended or a restore is active
- preserve backup target safety requirements: PVC-backed storage and exactly one primary replica group
- report invalid backup targets on the Schedule and fail closed in the Kanidm reconciler
- fail closed if reconciliation observes multiple Schedules targeting one Kanidm
- retain the existing validating-webhook uniqueness check, which rejects a second `KanidmBackupSchedule` targeting the same Kanidm in the namespace
- update StatefulSet/unit coverage and the backup transport E2E fixture so it no longer duplicates backup settings on the `Kanidm` resource
- update backup documentation to describe `KanidmBackupSchedule` as the only backup configuration surface

## Resulting ownership model

```text
Kanidm
  └── no backup configuration

KanidmBackupSchedule
  ├── kanidmRef
  ├── repositoryRef
  ├── schedule          -> Kanidm [online_backup].schedule
  ├── localVersions     -> Kanidm [online_backup].versions
  ├── suspend
  └── retention
```

Exactly one `KanidmBackupSchedule` may target a Kanidm. Admission rejects conflicts; reconciliation also fails closed as defense in depth.

## Validation

The migration validation run successfully completed:

- `cargo check --workspace --all-targets --all-features`
- `cargo fmt -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features --lib --bins`
- generated-CRD assertion that `Kanidm` no longer exposes `spec.backup`

The branch history is squashed to one reviewable commit. Normal PR workflows are running on the final tree.