### PR TITLE
chore(deps): bump Kanidm crate requirements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Keep Kanidm crate requirements current",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "kanidm_client",
+        "kanidm_lib_crypto",
+        "kanidm_proto"
+      ],
+      "rangeStrategy": "bump"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Configure Renovate to use `rangeStrategy: bump` for the Kanidm Rust crates:

- `kanidm_client`
- `kanidm_lib_crypto`
- `kanidm_proto`

All other Cargo dependencies keep Renovate's default lockfile-first behavior.

## Why

For most Rust dependencies, keeping `Cargo.toml` as a compatibility range while updating `Cargo.lock` is desirable. Kanidm is different: its version is part of Kaniop's effective supported-upstream contract.

With Cargo's caret semantics, a requirement such as `kanidm_client = "1.10.0"` accepts `1.11.1`, so Renovate normally updates only `Cargo.lock`. That leaves the manifest looking older than the Kanidm version Kaniop is actually tracking and testing.

Using `rangeStrategy: bump` for these three crates makes Renovate update the manifest requirement to the new resolved version as well, while leaving the rest of the Rust dependency policy unchanged.

## Expected behavior

For example, a future update from `1.11.1` to `1.12.0` will update both the Kanidm entries in `Cargo.toml` and `Cargo.lock`, rather than only refreshing the lockfile.