### PR TITLE
fix(backup): require S3 endpoint and region

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,13 @@ Handle these scenarios gracefully:
 - **Pre-commit hooks**: Configured via `.pre-commit-config.yaml`
 - **Auto-updates**: Renovate handles dependency updates
 
+### PR Workflow
+
+1. Run `make lint` and `make test` locally before pushing.
+2. Do **not** run e2e locally; push the PR and let CI run e2e.
+3. Wait for CI: `gh pr checks <pr> --watch`.
+4. If an e2e CI job fails, reproduce it locally (`make e2e && make e2e-test-shard SHARD=<failing-shard>`), fix, push, and repeat until CI is green.
+
 ## Profiles
 
 - **release**: Full optimization (LTO fat, opt-level 3, stripped symbols)

--- a/cmd/data-mover/src/commands/transport.rs
+++ b/cmd/data-mover/src/commands/transport.rs
@@ -57,8 +57,8 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
     let poll_interval = Duration::from_secs(op.poll_interval_secs.min(60));
     wait_for_watch_dir(watch_dir, &op.watch_dir, poll_interval, &mut shutdown_rx).await?;
 
-    let endpoint = op.endpoint.as_deref().unwrap_or("");
-    let region = op.region.as_deref().unwrap_or("");
+    let endpoint = &op.endpoint;
+    let region = &op.region;
 
     if endpoint.is_empty() || region.is_empty() {
         error!("endpoint and region are required for transport");
@@ -67,8 +67,8 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
 
     let s3_config = S3Config {
         bucket: op.bucket.clone(),
-        endpoint: endpoint.to_string(),
-        region: region.to_string(),
+        endpoint: endpoint.clone(),
+        region: region.clone(),
         force_path_style: op.force_path_style,
         ca_bundle_path: op.ca_bundle_path.clone(),
         insecure: op.insecure,

--- a/cmd/examples/src/backup.rs
+++ b/cmd/examples/src/backup.rs
@@ -18,8 +18,8 @@ pub fn repository_example() -> KanidmBackupRepository {
             s3: S3Config {
                 bucket: "corp-kaniop-backups".to_string(),
                 prefix: "prod".to_string(),
-                region: Some("eu-west-1".to_string()),
-                endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
+                region: "eu-west-1".to_string(),
+                endpoint: "https://s3.eu-west-1.amazonaws.com".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,

--- a/cmd/webhook/src/backup_validator.rs
+++ b/cmd/webhook/src/backup_validator.rs
@@ -394,8 +394,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "my-bucket".to_string(),
                     prefix: "prod".to_string(),
-                    region: Some("eu-west-1".to_string()),
-                    endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
+                    region: "eu-west-1".to_string(),
+                    endpoint: "https://s3.eu-west-1.amazonaws.com".to_string(),
                     force_path_style: false,
                     ca_bundle_ref: None,
                     insecure: false,
@@ -461,7 +461,7 @@ mod tests {
             ..Default::default()
         });
         let mut new = old.clone();
-        new.spec.s3.endpoint = Some("https://other.endpoint.com".to_string());
+        new.spec.s3.endpoint = "https://other.endpoint.com".to_string();
         assert!(validate_repository_immutable_after_use(&old, &new).is_err());
     }
 
@@ -473,7 +473,7 @@ mod tests {
             ..Default::default()
         });
         let mut new = old.clone();
-        new.spec.s3.region = Some("us-east-1".to_string());
+        new.spec.s3.region = "us-east-1".to_string();
         assert!(validate_repository_immutable_after_use(&old, &new).is_ok());
     }
 

--- a/cmd/webhook/src/handlers.rs
+++ b/cmd/webhook/src/handlers.rs
@@ -196,13 +196,11 @@ pub async fn validate_backup_repository(
         }
     }
 
