### PR TITLE
fix(backup): prevent discovery result truncation

### DIFF
--- a/charts/kaniop/templates/clusterrole.yaml
+++ b/charts/kaniop/templates/clusterrole.yaml
@@ -33,6 +33,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
       - secrets
       - services
     verbs:

--- a/charts/kaniop/tests/clusterrole_test.yaml
+++ b/charts/kaniop/tests/clusterrole_test.yaml
@@ -86,6 +86,22 @@ tests:
               - create
           any: true
 
+  - it: Should have pods/log get permission
+    release:
+      name: kaniop
+      namespace: kaniop
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods/log
+            verbs:
+              - get
+          any: true
+
   - it: Should have full access to secrets and services
     release:
       name: kaniop

--- a/libs/backup-core/src/result.rs
+++ b/libs/backup-core/src/result.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 pub const RESULT_DOC_VERSION: &str = "backup.kaniop.rs/v1alpha1";
-pub const MAX_RESULT_DOC_SIZE: usize = 16 * 1024;
+pub const MAX_RESULT_DOC_SIZE: usize = 512 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResultDocError {
@@ -216,5 +216,127 @@ mod tests {
         let parsed = parse_result_document(&json).unwrap();
         assert_eq!(result, parsed);
         assert_eq!(parsed.discovery.unwrap().total_found, 2);
+    }
+
+    #[test]
+    fn parse_at_max_size_succeeds() {
+        let mut doc = ResultDocument::success("discover");
+        let mut keys = Vec::new();
+        let mut total_len = 0usize;
+        let target = MAX_RESULT_DOC_SIZE - 512;
+        for i in 0.. {
+            let key = format!(
+                "prod/v1/tenants/default-ns/clusters/kaniop/backups/{:032x}-f423-7a12-8f41-2bea7588a303/manifest.json",
+                i
+            );
+            let entry_len = key.len() + 3;
+            if total_len + entry_len > target {
+                break;
+            }
+            total_len += entry_len;
+            keys.push(key);
+        }
+        doc.discovery = Some(DiscoverResult {
+            manifest_keys: keys,
+            total_found: 0,
+            truncated: false,
+        });
+        if let Some(ref mut d) = doc.discovery {
+            d.total_found = d.manifest_keys.len() as u32;
+        }
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(
+            json.len() <= MAX_RESULT_DOC_SIZE,
+            "serialized doc len {} exceeds MAX_RESULT_DOC_SIZE {}",
+            json.len(),
+            MAX_RESULT_DOC_SIZE
+        );
+        assert!(json.len() > MAX_RESULT_DOC_SIZE / 2);
+        assert!(parse_result_document(&json).is_ok());
+    }
+
+    #[test]
+    fn parse_over_max_size_fails() {
+        let huge = "x".repeat(MAX_RESULT_DOC_SIZE + 1);
+        let err = parse_result_document(&huge);
+        assert!(err.is_err());
+        assert!(matches!(err.unwrap_err(), ResultDocError::DocumentTooLarge));
+    }
+
+    #[test]
+    fn parse_max_results_keys_within_limit() {
+        let keys: Vec<String> = (0..1000)
+            .map(|i| {
+                format!(
+                    "prod/v1/tenants/default-ns/clusters/kaniop/backups/{:032x}-f423-7a12-8f41-2bea7588a303/manifest.json",
+                    i
+                )
+            })
+            .collect();
+        let doc = ResultDocument {
+            api_version: RESULT_DOC_VERSION.to_string(),
+            kind: "ResultDocument".to_string(),
+            operation: "discover".to_string(),
+            success: true,
+            exit_code: ExitCode::Success,
+            backup_id: None,
+            manifest_key: None,
+            payload_key: None,
+            payload_sha256: None,
+            payload_size_bytes: None,
+            error: None,
+            deletion: None,
+            discovery: Some(DiscoverResult {
+                manifest_keys: keys,
+                total_found: 1000,
+                truncated: true,
+            }),
+        };
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(
+            json.len() <= MAX_RESULT_DOC_SIZE,
+            "1000 manifest keys serialized to {} bytes, exceeds MAX_RESULT_DOC_SIZE {MAX_RESULT_DOC_SIZE}",
+            json.len()
+        );
+        assert!(parse_result_document(&json).is_ok());
+    }
+
+    #[test]
+    fn parse_1000_manifest_keys_size_gt_4096() {
+        let keys: Vec<String> = (0..1000)
+            .map(|i| {
+                format!(
+                    "prod/v1/tenants/default-ns/clusters/kaniop/backups/{:032x}-f423-7a12-8f41-2bea7588a303/manifest.json",
+                    i
+                )
+            })
+            .collect();
+        let doc = ResultDocument {
+            api_version: RESULT_DOC_VERSION.to_string(),
+            kind: "ResultDocument".to_string(),
+            operation: "discover".to_string(),
+            success: true,
+            exit_code: ExitCode::Success,
+            backup_id: None,
+            manifest_key: None,
+            payload_key: None,
+            payload_sha256: None,
+            payload_size_bytes: None,
+            error: None,
+            deletion: None,
+            discovery: Some(DiscoverResult {
+                manifest_keys: keys,
+                total_found: 1000,
+                truncated: true,
+            }),
+        };
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(
+            json.len() > 4096,
+            "1000 manifest keys serialized to {} bytes, expected >4096",
+            json.len()
+        );
+        let parsed = parse_result_document(&json).unwrap();
+        assert_eq!(parsed.discovery.unwrap().manifest_keys.len(), 1000);
     }
 }

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -1,8 +1,8 @@
 use crate::controller::{
-    BACKUP_JOB_TTL_SECONDS, DISCOVERY_CONTROLLER_ID, RESULT_PATH, background_delete_params,
-    build_data_mover_wrapper, data_mover_image, default_resource_requirements,
-    extract_termination_message, hardened_pod_security_context, hardened_security_context,
-    select_succeeded_pod,
+    BACKUP_JOB_TTL_SECONDS, DISCOVER_LOG_LIMIT_BYTES, DISCOVERY_CONTROLLER_ID, RESULT_PATH,
+    background_delete_params, build_discover_data_mover_wrapper, data_mover_image,
+    default_resource_requirements, extract_framed_result, hardened_pod_security_context,
+    hardened_security_context, select_succeeded_pod,
 };
 use crate::crd::{
     BackupKanidmRef, BackupRepositoryRef, KanidmBackup, KanidmBackupRepository,
@@ -28,7 +28,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, ObjectMeta, Time};
 use k8s_openapi::jiff::Timestamp;
 use kaniop_k8s_util::error::{Error, Result};