-    if let Some(endpoint) = &object.spec.s3.endpoint {
-        if !endpoint.starts_with("https://") && !object.spec.s3.insecure {
-            return Json(review.response(AdmissionResponse::deny(
-                uid,
-                "Repository endpoint must use HTTPS",
-            )));
-        }
+    if !object.spec.s3.endpoint.starts_with("https://") && !object.spec.s3.insecure {
+        return Json(review.response(AdmissionResponse::deny(
+            uid,
+            "Repository endpoint must use HTTPS",
+        )));
     }
 
     if object.spec.s3.prefix.contains("..") {

--- a/examples/backup-repository.yaml
+++ b/examples/backup-repository.yaml
@@ -18,13 +18,13 @@ spec:
     #  This field is immutable after the repository has been used. To use a different prefix, delete this Repository and
     #  create a new one.
     prefix: prod
-    # # AWS region. Optional for S3-compatible providers that do not require region specification.
-    # region: eu-west-1
-    # # S3 endpoint URL. Must use HTTPS unless insecure is enabled.
-    # #
-    # # This field is immutable after the repository has been used. To use a different endpoint, delete this Repository
-    # # and create a new one.
-    # endpoint: https://s3.eu-west-1.amazonaws.com
+    #  AWS region. Required for all S3-compatible providers.
+    region: eu-west-1
+    #  S3 endpoint URL. Must use HTTPS unless insecure is enabled.
+    #
+    #  This field is immutable after the repository has been used. To use a different endpoint, delete this Repository
+    #  and create a new one.
+    endpoint: https://s3.eu-west-1.amazonaws.com
     # # Use path-style addressing (http://endpoint/bucket) instead of virtual-hosted-style (http://bucket.endpoint).
     # forcePathStyle: false
     # # Allow HTTP endpoints. Not recommended for production use.

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
         },
         {
             "message": "s3.endpoint is immutable after creation. To use a different endpoint, delete this KanidmBackupRepository and create a new one. Existing Backup CRs referencing this repository are not affected, but remote S3 data at the old endpoint remains accessible only through the old Repository.",
-            "rule": "!has(oldSelf.s3.endpoint) || self.s3.endpoint == oldSelf.s3.endpoint"
+            "rule": "self.s3.endpoint == oldSelf.s3.endpoint"
         }
     ]))
 )]
@@ -61,7 +61,7 @@ pub struct KanidmBackupRepositorySpec {
     schemars(extend("x-kubernetes-validations" = [
         {
             "message": "endpoint must use HTTPS unless insecure is enabled",
-            "rule": "!has(self.endpoint) || self.endpoint.startsWith('https://') || self.insecure"
+            "rule": "self.endpoint.startsWith('https://') || self.insecure"
         }
     ]))
 )]