-use kube::api::{ListParams, Patch, PatchParams};
+use kube::api::{ListParams, LogParams, Patch, PatchParams};
 use kube::client::Client;
 use kube::{Api, ResourceExt};
 use opentelemetry::KeyValue;
@@ -766,7 +766,7 @@ fn build_discover_job(
                         command: Some(vec!["/bin/sh".to_string()]),
                         args: Some(vec![
                             "-c".to_string(),
-                            build_data_mover_wrapper("discover"),
+                            build_discover_data_mover_wrapper(),
                             "--".to_string(),
                             serde_json::to_string(&operation_json).unwrap_or_default(),
                         ]),
@@ -833,8 +833,20 @@ async fn read_discover_result(
         None => return Ok(None),
     };
 
-    let raw = match extract_termination_message(pod, "discover") {
-        Some(msg) => msg,
+    let pod_name = pod.name_any();
+    let log_params = LogParams {
+        limit_bytes: Some(DISCOVER_LOG_LIMIT_BYTES),
+        ..Default::default()
+    };
+    let logs = pod_api.logs(&pod_name, &log_params).await.map_err(|e| {
+        Error::KubeError(
+            format!("failed to read logs for discover pod {namespace}/{pod_name}"),
+            Box::new(e),
+        )
+    })?;
+
+    let raw = match extract_framed_result(&logs) {
+        Some(payload) => payload,
         None => return Ok(None),
     };
 
@@ -1265,6 +1277,56 @@ mod tests {
         assert_eq!(op["bucket"], "test-bucket");
         assert_eq!(op["prefix"], "prod");
         assert_eq!(op["maxResults"], DEFAULT_DISCOVER_MAX_RESULTS);
+    }
+
+    #[test]
+    fn build_discover_job_uses_framed_wrapper() {
+        let repo = make_repository("offsite");
+        let job = build_discover_job(&repo, "default", "daily", "ns-uid", "k-uid");
+        let pod_spec = job.spec.unwrap().template.spec.unwrap();
+        let args = pod_spec.containers[0].args.as_ref().unwrap();
+        let wrapper_script = &args[1];
+        assert!(wrapper_script.contains(crate::controller::RESULT_FRAME_BEGIN));
+        assert!(wrapper_script.contains(crate::controller::RESULT_FRAME_END));
+        assert!(wrapper_script.contains("/bin/kaniop-data-mover discover"));
+        assert!(wrapper_script.contains("exit $STATUS"));
+    }
+
+    #[test]
+    fn framed_discovery_result_exceeding_termination_limit_extracts_and_parses() {
+        let keys: Vec<String> = (0..80)
+            .map(|i| {
+                format!(
+                    "prod/v1/tenants/default-ns/clusters/kaniop/backups/{:032x}-f423-7a12-8f41-2bea7588a303/manifest.json",
+                    i
+                )
+            })
+            .collect();
+        let mut doc = kaniop_backup_core::result::ResultDocument::success("discover");
+        doc.discovery = Some(kaniop_backup_core::result::DiscoverResult {
+            manifest_keys: keys,
+            total_found: 80,
+            truncated: false,
+        });
+        let json = serde_json::to_string_pretty(&doc).unwrap();
+        assert!(
+            json.len() > crate::controller::TERMINATION_MESSAGE_LIMIT,
+            "test payload must exceed the old termination-message limit of {} bytes, got {}",
+            crate::controller::TERMINATION_MESSAGE_LIMIT,
+            json.len()
+        );
+        let log = format!(
+            "{}\n{}\n{}",
+            crate::controller::RESULT_FRAME_BEGIN,
+            json,
+            crate::controller::RESULT_FRAME_END
+        );
+        let extracted = crate::controller::extract_framed_result(&log);
+        assert!(extracted.is_some());
+        let parsed = kaniop_backup_core::result::parse_result_document(&extracted.unwrap());
+        assert!(parsed.is_ok());
+        let parsed_doc = parsed.unwrap();
+        assert_eq!(parsed_doc.discovery.as_ref().unwrap().total_found, 80);
     }
 
     #[test]

--- a/libs/backup/src/controller/mod.rs
+++ b/libs/backup/src/controller/mod.rs
@@ -19,6 +19,9 @@ pub use kaniop_backup_core::pod_defaults::{
 pub const RESULT_PATH: &str = "/kaniop-result/result.json";
 pub const TERMINATION_MESSAGE_LIMIT: usize = 4096;
 pub const BACKUP_JOB_TTL_SECONDS: i32 = 600;
+pub const RESULT_FRAME_BEGIN: &str = "---BEGIN-KANIOP-RESULT---";
+pub const RESULT_FRAME_END: &str = "---END-KANIOP-RESULT---";
+pub const DISCOVER_LOG_LIMIT_BYTES: i64 = 1024 * 1024;
 
 pub fn background_delete_params() -> kube::api::DeleteParams {
     kube::api::DeleteParams {
@@ -38,6 +41,65 @@ if [ -f "$RESULT_FILE" ]; then
 fi
 exit $STATUS"#
     )
+}
+
+pub fn build_discover_data_mover_wrapper() -> String {
+    format!(
+        r#"set +e
+/bin/kaniop-data-mover discover --operation-doc "$1"
+STATUS=$?
+RESULT_FILE="{RESULT_PATH}"
+if [ -f "$RESULT_FILE" ]; then
+  head -c {TERMINATION_MESSAGE_LIMIT} "$RESULT_FILE" > /dev/termination-log
+  printf '%s\n' "{RESULT_FRAME_BEGIN}"
+  cat "$RESULT_FILE"
+  printf '\n{RESULT_FRAME_END}\n'
+fi
+exit $STATUS"#
+    )
+}
+
+pub fn extract_framed_result(log: &str) -> Option<String> {
+    let lines: Vec<&str> = log.lines().collect();
+    let mut frame_begin: Option<usize> = None;
+    let mut frame_end: Option<usize> = None;
+    let mut found_complete = false;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed == RESULT_FRAME_BEGIN {
+            if frame_begin.is_some() && frame_end.is_none() {
+                return None;
+            }
+            if found_complete {
+                return None;
+            }
+            frame_begin = Some(i);
+            frame_end = None;
+        } else if trimmed == RESULT_FRAME_END && frame_begin.is_some() && frame_end.is_none() {
+            frame_end = Some(i);
+            found_complete = true;
+        }
+    }
+
+    if !found_complete {
+        return None;
+    }
+
+    let begin = frame_begin?;
+    let end = frame_end?;
+
+    if end <= begin + 1 {
+        return None;
+    }
+
+    let payload = lines[begin + 1..end].join("\n");
+    let trimmed = payload.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 pub fn select_succeeded_pod(pods: &[Pod]) -> Option<&Pod> {
@@ -300,5 +362,206 @@ mod tests {
     #[test]
     fn backup_job_ttl_is_positive() {
         const { assert!(BACKUP_JOB_TTL_SECONDS > 0) };
+    }
+
+    #[test]
+    fn build_discover_wrapper_uses_discover_subcommand() {
+        let wrapper = build_discover_data_mover_wrapper();
+        assert!(wrapper.contains("/bin/kaniop-data-mover discover"));
+        assert!(wrapper.contains("--operation-doc"));
+    }
+
+    #[test]
+    fn build_discover_wrapper_emits_frame_markers() {
+        let wrapper = build_discover_data_mover_wrapper();
+        assert!(wrapper.contains(RESULT_FRAME_BEGIN));
+        assert!(wrapper.contains(RESULT_FRAME_END));
+    }
+
+    #[test]
+    fn build_discover_wrapper_preserves_exit_status() {
+        let wrapper = build_discover_data_mover_wrapper();
+        assert!(wrapper.contains("STATUS=$?"));
+        assert!(wrapper.contains("exit $STATUS"));
+    }
+
+    #[test]
+    fn build_discover_wrapper_writes_termination_log() {
+        let wrapper = build_discover_data_mover_wrapper();
+        assert!(wrapper.contains("/dev/termination-log"));
+        assert!(wrapper.contains(&TERMINATION_MESSAGE_LIMIT.to_string()));
+    }
+
+    #[test]
+    fn extract_framed_result_extracts_payload() {
+        let log = format!(
+            "some log line\n{RESULT_FRAME_BEGIN}\n{{\"success\":true}}\n{RESULT_FRAME_END}\nmore logs"
+        );
+        let result = extract_framed_result(&log);
+        assert_eq!(result, Some("{\"success\":true}".to_string()));
+    }
+
+    #[test]
+    fn extract_framed_result_with_surrounding_logs() {
+        let log = format!(
+            "2024-01-01 INFO starting discover\n\
+             2024-01-01 INFO connecting to S3\n\
+             {RESULT_FRAME_BEGIN}\n\
+             {{\"apiVersion\":\"backup.kaniop.rs/v1alpha1\",\"kind\":\"ResultDocument\"}}\n\
+             {RESULT_FRAME_END}\n\
+             2024-01-01 INFO done"
+        );
+        let result = extract_framed_result(&log);
+        assert!(result.is_some());
+        let payload = result.unwrap();
+        assert!(payload.contains("\"apiVersion\""));
+        assert!(payload.contains("ResultDocument"));
+    }
+
+    #[test]
+    fn extract_framed_result_multiline_json() {
+        let json = serde_json::json!({
+            "apiVersion": "backup.kaniop.rs/v1alpha1",
+            "kind": "ResultDocument",
+            "operation": "discover",
+            "success": true,
+            "exitCode": "success",
+            "discovery": {
+                "manifestKeys": [
+                    "prod/v1/backups/b1/manifest.json",
+                    "prod/v1/backups/b2/manifest.json",
+                    "prod/v1/backups/b3/manifest.json"
+                ],
+                "totalFound": 3,
+                "truncated": false
+            }
+        });
+        let pretty = serde_json::to_string_pretty(&json).unwrap();
+        let log =
+            format!("log line 1\n{RESULT_FRAME_BEGIN}\n{pretty}\n{RESULT_FRAME_END}\nlog line 2");
+        let result = extract_framed_result(&log);
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&extracted).unwrap();
+        assert_eq!(parsed["operation"], "discover");
+        assert_eq!(parsed["discovery"]["totalFound"], 3);
+    }
+
+    #[test]
+    fn extract_framed_result_missing_begin_marker() {
+        let log = format!("some logs\n{{\"success\":true}}\n{RESULT_FRAME_END}\nmore logs");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_missing_end_marker() {
+        let log = format!("some logs\n{RESULT_FRAME_BEGIN}\n{{\"success\":true}}\nmore logs");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_no_markers() {
+        let log = "just some normal log lines\nnothing special here";
+        let result = extract_framed_result(log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_empty_payload() {
+        let log = format!("{RESULT_FRAME_BEGIN}\n\n{RESULT_FRAME_END}");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_whitespace_only_payload() {
+        let log = format!("{RESULT_FRAME_BEGIN}\n   \n  \n{RESULT_FRAME_END}");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_empty_log() {
+        let result = extract_framed_result("");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_markers_reversed() {
+        let log = format!("{RESULT_FRAME_END}\n{RESULT_FRAME_BEGIN}\n{{\"ok\":true}}");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_rejects_inline_begin_marker() {
+        let log = format!("INFO {RESULT_FRAME_BEGIN}\n{{\"ok\":true}}\n{RESULT_FRAME_END}");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_rejects_inline_end_marker() {
+        let log = format!("{RESULT_FRAME_BEGIN}\n{{\"ok\":true}}\n{RESULT_FRAME_END} INFO");
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_rejects_multiple_complete_frames() {
+        let log = format!(
+            "{RESULT_FRAME_BEGIN}\n{{\"first\":true}}\n{RESULT_FRAME_END}\n\
+             {RESULT_FRAME_BEGIN}\n{{\"second\":true}}\n{RESULT_FRAME_END}"
+        );
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_rejects_nested_begin() {
+        let log = format!(
+            "{RESULT_FRAME_BEGIN}\n{RESULT_FRAME_BEGIN}\n{{\"ok\":true}}\n{RESULT_FRAME_END}"
+        );
+        let result = extract_framed_result(&log);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_framed_result_oversized_payload_detected_by_parse() {
+        let large_keys: Vec<String> = (0..2000)
+            .map(|i| {
+                format!(
+                    "prod/v1/tenants/default-ns/clusters/kaniop/backups/{:032x}-f423-7a12-8f41-2bea7588a303/manifest.json",
+                    i
+                )
+            })
+            .collect();
+        let doc = serde_json::json!({
+            "apiVersion": "backup.kaniop.rs/v1alpha1",
+            "kind": "ResultDocument",
+            "operation": "discover",
+            "success": true,
+            "exitCode": "success",
+            "discovery": {
+                "manifestKeys": large_keys,
+                "totalFound": 2000,
+                "truncated": true
+            }
+        });
+        let pretty = serde_json::to_string_pretty(&doc).unwrap();
+        let log = format!("{RESULT_FRAME_BEGIN}\n{pretty}\n{RESULT_FRAME_END}");
+        let extracted = extract_framed_result(&log);
+        assert!(extracted.is_some());
+        let parse_result = kaniop_backup_core::result::parse_result_document(&extracted.unwrap());
+        if pretty.len() > kaniop_backup_core::result::MAX_RESULT_DOC_SIZE {
+            assert!(parse_result.is_err());
+        }
+    }
+
+    #[test]
+    fn discover_log_limit_bytes_exceeds_max_result_doc_size() {
+        assert!(DISCOVER_LOG_LIMIT_BYTES > kaniop_backup_core::result::MAX_RESULT_DOC_SIZE as i64);
     }
 }


### PR DESCRIPTION
## Root cause

Discovery result documents were transported through `/dev/termination-log`, which Kubernetes limits to 4096 bytes. Repositories with enough backup manifests produced truncated JSON, preventing `KanidmBackup` CR creation and retention.

## Solution

- Emit complete discovery results to pod logs using strict frame markers.
- Read bounded pod logs and reject missing, nested, or duplicate result frames.
- Increase the result document limit to 512 KiB for up to 1000 manifest keys.
- Preserve the termination message for diagnostics and other data-mover operations.
- Grant the operator read-only `pods/log` access.

Discovery cadence and validation timing are unchanged.

## Security / RBAC

Discovery Jobs remain tokenless and receive no Kubernetes API permissions. The operator gains only `get` on `pods/log`.

## Tests

- `make lint`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace`
- `helm unittest charts/kaniop`