@@ -77,14 +77,12 @@ pub struct S3Config {
     /// This field is immutable after the repository has been used. To use a different prefix, delete this Repository and create a new one.
     #[schemars(extend("x-kubernetes-validations" = [{"message": "prefix must not contain path traversal segments", "rule": "!self.contains('..')"}]))]
     pub prefix: String,
-    /// AWS region. Optional for S3-compatible providers that do not require region specification.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
+    /// AWS region. Required for all S3-compatible providers.
+    pub region: String,
     /// S3 endpoint URL. Must use HTTPS unless insecure is enabled.
     ///
     /// This field is immutable after the repository has been used. To use a different endpoint, delete this Repository and create a new one.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub endpoint: Option<String>,
+    pub endpoint: String,
     /// Use path-style addressing (http://endpoint/bucket) instead of virtual-hosted-style (http://bucket.endpoint).
     #[serde(default)]
     pub force_path_style: bool,
@@ -536,8 +534,8 @@ mod tests {
             s3: S3Config {
                 bucket: "my-bucket".to_string(),
                 prefix: "prod".to_string(),
-                region: Some("eu-west-1".to_string()),
-                endpoint: Some("https://s3.eu-west-1.amazonaws.com".to_string()),
+                region: "eu-west-1".to_string(),
+                endpoint: "https://s3.eu-west-1.amazonaws.com".to_string(),
                 force_path_style: false,
                 ca_bundle_ref: None,
                 insecure: false,

--- a/libs/backup-core/src/operation.rs
+++ b/libs/backup-core/src/operation.rs
@@ -174,10 +174,8 @@ pub struct TransportOperation {
     pub min_file_age_secs: u64,
     pub bucket: String,
     pub prefix: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub endpoint: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
+    pub endpoint: String,
+    pub region: String,
     #[serde(default)]
     pub force_path_style: bool,
     #[serde(default)]
@@ -343,6 +341,12 @@ impl OperationDocument {
                 }
                 if op.bucket.is_empty() {
                     return Err(OperationError::MissingField("bucket".to_string()));
+                }
+                if op.endpoint.is_empty() {
+                    return Err(OperationError::MissingField("endpoint".to_string()));
+                }
+                if op.region.is_empty() {
+                    return Err(OperationError::MissingField("region".to_string()));
                 }
                 if op.namespace_uid.is_empty() {
                     return Err(OperationError::MissingField("namespaceUid".to_string()));
@@ -769,8 +773,8 @@ mod tests {
                 min_file_age_secs: 120,
                 bucket: "test-bucket".to_string(),
                 prefix: "prod".to_string(),
-                endpoint: Some("https://s3.example.com".to_string()),
-                region: Some("us-east-1".to_string()),
+                endpoint: "https://s3.example.com".to_string(),
+                region: "us-east-1".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_path: None,

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -82,16 +82,8 @@ pub fn build_validation_job(
     namespace: &str,
 ) -> Job {
     let spec = &repository.spec;
-    let endpoint = spec
-        .s3
-        .endpoint
-        .clone()
-        .unwrap_or_else(|| "https://s3.amazonaws.com".to_string());
-    let region = spec
-        .s3
-        .region
-        .clone()
-        .unwrap_or_else(|| "us-east-1".to_string());
+    let endpoint = &spec.s3.endpoint;
+    let region = &spec.s3.region;
 
     let ca_bundle_path = spec.s3.ca_bundle_ref.as_ref().map(|_| ca_bundle_path());
 
@@ -224,16 +216,8 @@ pub fn build_deletion_job(
     backup_prefix: &str,
 ) -> Job {
     let spec = &repository.spec;
-    let endpoint = spec
-        .s3
-        .endpoint
-        .clone()
-        .unwrap_or_else(|| "https://s3.amazonaws.com".to_string());
-    let region = spec
-        .s3
-        .region
-        .clone()
-        .unwrap_or_else(|| "us-east-1".to_string());
+    let endpoint = &spec.s3.endpoint;
+    let region = &spec.s3.region;
 
     let ca_bundle_path = spec.s3.ca_bundle_ref.as_ref().map(|_| ca_bundle_path());
 
@@ -1167,8 +1151,8 @@ mod tests {
                 s3: crate::crd::S3Config {
                     bucket: "my-bucket".to_string(),
                     prefix: "prod".to_string(),
-                    region: Some("us-east-1".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "us-east-1".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,
@@ -1260,8 +1244,8 @@ mod tests {
                 s3: crate::crd::S3Config {
                     bucket: "b".to_string(),
                     prefix: "p".to_string(),
-                    region: Some("r".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "r".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,
@@ -1325,8 +1309,8 @@ mod tests {
                 s3: crate::crd::S3Config {
                     bucket: "b".to_string(),
                     prefix: "prod".to_string(),
-                    region: Some("r".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "r".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,
@@ -1475,8 +1459,8 @@ mod tests {
                 s3: crate::crd::S3Config {
                     bucket: "b".to_string(),
                     prefix: "p".to_string(),
-                    region: Some("r".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "r".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -671,16 +671,8 @@ fn build_discover_job(
     kanidm_uid: &str,
 ) -> Job {
     let spec = &repository.spec;
-    let endpoint = spec
-        .s3
-        .endpoint
-        .clone()
-        .unwrap_or_else(|| "https://s3.amazonaws.com".to_string());
-    let region = spec
-        .s3
-        .region
-        .clone()
-        .unwrap_or_else(|| "us-east-1".to_string());
+    let endpoint = &spec.s3.endpoint;
+    let region = &spec.s3.region;
 
     let ca_bundle_path = spec.s3.ca_bundle_ref.as_ref().map(|_| ca_bundle_path());
 
@@ -1130,8 +1122,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "test-bucket".to_string(),
                     prefix: "prod".to_string(),
-                    region: Some("us-east-1".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "us-east-1".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,

--- a/libs/backup/src/controller/repository.rs
+++ b/libs/backup/src/controller/repository.rs
@@ -141,10 +141,8 @@ fn validate_spec(spec: &KanidmBackupRepositorySpec) -> Option<String> {
     if spec.s3.prefix.contains("..") {
         return Some("prefix contains path traversal".to_string());
     }
-    if let Some(endpoint) = &spec.s3.endpoint {
-        if !endpoint.starts_with("https://") && !spec.s3.insecure {
-            return Some("endpoint must use HTTPS".to_string());
-        }
+    if !spec.s3.endpoint.starts_with("https://") && !spec.s3.insecure {
+        return Some("endpoint must use HTTPS".to_string());
     }
     if let Err(e) = RepositoryPath::new(&spec.s3.bucket, &spec.s3.prefix) {
         return Some(format!("invalid repository path: {e}"));
@@ -264,8 +262,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "b".to_string(),
                     prefix: "p".to_string(),
-                    region: None,
-                    endpoint: None,
+                    region: String::new(),
+                    endpoint: String::new(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: ca_bundle.map(String::from),
@@ -394,8 +392,8 @@ mod tests {
             s3: S3Config {
                 bucket: "my-bucket".to_string(),
                 prefix: "prod".to_string(),
-                region: None,
-                endpoint: Some("https://s3.example.com".to_string()),
+                region: "us-east-1".to_string(),
+                endpoint: "https://s3.example.com".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,
@@ -428,8 +426,8 @@ mod tests {
             s3: S3Config {
                 bucket: "".to_string(),
                 prefix: "p".to_string(),
-                region: None,
-                endpoint: None,
+                region: "us-east-1".to_string(),
+                endpoint: "https://s3.example.com".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,
@@ -463,8 +461,8 @@ mod tests {
             s3: S3Config {
                 bucket: "b".to_string(),
                 prefix: "foo/../bar".to_string(),
-                region: None,
-                endpoint: None,
+                region: "us-east-1".to_string(),
+                endpoint: "https://s3.example.com".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,
@@ -498,8 +496,8 @@ mod tests {
             s3: S3Config {
                 bucket: "b".to_string(),
                 prefix: "p".to_string(),
-                region: None,
-                endpoint: Some("http://s3.example.com".to_string()),
+                region: "us-east-1".to_string(),
+                endpoint: "http://s3.example.com".to_string(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,
@@ -533,8 +531,8 @@ mod tests {
             s3: S3Config {
                 bucket: "b".to_string(),
                 prefix: "p".to_string(),
-                region: None,
-                endpoint: Some("http://localhost:9000".to_string()),
+                region: "us-east-1".to_string(),
+                endpoint: "http://localhost:9000".to_string(),
                 force_path_style: false,
                 insecure: true,
                 ca_bundle_ref: None,
@@ -707,8 +705,8 @@ mod tests {
             s3: S3Config {
                 bucket: "".to_string(),
                 prefix: "p".to_string(),
-                region: None,
-                endpoint: None,
+                region: String::new(),
+                endpoint: String::new(),
                 force_path_style: false,
                 insecure: false,
                 ca_bundle_ref: None,
@@ -732,7 +730,6 @@ mod tests {
             encryption: None,
             limits: None,
         };
-
         let validation_error = validate_spec(&spec);
         assert!(validation_error.is_some());
 

--- a/libs/backup/src/controller/schedule.rs
+++ b/libs/backup/src/controller/schedule.rs
@@ -596,8 +596,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "bucket".to_string(),
                     prefix: "prefix".to_string(),
-                    region: None,
-                    endpoint: None,
+                    region: String::new(),
+                    endpoint: String::new(),
                     force_path_style: false,
                     insecure: false,
                     ca_bundle_ref: None,

--- a/libs/operator/src/kanidm/controller/mod.rs
+++ b/libs/operator/src/kanidm/controller/mod.rs
@@ -548,8 +548,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "bucket".to_string(),
                     prefix: "".to_string(),
-                    region: None,
-                    endpoint: None,
+                    region: String::new(),
+                    endpoint: String::new(),
                     force_path_style: false,
                     ca_bundle_ref: None,
                     insecure: false,

--- a/libs/operator/src/kanidm/reconcile/transport.rs
+++ b/libs/operator/src/kanidm/reconcile/transport.rs
@@ -296,8 +296,8 @@ mod tests {
                 s3: S3Config {
                     bucket: "test-bucket".to_string(),
                     prefix: "backups".to_string(),
-                    region: Some("us-east-1".to_string()),
-                    endpoint: Some("https://s3.example.com".to_string()),
+                    region: "us-east-1".to_string(),
+                    endpoint: "https://s3.example.com".to_string(),
                     force_path_style: false,
                     ca_bundle_ref: None,
                     insecure: false,

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -2111,13 +2111,8 @@ async fn ensure_safety_backup_job(
         .map_err(|e| Error::kube_error("get", "KanidmBackupRepository", &ns, &repo_ref.name, e))?;
     let _namespace_uid = &ns;
     let _kanidm_uid = &restore.spec.target_ref.uid;
-    let endpoint = repo
-        .spec
-        .s3
-        .endpoint
-        .as_deref()
-        .unwrap_or("https://s3.amazonaws.com");
-    let region = repo.spec.s3.region.as_deref().unwrap_or("us-east-1");
+    let endpoint = &repo.spec.s3.endpoint;
+    let region = &repo.spec.s3.region;
     let operation_doc = build_safety_upload_operation_doc(
         restore,
         target,
@@ -2385,13 +2380,8 @@ async fn ensure_source_prep_job(
                 e,
             )
         })?;
-    let endpoint = repo
-        .spec
-        .s3
-        .endpoint
-        .as_deref()
-        .unwrap_or("https://s3.amazonaws.com");
-    let region = repo.spec.s3.region.as_deref().unwrap_or("us-east-1");
+    let endpoint = &repo.spec.s3.endpoint;
+    let region = &repo.spec.s3.region;
     let operation_doc = build_download_operation_doc(
         restore,
         target,

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -41,8 +41,8 @@ fn minio_s3_config(prefix: &str) -> S3Config {
     S3Config {
         bucket: MINIO_BUCKET.to_string(),
         prefix: prefix.to_string(),
-        region: Some(MINIO_REGION.to_string()),
-        endpoint: Some(MINIO_ENDPOINT.to_string()),
+        region: MINIO_REGION.to_string(),
+        endpoint: MINIO_ENDPOINT.to_string(),
         force_path_style: true,
         insecure: false,
         ca_bundle_ref: Some(MINIO_CA_CM.to_string()),
@@ -1439,7 +1439,7 @@ e2e_test!(
         );
 
         let mut repo = api.get(repo_name).await.unwrap();
-        repo.spec.s3.endpoint = Some("https://other.endpoint.example.com".to_string());
+        repo.spec.s3.endpoint = "https://other.endpoint.example.com".to_string();
         repo.metadata.managed_fields = None;
         let result = api
             .patch(

--- a/tests/e2e/test/kanidm/backup_transport.rs
+++ b/tests/e2e/test/kanidm/backup_transport.rs
@@ -34,8 +34,8 @@ fn minio_s3_config(prefix: &str) -> S3Config {
     S3Config {
         bucket: MINIO_BUCKET.to_string(),
         prefix: prefix.to_string(),
-        region: Some(MINIO_REGION.to_string()),
-        endpoint: Some(MINIO_ENDPOINT.to_string()),
+        region: MINIO_REGION.to_string(),
+        endpoint: MINIO_ENDPOINT.to_string(),
         force_path_style: true,
         insecure: false,
         ca_bundle_ref: Some(MINIO_CA_CM.to_string()),

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1086,8 +1086,8 @@ fn restore_minio_s3_config(prefix: &str) -> S3Config {
     S3Config {
         bucket: RESTORE_MINIO_BUCKET.to_string(),
         prefix: prefix.to_string(),
-        region: Some(RESTORE_MINIO_REGION.to_string()),
-        endpoint: Some(RESTORE_MINIO_ENDPOINT.to_string()),
+        region: RESTORE_MINIO_REGION.to_string(),
+        endpoint: RESTORE_MINIO_ENDPOINT.to_string(),
         force_path_style: true,
         insecure: false,
         ca_bundle_ref: Some(RESTORE_MINIO_CA_CM.to_string()),


### PR DESCRIPTION
## Summary
- require S3 endpoint and region in the backup repository CRD
- validate both fields in transport operation documents
- align controllers, webhook validation, examples, and tests with the required fields

## Validation
- `make lint`
- `make test`
- `make crdgen`
- `make examples`

E2E tests are delegated to CI.