### PR TITLE
fix(backup): harden transport retention and restore validation

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -50,6 +50,7 @@
         "person",
         "quickstart",
         "release",
+        "restore",
         "sa",
         "test",
         "webhook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,6 +3361,7 @@ dependencies = [
  "kaniop-operator",
  "kube",
  "opentelemetry",
+ "opentelemetry_sdk",
  "schemars 1.2.2",
  "serde",
  "serde_json",

--- a/Documentation/src/usage/backup-restore.md
+++ b/Documentation/src/usage/backup-restore.md
@@ -76,7 +76,7 @@ The `TransportExperimental` condition on `KanidmBackupSchedule` indicates that t
 
 - Kanidm has no documented completion contract for online backups. It writes directly to the final filename with no atomic rename, completion marker, or event that an external data mover can use as an unambiguous completion signal.
 - Kaniop's data mover uses file stability heuristics (size, mtime, checksums) to detect when a backup is complete, but these are **not a production completion contract**.
-- Kaniop **does not report production backup success** based on these heuristics alone. A `Ready` condition on the Schedule means the schedule is configured, not that backups are successfully committed to the remote repository.
+- Kaniop **does not report production backup success** based on these heuristics alone. A `Ready` condition on the Schedule means manifest metadata has been validated against S3 objects; it is not a guarantee that full payload integrity was independently verified.
 
 **Current support status:**
 
@@ -249,9 +249,19 @@ data:
 
 The KEK must be exactly 32 bytes. It can be provided as raw 32 bytes or base64-encoded 32 bytes in the Secret's `encryption-key` field.
 
-**KEK loss warning:** If the KEK Secret is lost, all backups encrypted with that KEK become **unrecoverable**. Store the KEK securely and separately from the backup repository. KEK rotation (re-wrapping the DEK in manifests without re-uploading data) is documented but tooling is deferred.
+**Rotation and rekey:** Rotating the KEK (re-wrapping all existing DEK blobs in manifests without re-uploading data) is documented but tooling is not yet implemented and is deferred. Until that support exists, you must retain the original KEK for as long as any backup encrypted with it could be needed.
+
+**KEK escrow retention:** The KEK Secret must be retained for at least the longest remote retention horizon configured on any `KanidmBackupSchedule` referencing this repository, plus a safety margin of your choosing. If the KEK is lost or rendered inaccessible, **all backups encrypted with that KEK become unrecoverable**. Store the KEK securely and separately from the backup repository, and treat its availability as a critical dependency in your disaster-recovery plan.
 
 **Immutability:** Once a repository has been used (backups exist), the encryption configuration (`mode`, `keyId`, `keyRef`) becomes immutable. This prevents breaking existing backups that were created with a specific encryption configuration. Adding encryption to a repository that previously had none is allowed (forward-only change).
+
+### Workload Security Boundary
+
+Backup payloads contain sensitive identity data including password hashes, TOTP seeds, and credential material. The transport sidecar runs as a container within the primary Kanidm pod's StatefulSet and shares the same pod network namespace — Kubernetes workload identity commonly binds to the Pod rather than an individual container. Compromise of the Kanidm pod therefore potentially exposes S3 writer credentials and backup payload access.
+
+Data-mover Jobs (used for discovery, retention enforcement, deletion, and restore safety backups) run with restricted security contexts and resource limits but still mount the S3 credentials needed for their operation. They do not mount Kubernetes service account tokens or the Kanidm database volume. IAM policy should assume compromise of any workload holding S3 credentials and enforce least-privilege scoping per role (writer, reader, deleter, restore reader) as described in the [Backup Transport Sidecar](#backup-transport-sidecar) section.
+
+SHA-256 checksums protect against accidental corruption but are not cryptographic signatures against a determined attacker who can replace both payload and manifest. Immutable object keys, overwrite protection, split read/write/delete roles, and provider Object Lock reduce this risk. Cryptographic manifest signing is required in a future threat model where the storage writer is untrusted.
 
 ## Restore
 
@@ -272,7 +282,7 @@ spec:
   restoreImage: kanidm/server:1.10.0
 ```
 
-The controller validates the request, marks the target in maintenance, scales all Kanidm pods down, runs `kanidmd database restore`, verifies the database offline, discards stale secondary PVC data, starts the restored primary, rebuilds replicas through normal Kanidm replication, and only then resumes ordinary Kaniop reconciliation. A failure after database mutation is fail-closed: the restore remains `Failed` and the target remains marked as restoring.
+The controller validates the request, verifies the source payload size and checksum against the manifest before any database mutation occurs, marks the target in maintenance, scales all Kanidm pods down, runs `kanidmd database restore`, verifies the database offline, discards stale secondary PVC data, starts the restored primary, rebuilds replicas through normal Kanidm replication, and only then resumes ordinary Kaniop reconciliation. A failure after database mutation is fail-closed: the restore remains `Failed` and the target remains marked as restoring.
 
 Restoring a historical database is followed by GitOps reconciliation. Declaratively managed Kaniop resources can therefore be recreated or changed after recovery.
 

--- a/charts/kaniop/files/prometheusrules.yaml
+++ b/charts/kaniop/files/prometheusrules.yaml
@@ -78,13 +78,13 @@ groups:
           description: "A restore operation has been running for over 1 hour."
 
       - alert: KaniopBackupDiscoveryStale
-        expr: backup_discovery_scan_duration_seconds == 0 or time() - backup_discovery_last_scan_success_timestamp > 7200
+        expr: time() - kaniop_backup_discovery_last_scan_success_timestamp > 7200
         for: 15m
         labels:
           severity: warning
         annotations:
           summary: "Kaniop backup discovery stale"
-          description: "Backup discovery for repository {{$labels.repository}} has not succeeded recently."
+          description: "Backup discovery has not succeeded for over 2 hours."
 
       - alert: KaniopRestoreBreakGlassUsed
         expr: increase(kaniop_restore_break_glass_total[1h]) > 0
@@ -94,3 +94,30 @@ groups:
         annotations:
           summary: "Kaniop restore break-glass override used"
           description: "A break-glass restore bypassed the safety backup requirement."
+
+      - alert: KaniopDiscoveryTruncated
+        expr: increase(kaniop_backup_discovery_truncations_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Kaniop discovery results truncated"
+          description: "Discovery for repository {{$labels.repository}} returned truncated results in the last hour; some backups may not be represented."
+
+      - alert: KaniopBackupValidationFailures
+        expr: increase(kaniop_backup_validation_failures_total[10m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Kaniop backup validation failures"
+          description: "Backup manifest validation failed in namespace {{$labels.namespace}}."
+
+      - alert: KaniopBackupDeletionDeferred
+        expr: increase(kaniop_backup_deletions_deferred_total[30m]) > 0
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: "Kaniop backup deletion deferred"
+          description: "Backup deletion deferred in namespace {{$labels.namespace}} due to active restore reference."

--- a/charts/kaniop/tests/prometheusrules_test.yaml
+++ b/charts/kaniop/tests/prometheusrules_test.yaml
@@ -240,6 +240,9 @@ tests:
       metrics.prometheusRules.overrides.KaniopBackupDiscoveryStale.disabled: true
       metrics.prometheusRules.overrides.KaniopRestoreBreakGlassUsed.disabled: true
       metrics.prometheusRules.overrides.KaniopBackupGCDeferred.disabled: true
+      metrics.prometheusRules.overrides.KaniopDiscoveryTruncated.disabled: true
+      metrics.prometheusRules.overrides.KaniopBackupValidationFailures.disabled: true
+      metrics.prometheusRules.overrides.KaniopBackupDeletionDeferred.disabled: true
     release:
       name: kaniop
       namespace: kaniop
@@ -275,6 +278,9 @@ tests:
       metrics.prometheusRules.overrides.KaniopBackupDiscoveryStale.disabled: true
       metrics.prometheusRules.overrides.KaniopRestoreBreakGlassUsed.disabled: true
       metrics.prometheusRules.overrides.KaniopBackupGCDeferred.disabled: true
+      metrics.prometheusRules.overrides.KaniopDiscoveryTruncated.disabled: true
+      metrics.prometheusRules.overrides.KaniopBackupValidationFailures.disabled: true
+      metrics.prometheusRules.overrides.KaniopBackupDeletionDeferred.disabled: true
     release:
       name: kaniop
       namespace: kaniop

--- a/cmd/data-mover/src/commands/download.rs
+++ b/cmd/data-mover/src/commands/download.rs
@@ -81,6 +81,8 @@ fn build_download_result(manifest: &KanidmBackupManifest, manifest_key: &str) ->
     result.payload_key = Some(manifest.payload.key.clone());
     result.payload_sha256 = Some(manifest.payload.sha256.clone());
     result.payload_size_bytes = Some(manifest.payload.size_bytes);
+    result.created_at = Some(manifest.created_at.clone());
+    result.consistency = Some(manifest.backup.consistency.clone());
     result
 }
 
@@ -397,6 +399,8 @@ mod tests {
         assert_eq!(result.payload_key.as_deref(), Some(m.payload.key.as_str()));
         assert_eq!(result.payload_sha256.as_deref(), Some("abc123"));
         assert_eq!(result.payload_size_bytes, Some(1024));
+        assert_eq!(result.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
+        assert_eq!(result.consistency.as_deref(), Some("kanidm-offline"));
     }
 
     #[test]

--- a/cmd/data-mover/src/commands/transport.rs
+++ b/cmd/data-mover/src/commands/transport.rs
@@ -10,7 +10,7 @@ use s3::bucket::Bucket;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
-use uuid::{NoContext, Uuid};
+use uuid::Uuid;
 
 use crate::checksum;
 use crate::crypto;
@@ -98,11 +98,12 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
             ExitCode::InvalidInput as i32
         })?;
 
-    let known_backup_ids =
+    let (known_backup_ids, legacy_v7_timestamps_ms) =
         backfill_existing_backups(&bucket, &manifests_prefix, op.max_retries).await?;
 
     info!(
         known_backups = known_backup_ids.len(),
+        legacy_v7_count = legacy_v7_timestamps_ms.len(),
         "startup backfill complete, entering poll loop"
     );
 
@@ -112,6 +113,7 @@ pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
         op,
         watch_dir,
         known_backup_ids,
+        legacy_v7_timestamps_ms,
         shutdown_rx,
     )
     .await?;
@@ -140,17 +142,23 @@ async fn backfill_existing_backups(
     bucket: &Bucket,
     manifests_prefix: &str,
     max_retries: u32,
-) -> Result<HashSet<String>, i32> {
+) -> Result<(HashSet<String>, HashSet<u64>), i32> {
     let manifest_keys =
         list_manifest_keys(bucket, manifests_prefix, usize::MAX, max_retries).await?;
 
-    let known_ids: HashSet<String> = manifest_keys
-        .iter()
-        .filter_map(|key| extract_backup_id_from_manifest_key(key))
-        .map(String::from)
-        .collect();
+    let mut known_ids = HashSet::new();
+    let mut legacy_v7_timestamps_ms = HashSet::new();
 
-    Ok(known_ids)
+    for key in &manifest_keys {
+        if let Some(backup_id) = extract_backup_id_from_manifest_key(key) {
+            known_ids.insert(backup_id.to_string());
+            if let Some(ts_ms) = extract_v7_timestamp_ms(backup_id) {
+                legacy_v7_timestamps_ms.insert(ts_ms);
+            }
+        }
+    }
+
+    Ok((known_ids, legacy_v7_timestamps_ms))
 }
 
 async fn run_poll_loop(
@@ -159,6 +167,7 @@ async fn run_poll_loop(
     op: &kaniop_backup_core::operation::TransportOperation,
     watch_dir: &Path,
     mut known_backup_ids: HashSet<String>,
+    legacy_v7_timestamps_ms: HashSet<u64>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<(), i32> {
     let poll_interval = Duration::from_secs(op.poll_interval_secs);
@@ -194,7 +203,8 @@ async fn run_poll_loop(
             let backup_id = match derive_backup_id(
                 &candidate.path,
                 &op.file_prefix,
-                &candidate.mtime,
+                &op.namespace_uid,
+                &op.kanidm_uid,
             ) {
                 Some(id) => id,
                 None => {
@@ -205,6 +215,19 @@ async fn run_poll_loop(
 
             if known_backup_ids.contains(&backup_id) {
                 info!(backup_id = %backup_id, "backup already known, skipping");
+                continue;
+            }
+
+            if candidate_matches_legacy_v7(
+                &candidate.path,
+                &op.file_prefix,
+                &legacy_v7_timestamps_ms,
+            ) {
+                info!(
+                    backup_id = %backup_id,
+                    "backup matches legacy v7 manifest, skipping"
+                );
+                known_backup_ids.insert(backup_id.clone());
                 continue;
             }
 
@@ -359,7 +382,12 @@ async fn scan_for_candidates(
     candidates
 }
 
-fn derive_backup_id(path: &Path, file_prefix: &str, mtime: &SystemTime) -> Option<String> {
+fn derive_backup_id(
+    path: &Path,
+    file_prefix: &str,
+    namespace_uid: &str,
+    kanidm_uid: &str,
+) -> Option<String> {
     let file_name = path.file_name()?.to_str()?;
 
     let stem = file_name
@@ -368,25 +396,56 @@ fn derive_backup_id(path: &Path, file_prefix: &str, mtime: &SystemTime) -> Optio
         .map(|(ts, _)| ts)
         .unwrap_or(file_name);
 
-    if let Ok(dt) = DateTime::parse_from_rfc3339(stem) {
-        let timestamp = dt.timestamp_millis();
-        if timestamp > 0 {
-            let seconds = (timestamp / 1000) as u64;
-            let nanos = ((timestamp % 1000) * 1_000_000) as u32;
-            let uuid = Uuid::new_v7(uuid::timestamp::Timestamp::from_unix(
-                NoContext, seconds, nanos,
-            ));
-            return Some(uuid.to_string());
+    let mut name = String::with_capacity(namespace_uid.len() + kanidm_uid.len() + stem.len() + 2);
+    name.push_str(namespace_uid);
+    name.push(':');
+    name.push_str(kanidm_uid);
+    name.push(':');
+    name.push_str(stem);
+
+    let uuid = Uuid::new_v5(&Uuid::NAMESPACE_DNS, name.as_bytes());
+    Some(uuid.to_string())
+}
+
+fn extract_v7_timestamp_ms(uuid_str: &str) -> Option<u64> {
+    let uuid = Uuid::parse_str(uuid_str).ok()?;
+    if uuid.get_version_num() != 7 {
+        return None;
+    }
+    let bytes = uuid.as_bytes();
+    let ts_ms = ((bytes[0] as u64) << 40)
+        | ((bytes[1] as u64) << 32)
+        | ((bytes[2] as u64) << 24)
+        | ((bytes[3] as u64) << 16)
+        | ((bytes[4] as u64) << 8)
+        | (bytes[5] as u64);
+    Some(ts_ms)
+}
+
+fn extract_filename_timestamp_ms(path: &Path, file_prefix: &str) -> Option<u64> {
+    let file_name = path.file_name()?.to_str()?;
+    let after_prefix = file_name.strip_prefix(file_prefix)?;
+
+    let mut try_str = after_prefix;
+    loop {
+        if let Ok(dt) = DateTime::parse_from_rfc3339(try_str) {
+            return Some(dt.timestamp_millis() as u64);
+        }
+        match try_str.rsplit_once('.') {
+            Some((before, _)) if !before.is_empty() => try_str = before,
+            _ => break,
         }
     }
+    None
+}
 
-    let duration = mtime.duration_since(SystemTime::UNIX_EPOCH).ok()?;
-    let seconds = duration.as_secs();
-    let nanos = duration.subsec_nanos();
-    let uuid = Uuid::new_v7(uuid::timestamp::Timestamp::from_unix(
-        NoContext, seconds, nanos,
-    ));
-    Some(uuid.to_string())
+fn candidate_matches_legacy_v7(
+    path: &Path,
+    file_prefix: &str,
+    legacy_timestamps_ms: &HashSet<u64>,
+) -> bool {
+    extract_filename_timestamp_ms(path, file_prefix)
+        .is_some_and(|ts_ms| legacy_timestamps_ms.contains(&ts_ms))
 }
 
 enum UploadError {
@@ -520,8 +579,7 @@ mod tests {
     #[test]
     fn derive_backup_id_from_rfc3339_filename() {
         let path = Path::new("/data/backups/backup-2026-08-18T02:03:41.123456789+00:00.json.gz");
-        let mtime = SystemTime::now();
-        let id = derive_backup_id(path, "backup-", &mtime);
+        let id = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
         assert!(id.is_some());
         let uuid_str = id.unwrap();
         assert!(Uuid::parse_str(&uuid_str).is_ok());
@@ -530,45 +588,60 @@ mod tests {
     #[test]
     fn derive_backup_id_with_custom_prefix() {
         let path = Path::new("/data/backups/mybackup-2026-08-18T02:03:41+00:00.json.gz");
-        let mtime = SystemTime::now();
-        let id = derive_backup_id(path, "mybackup-", &mtime);
+        let id = derive_backup_id(path, "mybackup-", "ns-uid-1", "kanidm-uid-1");
         assert!(id.is_some());
         assert!(Uuid::parse_str(&id.unwrap()).is_ok());
     }
 
     #[test]
-    fn derive_backup_id_mismatched_prefix_falls_back_to_mtime() {
+    fn derive_backup_id_mismatched_prefix_still_deterministic() {
         let path = Path::new("/data/backups/other-2026-08-18T02:03:41+00:00.json.gz");
-        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1724000000);
-        let id = derive_backup_id(path, "backup-", &mtime);
-        assert!(id.is_some());
-        let uuid_str = id.unwrap();
-        assert!(Uuid::parse_str(&uuid_str).is_ok());
-    }
-
-    #[test]
-    fn derive_backup_id_fallback_to_mtime() {
-        let path = Path::new("/data/backups/backup-unknown-format.json.gz");
-        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1724000000);
-        let id = derive_backup_id(path, "backup-", &mtime);
-        assert!(id.is_some());
-        let uuid_str = id.unwrap();
-        assert!(Uuid::parse_str(&uuid_str).is_ok());
-    }
-
-    #[test]
-    fn derive_backup_id_same_timestamp_produces_valid_uuids() {
-        let path1 = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
-        let path2 = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
-        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1724000000);
-
-        let id1 = derive_backup_id(path1, "backup-", &mtime);
-        let id2 = derive_backup_id(path2, "backup-", &mtime);
-
+        let id1 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
+        let id2 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
         assert!(id1.is_some());
-        assert!(id2.is_some());
-        assert!(Uuid::parse_str(&id1.unwrap()).is_ok());
-        assert!(Uuid::parse_str(&id2.unwrap()).is_ok());
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn derive_backup_id_fallback_to_full_filename() {
+        let path = Path::new("/data/backups/backup-unknown-format.json.gz");
+        let id = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
+        assert!(id.is_some());
+        let uuid_str = id.unwrap();
+        assert!(Uuid::parse_str(&uuid_str).is_ok());
+    }
+
+    #[test]
+    fn derive_backup_id_is_deterministic_across_calls() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let id1 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
+        let id2 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1");
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn derive_backup_id_distinct_timestamps_produce_distinct_ids() {
+        let path1 = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let path2 = Path::new("/data/backups/backup-2026-08-18T03:00:00+00:00.json.gz");
+        let id1 = derive_backup_id(path1, "backup-", "ns-uid-1", "kanidm-uid-1").unwrap();
+        let id2 = derive_backup_id(path2, "backup-", "ns-uid-1", "kanidm-uid-1").unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn derive_backup_id_distinct_kanidm_uids_produce_distinct_ids() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let id1 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-A").unwrap();
+        let id2 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-B").unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn derive_backup_id_distinct_namespaces_produce_distinct_ids() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let id1 = derive_backup_id(path, "backup-", "ns-uid-X", "kanidm-uid-1").unwrap();
+        let id2 = derive_backup_id(path, "backup-", "ns-uid-Y", "kanidm-uid-1").unwrap();
+        assert_ne!(id1, id2);
     }
 
     #[tokio::test]
@@ -776,5 +849,224 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    fn make_v7_uuid(ts_ms: u64) -> Uuid {
+        let ts_bytes = ts_ms.to_be_bytes();
+        let mut bytes = [0u8; 16];
+        bytes[0] = ts_bytes[2];
+        bytes[1] = ts_bytes[3];
+        bytes[2] = ts_bytes[4];
+        bytes[3] = ts_bytes[5];
+        bytes[4] = ts_bytes[6];
+        bytes[5] = ts_bytes[7];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        Uuid::from_bytes(bytes)
+    }
+
+    #[test]
+    fn extract_v7_timestamp_ms_from_valid_v7_uuid() {
+        let ts_ms = 1_723_943_021_123u64;
+        let uuid = make_v7_uuid(ts_ms);
+        let extracted = extract_v7_timestamp_ms(&uuid.to_string());
+        assert_eq!(extracted, Some(ts_ms));
+    }
+
+    #[test]
+    fn extract_v7_timestamp_ms_returns_none_for_v5_uuid() {
+        let uuid = Uuid::new_v5(&Uuid::NAMESPACE_DNS, b"test");
+        assert_eq!(extract_v7_timestamp_ms(&uuid.to_string()), None);
+    }
+
+    #[test]
+    fn extract_v7_timestamp_ms_returns_none_for_invalid_string() {
+        assert_eq!(extract_v7_timestamp_ms("not-a-uuid"), None);
+        assert_eq!(extract_v7_timestamp_ms(""), None);
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_nanosecond_precision() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41.123456789+00:00.json.gz");
+        let ts = extract_filename_timestamp_ms(path, "backup-");
+        let expected = DateTime::parse_from_rfc3339("2026-08-18T02:03:41.123456789+00:00")
+            .unwrap()
+            .timestamp_millis() as u64;
+        assert_eq!(ts, Some(expected));
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_second_precision() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let ts = extract_filename_timestamp_ms(path, "backup-");
+        let expected = DateTime::parse_from_rfc3339("2026-08-18T02:03:41+00:00")
+            .unwrap()
+            .timestamp_millis() as u64;
+        assert_eq!(ts, Some(expected));
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_millisecond_precision() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41.123+00:00.json.gz");
+        let ts = extract_filename_timestamp_ms(path, "backup-");
+        let expected = DateTime::parse_from_rfc3339("2026-08-18T02:03:41.123+00:00")
+            .unwrap()
+            .timestamp_millis() as u64;
+        assert_eq!(ts, Some(expected));
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_z_timezone() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41Z.json.gz");
+        let ts = extract_filename_timestamp_ms(path, "backup-");
+        let expected = DateTime::parse_from_rfc3339("2026-08-18T02:03:41Z")
+            .unwrap()
+            .timestamp_millis() as u64;
+        assert_eq!(ts, Some(expected));
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_returns_none_for_non_timestamp() {
+        let path = Path::new("/data/backups/backup-unknown-format.json.gz");
+        assert_eq!(extract_filename_timestamp_ms(path, "backup-"), None);
+    }
+
+    #[test]
+    fn extract_filename_timestamp_ms_returns_none_for_wrong_prefix() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41Z.json.gz");
+        assert_eq!(extract_filename_timestamp_ms(path, "other-"), None);
+    }
+
+    #[test]
+    fn candidate_matches_legacy_v7_with_matching_timestamp() {
+        let ts_ms = 1_723_943_021_000u64;
+        let mut legacy_timestamps = HashSet::new();
+        legacy_timestamps.insert(ts_ms);
+
+        let dt = DateTime::from_timestamp_millis(ts_ms as i64).unwrap();
+        let filename = format!(
+            "backup-{}.json.gz",
+            dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        );
+        let full_path = format!("/data/backups/{filename}");
+        let path = Path::new(&full_path);
+
+        assert!(candidate_matches_legacy_v7(
+            path,
+            "backup-",
+            &legacy_timestamps
+        ));
+    }
+
+    #[test]
+    fn candidate_does_not_match_legacy_v7_with_different_timestamp() {
+        let mut legacy_timestamps = HashSet::new();
+        legacy_timestamps.insert(1_723_943_021_000u64);
+
+        let path = Path::new("/data/backups/backup-2026-08-18T03:00:00+00:00.json.gz");
+        assert!(!candidate_matches_legacy_v7(
+            path,
+            "backup-",
+            &legacy_timestamps
+        ));
+    }
+
+    #[test]
+    fn candidate_does_not_match_empty_legacy_set() {
+        let legacy_timestamps = HashSet::new();
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        assert!(!candidate_matches_legacy_v7(
+            path,
+            "backup-",
+            &legacy_timestamps
+        ));
+    }
+
+    #[test]
+    fn candidate_does_not_match_legacy_when_filename_has_no_timestamp() {
+        let mut legacy_timestamps = HashSet::new();
+        legacy_timestamps.insert(1_723_943_021_000u64);
+
+        let path = Path::new("/data/backups/backup-unknown-format.json.gz");
+        assert!(!candidate_matches_legacy_v7(
+            path,
+            "backup-",
+            &legacy_timestamps
+        ));
+    }
+
+    #[test]
+    fn v5_backup_id_is_version_5_and_deterministic() {
+        let path = Path::new("/data/backups/backup-2026-08-18T02:03:41+00:00.json.gz");
+        let id1 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1").unwrap();
+        let id2 = derive_backup_id(path, "backup-", "ns-uid-1", "kanidm-uid-1").unwrap();
+        assert_eq!(id1, id2);
+
+        let uuid = Uuid::parse_str(&id1).unwrap();
+        assert_eq!(uuid.get_version_num(), 5);
+    }
+
+    #[test]
+    fn legacy_v7_match_promotes_to_known_ids() {
+        let ts_ms = 1_723_943_021_000u64;
+        let v7_uuid = make_v7_uuid(ts_ms);
+
+        let mut known_ids = HashSet::new();
+        known_ids.insert(v7_uuid.to_string());
+
+        let mut legacy_timestamps = HashSet::new();
+        legacy_timestamps.insert(ts_ms);
+
+        let dt = DateTime::from_timestamp_millis(ts_ms as i64).unwrap();
+        let filename = format!(
+            "backup-{}.json.gz",
+            dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        );
+        let full_path = format!("/data/backups/{filename}");
+        let path = Path::new(&full_path);
+
+        let v5_id = derive_backup_id(path, "backup-", "ns-uid", "k-uid").unwrap();
+        assert!(!known_ids.contains(&v5_id));
+
+        assert!(candidate_matches_legacy_v7(
+            path,
+            "backup-",
+            &legacy_timestamps
+        ));
+
+        known_ids.insert(v5_id.clone());
+        assert!(known_ids.contains(&v5_id));
+    }
+
+    #[test]
+    fn nanosecond_and_millisecond_filenames_match_same_v7_timestamp() {
+        let ts_ms = 1_723_943_021_123u64;
+        let mut legacy_timestamps = HashSet::new();
+        legacy_timestamps.insert(ts_ms);
+
+        let dt = DateTime::from_timestamp_millis(ts_ms as i64).unwrap();
+        let rfc_nano = dt.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+        let rfc_milli = dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+        let nano_path_str = format!("/data/backups/backup-{rfc_nano}.json.gz");
+        let milli_path_str = format!("/data/backups/backup-{rfc_milli}.json.gz");
+        let path_nano = Path::new(&nano_path_str);
+        let path_milli = Path::new(&milli_path_str);
+
+        let ts_nano = extract_filename_timestamp_ms(path_nano, "backup-").unwrap();
+        let ts_milli = extract_filename_timestamp_ms(path_milli, "backup-").unwrap();
+        assert_eq!(ts_nano, ts_milli);
+        assert_eq!(ts_nano, ts_ms);
+
+        assert!(candidate_matches_legacy_v7(
+            path_nano,
+            "backup-",
+            &legacy_timestamps
+        ));
+        assert!(candidate_matches_legacy_v7(
+            path_milli,
+            "backup-",
+            &legacy_timestamps
+        ));
     }
 }

--- a/libs/backup-core/src/result.rs
+++ b/libs/backup-core/src/result.rs
@@ -46,6 +46,10 @@ pub struct ResultDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload_size_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consistency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ResultError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion: Option<DeletionResult>,
@@ -95,6 +99,8 @@ impl ResultDocument {
             payload_key: None,
             payload_sha256: None,
             payload_size_bytes: None,
+            created_at: None,
+            consistency: None,
             error: None,
             deletion: None,
             discovery: None,
@@ -113,6 +119,8 @@ impl ResultDocument {
             payload_key: None,
             payload_sha256: None,
             payload_size_bytes: None,
+            created_at: None,
+            consistency: None,
             error: Some(ResultError {
                 code: code.to_string(),
                 message: message.to_string(),
@@ -284,6 +292,8 @@ mod tests {
             payload_key: None,
             payload_sha256: None,
             payload_size_bytes: None,
+            created_at: None,
+            consistency: None,
             error: None,
             deletion: None,
             discovery: Some(DiscoverResult {
@@ -322,6 +332,8 @@ mod tests {
             payload_key: None,
             payload_sha256: None,
             payload_size_bytes: None,
+            created_at: None,
+            consistency: None,
             error: None,
             deletion: None,
             discovery: Some(DiscoverResult {
@@ -338,5 +350,53 @@ mod tests {
         );
         let parsed = parse_result_document(&json).unwrap();
         assert_eq!(parsed.discovery.unwrap().manifest_keys.len(), 1000);
+    }
+
+    #[test]
+    fn created_at_and_consistency_roundtrip() {
+        let mut result = ResultDocument::success("download");
+        result.backup_id = Some("019c7c76-f423-7a12-8f41-2bea7588a303".to_string());
+        result.manifest_key = Some("v1/tenants/ns/clusters/k/backups/b/manifest.json".to_string());
+        result.payload_key = Some("v1/tenants/ns/clusters/k/backups/b/payload/data".to_string());
+        result.payload_sha256 = Some("abc123".to_string());
+        result.payload_size_bytes = Some(1024);
+        result.created_at = Some("2026-08-18T02:03:41Z".to_string());
+        result.consistency = Some("kanidm-offline".to_string());
+        let json = result.to_json().unwrap();
+        let parsed = parse_result_document(&json).unwrap();
+        assert_eq!(parsed.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
+        assert_eq!(parsed.consistency.as_deref(), Some("kanidm-offline"));
+        assert_eq!(result, parsed);
+    }
+
+    #[test]
+    fn created_at_and_consistency_omitted_when_none() {
+        let result = ResultDocument::success("download");
+        let json = result.to_json().unwrap();
+        assert!(!json.contains("createdAt"));
+        assert!(!json.contains("consistency"));
+    }
+
+    #[test]
+    fn backward_compatible_parse_without_created_at_or_consistency() {
+        let json = r#"{
+            "apiVersion": "backup.kaniop.rs/v1alpha1",
+            "kind": "ResultDocument",
+            "operation": "download",
+            "success": true,
+            "exitCode": "success",
+            "backupId": "019c7c76-f423-7a12-8f41-2bea7588a303",
+            "manifestKey": "key",
+            "payloadKey": "pk",
+            "payloadSha256": "sha",
+            "payloadSizeBytes": 100
+        }"#;
+        let parsed = parse_result_document(json).unwrap();
+        assert!(parsed.created_at.is_none());
+        assert!(parsed.consistency.is_none());
+        assert_eq!(
+            parsed.backup_id.as_deref(),
+            Some("019c7c76-f423-7a12-8f41-2bea7588a303")
+        );
     }
 }

--- a/libs/backup/Cargo.toml
+++ b/libs/backup/Cargo.toml
@@ -36,5 +36,6 @@ cron = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 schemars.workspace = true
 serde_json = { workspace = true }

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -19,7 +19,7 @@ use kaniop_operator::controller::{ControllerId, State, check_api_queryable, erro
 use kaniop_operator::kanidm::crd::Kanidm;
 use kaniop_operator::kanidm::restore::RESTORE_ANNOTATION;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use futures::StreamExt;
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
@@ -34,6 +34,8 @@ use kube::client::Client;
 use kube::runtime::controller::{self, Controller};
 use kube::runtime::watcher::Config;
 use kube::{Api, ResourceExt};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Meter};
 use tokio::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -44,6 +46,51 @@ const BACKUP_FINALIZER: &str = "kanidmbackups.kaniop.rs/finalizer";
 const REQUEUE_NORMAL: Duration = Duration::from_secs(300);
 const REQUEUE_JOB_PENDING: Duration = Duration::from_secs(10);
 const REQUEUE_DELETION: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+pub struct BackupMetrics {
+    validation_failures: Counter<u64>,
+    deletions_deferred: Counter<u64>,
+}
+
+impl BackupMetrics {
+    pub fn new(meter: &Meter) -> Self {
+        let validation_failures = meter
+            .u64_counter("backup_validation_failures")
+            .with_description("Total number of backup manifest validation failures")
+            .build();
+
+        let deletions_deferred = meter
+            .u64_counter("backup_deletions_deferred")
+            .with_description(
+                "Total number of backup deletions deferred due to active restore references",
+            )
+            .build();
+
+        Self {
+            validation_failures,
+            deletions_deferred,
+        }
+    }
+
+    pub fn inc_validation_failure(&self, namespace: &str) {
+        self.validation_failures
+            .add(1, &[KeyValue::new("namespace", namespace.to_string())]);
+    }
+
+    pub fn inc_deletion_deferred(&self, namespace: &str) {
+        self.deletions_deferred
+            .add(1, &[KeyValue::new("namespace", namespace.to_string())]);
+    }
+}
+
+fn backup_metrics() -> &'static BackupMetrics {
+    static INSTANCE: OnceLock<BackupMetrics> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let meter = opentelemetry::global::meter("kaniop");
+        BackupMetrics::new(&meter)
+    })
+}
 
 pub async fn run(state: State, client: Client) {
     let backup = check_api_queryable::<KanidmBackup>(client.clone()).await;
@@ -429,6 +476,11 @@ fn is_kube_not_found(err: &kube::Error) -> bool {
     matches!(err, kube::Error::Api(ae) if ae.code == 404)
 }
 
+fn needs_metadata_backfill(status: &KanidmBackupStatus) -> bool {
+    status.phase == KanidmBackupPhase::Ready
+        && (status.created_at.is_none() || status.consistency.is_none())
+}
+
 async fn get_repository(
     ctx: &kaniop_operator::controller::context::Context<KanidmBackup>,
     namespace: &str,
@@ -541,6 +593,22 @@ async fn reconcile_apply(
             handle_discovering(&obj, &ctx, &namespace, &name, &mut status).await
         }
         KanidmBackupPhase::Ready => {
+            if needs_metadata_backfill(&status) {
+                info!(
+                    %namespace,
+                    %name,
+                    "Ready backup missing manifest metadata; triggering revalidation"
+                );
+                status.phase = KanidmBackupPhase::Discovering;
+                status.consistency = None;
+                status.created_at = None;
+                status.conditions.retain(|c| c.type_ != "Ready");
+                patch_backup_status(&ctx, &namespace, &name, &status).await?;
+                return Ok((
+                    kube::runtime::controller::Action::requeue(Duration::from_secs(1)),
+                    false,
+                ));
+            }
             patch_backup_status(&ctx, &namespace, &name, &status).await?;
             Ok((
                 kube::runtime::controller::Action::requeue(REQUEUE_NORMAL),
@@ -665,6 +733,8 @@ async fn handle_discovering(
                         .to_string(),
                 };
 
+            backup_metrics().inc_validation_failure(namespace);
+
             let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
             job_api
                 .delete(&job.name_any(), &background_delete_params())
@@ -698,11 +768,11 @@ async fn handle_discovering(
                         && result.manifest_key.is_some() =>
                 {
                     status.phase = KanidmBackupPhase::Ready;
-                    status.consistency = Some("kanidm-offline".to_string());
+                    status.consistency = result.consistency;
                     status.reason = Some("validated".to_string());
                     status.size_bytes = result.payload_size_bytes;
                     status.payload_sha256 = result.payload_sha256;
-                    status.created_at = None;
+                    status.created_at = result.created_at;
 
                     let ready_condition = Condition {
                         type_: "Ready".to_string(),
@@ -837,6 +907,7 @@ async fn handle_deletion(
             namespace,
             name, "backup deletion deferred: referenced by active restore"
         );
+        backup_metrics().inc_deletion_deferred(namespace);
         status.phase = KanidmBackupPhase::Ready;
         let deferred_condition = Condition {
             type_: "DeletionDeferred".to_string(),
@@ -1059,6 +1130,7 @@ async fn patch_backup_status(
 mod tests {
     use super::*;
     use crate::crd::{KanidmBackupPhase, KanidmBackupSpec, KanidmBackupStatus};
+    use chrono::Datelike;
 
     fn make_backup(backup_id: &str, manifest_key: &str) -> KanidmBackup {
         KanidmBackup {
@@ -1716,5 +1788,135 @@ mod tests {
             .unwrap();
         assert_eq!(ready_cond.status, "False");
         assert_eq!(ready_cond.reason, "RepositoryGone");
+    }
+
+    #[test]
+    fn backup_metrics_new_creates_counters() {
+        use opentelemetry::metrics::MeterProvider;
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+        let meter = provider.meter("test");
+        let metrics = BackupMetrics::new(&meter);
+        metrics.inc_validation_failure("default");
+        metrics.inc_deletion_deferred("default");
+    }
+
+    #[test]
+    fn needs_metadata_backfill_ready_without_created_at() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            consistency: Some("kanidm-offline".to_string()),
+            created_at: None,
+            ..Default::default()
+        };
+        assert!(needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn needs_metadata_backfill_ready_without_consistency() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            created_at: Some("2026-08-18T02:03:41Z".to_string()),
+            consistency: None,
+            ..Default::default()
+        };
+        assert!(needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn needs_metadata_backfill_ready_with_both() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            created_at: Some("2026-08-18T02:03:41Z".to_string()),
+            consistency: Some("kanidm-offline".to_string()),
+            ..Default::default()
+        };
+        assert!(!needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn needs_metadata_backfill_not_ready_phase() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Discovering,
+            created_at: None,
+            consistency: None,
+            ..Default::default()
+        };
+        assert!(!needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn result_document_propagates_created_at_to_status() {
+        let mut result = kaniop_backup_core::result::ResultDocument::success("download");
+        result.backup_id = Some("019c7c76-f423-7a12-8f41-2bea7588a303".to_string());
+        result.manifest_key = Some("key/manifest.json".to_string());
+        result.created_at = Some("2026-08-18T02:03:41Z".to_string());
+        result.consistency = Some("kanidm-offline".to_string());
+        result.payload_size_bytes = Some(1024);
+        result.payload_sha256 = Some("abc".to_string());
+
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            consistency: result.consistency.clone(),
+            reason: Some("validated".to_string()),
+            size_bytes: result.payload_size_bytes,
+            payload_sha256: result.payload_sha256,
+            created_at: result.created_at.clone(),
+            ..Default::default()
+        };
+
+        assert_eq!(status.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
+        assert_eq!(status.consistency.as_deref(), Some("kanidm-offline"));
+        assert_eq!(status.phase, KanidmBackupPhase::Ready);
+    }
+
+    #[test]
+    fn retention_sees_created_at_from_status() {
+        use kaniop_backup_core::retention::{BackupEntry, parse_timestamp};
+
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            created_at: Some("2026-08-18T02:03:41Z".to_string()),
+            consistency: Some("kanidm-offline".to_string()),
+            reason: Some("scheduled".to_string()),
+            ..Default::default()
+        };
+
+        let created_str = status.created_at.as_deref().unwrap();
+        let created_at = parse_timestamp(created_str).unwrap();
+        let entry = BackupEntry {
+            id: "kb-test".to_string(),
+            created_at,
+            consistency: status.consistency.clone().unwrap_or_default(),
+            reason: status.reason.clone().unwrap_or_default(),
+            referenced_by_active_restore: false,
+            safety_backup_min_retention_hours: None,
+        };
+
+        assert_eq!(entry.id, "kb-test");
+        assert_eq!(entry.created_at.year(), 2026);
+        assert_eq!(entry.created_at.month(), 8);
+        assert_eq!(entry.consistency, "kanidm-offline");
+    }
+
+    #[test]
+    fn backfill_resets_to_discovering() {
+        let mut status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            consistency: Some("kanidm-offline".to_string()),
+            created_at: None,
+            ..Default::default()
+        };
+
+        assert!(needs_metadata_backfill(&status));
+
+        status.phase = KanidmBackupPhase::Discovering;
+        status.consistency = None;
+        status.created_at = None;
+        status.conditions.retain(|c| c.type_ != "Ready");
+
+        assert_eq!(status.phase, KanidmBackupPhase::Discovering);
+        assert!(status.consistency.is_none());
+        assert!(status.created_at.is_none());
+        assert!(!needs_metadata_backfill(&status));
     }
 }

--- a/libs/backup/src/controller/discovery.rs
+++ b/libs/backup/src/controller/discovery.rs
@@ -62,6 +62,7 @@ pub struct DiscoveryMetrics {
     last_scan_timestamp: Gauge<i64>,
     last_scan_success_timestamp: Gauge<i64>,
     repositories_scanned: Gauge<i64>,
+    truncations: Counter<u64>,
 }
 
 impl DiscoveryMetrics {
@@ -107,6 +108,11 @@ impl DiscoveryMetrics {
             .with_description("Number of repositories scanned in the last discovery loop")
             .build();
 
+        let truncations = meter
+            .u64_counter("backup_discovery_truncations")
+            .with_description("Total number of discovery scans that returned truncated results")
+            .build();
+
         Self {
             scan_duration,
             scan_failures,
@@ -116,6 +122,7 @@ impl DiscoveryMetrics {
             last_scan_timestamp,
             last_scan_success_timestamp,
             repositories_scanned,
+            truncations,
         }
     }
 
@@ -156,6 +163,11 @@ impl DiscoveryMetrics {
 
     fn set_repositories_scanned(&self, count: i64) {
         self.repositories_scanned.record(count, &[]);
+    }
+
+    fn inc_truncations(&self, repository: &str) {
+        self.truncations
+            .add(1, &[KeyValue::new("repository", repository.to_string())]);
     }
 }
 
@@ -491,6 +503,33 @@ async fn process_discovery_for_schedule(
                             schedule = schedule_name,
                             "discover results were truncated; some backups may not be represented"
                         );
+                        metrics.inc_truncations(&repo_name);
+                        update_discovery_status(
+                            client,
+                            namespace,
+                            schedule,
+                            "DiscoveryTruncated",
+                            "True",
+                            "ResultLimitReached",
+                            &format!(
+                                "Discovery found {} manifests but results were truncated; some backups may not be represented",
+                                discovery.total_found
+                            ),
+                            None,
+                        )
+                        .await?;
+                    } else {
+                        update_discovery_status(
+                            client,
+                            namespace,
+                            schedule,
+                            "DiscoveryTruncated",
+                            "False",
+                            "ResultComplete",
+                            "Discovery completed without truncation",
+                            None,
+                        )
+                        .await?;
                     }
 
                     debug!(
@@ -1877,5 +1916,22 @@ mod tests {
         assert_eq!(c.jobs_created, 0);
         assert_eq!(c.jobs_completed, 0);
         assert_eq!(c.backups_discovered, 0);
+    }
+
+    #[test]
+    fn discovery_metrics_new_creates_all_counters() {
+        use opentelemetry::metrics::MeterProvider;
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+        let meter = provider.meter("test");
+        let metrics = DiscoveryMetrics::new(&meter);
+        metrics.inc_truncations("test-repo");
+        metrics.inc_discover_jobs("test-repo");
+        metrics.inc_backups_discovered("test-repo", 5);
+        metrics.inc_backups_reconciled("test-repo", 3);
+        metrics.record_scan_duration(1.5);
+        metrics.inc_scan_failures();
+        metrics.set_last_scan(1700000000);
+        metrics.set_last_scan_success(1700000000);
+        metrics.set_repositories_scanned(2);
     }
 }

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -50,13 +50,11 @@ pub const CONTROLLER_ID: &str = "kanidm-restore";
 pub const RESTORE_ANNOTATION: &str = "kanidm.kaniop.rs/restore-in-progress";
 const RESTORE_FINALIZER: &str = "kanidmrestores.kaniop.rs/finalizer";
 const DATA_VOLUME: &str = "kanidm-data";
-const STAGING_VOLUME: &str = "restore-staging";
 const SHARED_VOLUME: &str = "safety-backup-shared";
 const DATA_PATH: &str = "/data";
 const TLS_VOLUME: &str = "kanidm-certs";
 const TLS_PATH: &str = "/etc/kanidm/tls";
 const BACKUP_PATH: &str = "/data";
-const STAGING_PATH: &str = "/staging";
 const SHARED_VOL_PATH: &str = "/shared";
 const REQUEUE: Duration = Duration::from_secs(2);
 const CONDITION_TRUE: &str = "True";
@@ -1362,7 +1360,7 @@ async fn ensure_database_job(
         command.push("/verify/verification.json.gz".to_string());
     } else {
         if is_remote_source(restore) {
-            command.push(format!("{STAGING_PATH}/source-payload.json.gz"));
+            command.push(format!("{DATA_PATH}/source-payload.json.gz"));
         } else {
             let file_name = restore
                 .spec
@@ -2500,8 +2498,8 @@ echo "source preparation download completed successfully"
                         volume_mounts: {
                             let mut mounts = vec![
                                 VolumeMount {
-                                    name: STAGING_VOLUME.to_string(),
-                                    mount_path: STAGING_PATH.to_string(),
+                                    name: DATA_VOLUME.to_string(),
+                                    mount_path: DATA_PATH.to_string(),
                                     ..Default::default()
                                 },
                                 VolumeMount {
@@ -2527,10 +2525,10 @@ echo "source preparation download completed successfully"
                     volumes: {
                         let mut vols = vec![
                             Volume {
-                                name: STAGING_VOLUME.to_string(),
-                                empty_dir: Some(k8s_openapi::api::core::v1::EmptyDirVolumeSource {
-                                    size_limit: Some(crate::controller::backup_job_volume_size()),
-                                    ..Default::default()
+                                name: DATA_VOLUME.to_string(),
+                                persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                                    claim_name: primary_pvc_name(target)?,
+                                    read_only: Some(false),
                                 }),
                                 ..Default::default()
                             },
@@ -2767,7 +2765,7 @@ fn build_download_operation_doc(
         "expectedBackupId": expected_backup_id,
         "expectedKanidmUid": restore.spec.target_ref.uid,
         "expectedDomain": target.spec.domain,
-        "outputPath": format!("{STAGING_PATH}/source-payload.json.gz"),
+        "outputPath": format!("{DATA_PATH}/source-payload.json.gz"),
         "resultPath": "/run/kaniop-result/result.json",
         "maxRetries": 3,
         "encryptionMode": enc_mode,
@@ -3480,8 +3478,8 @@ mod tests {
 
     #[test]
     fn shared_volume_constants_are_distinct() {
-        assert_ne!(super::SHARED_VOLUME, super::STAGING_VOLUME);
-        assert_ne!(super::SHARED_VOL_PATH, super::STAGING_PATH);
+        assert_ne!(super::SHARED_VOLUME, super::DATA_VOLUME);
+        assert_ne!(super::SHARED_VOL_PATH, super::DATA_PATH);
     }
 
     #[test]

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -494,7 +494,27 @@ async fn reconcile_apply(restore: Arc<KanidmRestore>, ctx: Arc<RestoreContext>) 
                             read_source_prep_result(&restore, &ctx, &name, expected_backup_id)
                                 .await;
                         match result {
-                            Ok(_verified) => {
+                            Ok(verified) => {
+                                if let Some(expected_sha256) = backup
+                                    .status
+                                    .as_ref()
+                                    .and_then(|s| s.payload_sha256.as_deref())
+                                {
+                                    if verified.payload_sha256 != expected_sha256 {
+                                        resume_before_mutation(&restore, &ctx).await?;
+                                        set_phase(
+                                            &restore,
+                                            &ctx,
+                                            KanidmRestorePhase::Failed,
+                                            Some(format!(
+                                                "payload SHA256 mismatch: backup CR has '{expected_sha256}', downloaded payload has '{}'",
+                                                verified.payload_sha256
+                                            )),
+                                        )
+                                        .await?;
+                                        return Ok(Action::requeue(REQUEUE));
+                                    }
+                                }
                                 let mut status = restore.status.clone().unwrap_or_default();
                                 status.source_prep_job_name = Some(name);
                                 status.phase = KanidmRestorePhase::RestoringPrimary;
@@ -1912,7 +1932,6 @@ async fn read_safety_backup_result(
 struct VerifiedSourcePrepResult {
     #[allow(dead_code)]
     manifest_key: String,
-    #[allow(dead_code)]
     payload_sha256: String,
 }
 

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -2096,6 +2096,24 @@ e2e_test!(
             "e2e-ret-keep2/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{expired_backup_id}/"
         );
 
+        let mut schedule_obj = schedule_api.get(&schedule_name).await.unwrap();
+        schedule_obj.metadata.managed_fields = None;
+        let mut annotations = schedule_obj
+            .metadata
+            .annotations
+            .clone()
+            .unwrap_or_default();
+        annotations.insert("kaniop.rs/trigger-retention".to_string(), "now".to_string());
+        schedule_obj.metadata.annotations = Some(annotations);
+        schedule_api
+            .replace(
+                &schedule_name,
+                &kube::api::PostParams::default(),
+                &schedule_obj,
+            )
+            .await
+            .unwrap();
+
         poll_until("schedule retention deletes expired backup CR", || {
             let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
             let expired_cr_name = expired_cr_name.clone();

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -1,16 +1,19 @@
 use serial_test::serial;
 
 use super::{
-    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, STORAGE_VOLUME_CLAIM_TEMPLATE_JSON,
-    is_kanidm, setup,
+    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, MINIO_BUCKET, MINIO_CA_CM,
+    MINIO_CREDS_INVALID_SECRET, MINIO_CREDS_SECRET, MINIO_ENDPOINT, MINIO_REGION,
+    STORAGE_VOLUME_CLAIM_TEMPLATE_JSON, cleanup_test_resources, create_backup_cr_and_wait,
+    create_kek_secret, create_repository, create_repository_with_encryption, data_mover_image,
+    force_delete_and_wait, is_kanidm, is_repo_ready, setup, trigger_backup_on_primary,
+    upload_backup_to_s3, upload_backup_to_s3_with_encryption_key,
 };
 use crate::test::{init_crypto_provider, poll_until, wait_for as test_wait_for};
 
 use kaniop_backup_core::crd::{
-    AuthMethod, BackupKanidmRef, BackupRepositoryRef, EncryptionMode, KanidmBackup,
-    KanidmBackupPhase, KanidmBackupRepository, KanidmBackupRepositorySpec, KanidmBackupSchedule,
-    KanidmBackupScheduleSpec, KanidmBackupSpec, RepositoryAuthentication, RepositoryEncryption,
-    S3Config, ScheduleKanidmRef, ScheduleRepositoryRef, SecretRef,
+    BackupKanidmRef, BackupRepositoryRef, EncryptionMode, KanidmBackup, KanidmBackupPhase,
+    KanidmBackupRepository, KanidmBackupSchedule, KanidmBackupScheduleSpec, KanidmBackupSpec,
+    RepositoryEncryption, RetentionPolicySpec, ScheduleKanidmRef, ScheduleRepositoryRef, SecretRef,
 };
 use kaniop_operator::kanidm::crd::Kanidm;
 use kaniop_operator::kanidm::restore::{
@@ -29,144 +32,6 @@ use kube::api::{Api, LogParams, PostParams};
 use kube::client::Client;
 use serde_json::json;
 use std::time::Duration;
-
-const MINIO_ENDPOINT: &str = "https://minio.default.svc:9000";
-const MINIO_BUCKET: &str = "kaniop-backups";
-const MINIO_REGION: &str = "us-east-1";
-const MINIO_CA_CM: &str = "minio-ca";
-const MINIO_CREDS_SECRET: &str = "minio-creds";
-const MINIO_CREDS_INVALID_SECRET: &str = "minio-creds-invalid";
-
-fn minio_s3_config(prefix: &str) -> S3Config {
-    S3Config {
-        bucket: MINIO_BUCKET.to_string(),
-        prefix: prefix.to_string(),
-        region: MINIO_REGION.to_string(),
-        endpoint: MINIO_ENDPOINT.to_string(),
-        force_path_style: true,
-        insecure: false,
-        ca_bundle_ref: Some(MINIO_CA_CM.to_string()),
-    }
-}
-
-fn minio_auth(secret_name: &str) -> RepositoryAuthentication {
-    let method = AuthMethod {
-        workload_identity: None,
-        secret_ref: Some(SecretRef {
-            name: secret_name.to_string(),
-        }),
-    };
-    RepositoryAuthentication {
-        writer: method.clone(),
-        reader: method.clone(),
-        deleter: method,
-    }
-}
-
-async fn force_delete_and_wait<K>(api: Api<K>, name: &str)
-where
-    K: kube::Resource
-        + Clone
-        + std::fmt::Debug
-        + for<'de> k8s_openapi::serde::Deserialize<'de>
-        + 'static
-        + Send,
-{
-    api.delete(name, &Default::default()).await.ok();
-    api.patch(
-        name,
-        &kube::api::PatchParams::default(),
-        &kube::api::Patch::Merge(json!({"metadata": {"finalizers": null}})),
-    )
-    .await
-    .ok();
-    poll_until(&format!("{name} deleted"), || {
-        let api = api.clone();
-        let name = name.to_string();
-        async move {
-            if api.get(&name).await.is_err() {
-                Some(())
-            } else {
-                None
-            }
-        }
-    })
-    .await;
-}
-
-async fn cleanup_test_resources(client: &Client, test_name: &str, repo_name: &str) {
-    let ns = "default";
-
-    let restore_api = Api::<KanidmRestore>::namespaced(client.clone(), ns);
-    force_delete_and_wait(restore_api, &format!("{test_name}-restore")).await;
-
-    let backup_api = Api::<KanidmBackup>::namespaced(client.clone(), ns);
-    if let Ok(list) = backup_api.list(&Default::default()).await {
-        for backup in list.items {
-            if backup.spec.kanidm_ref.name == test_name {
-                force_delete_and_wait(backup_api.clone(), &backup.name_any()).await;
-            }
-        }
-    }
-
-    let schedule_api = Api::<KanidmBackupSchedule>::namespaced(client.clone(), ns);
-    if let Ok(list) = schedule_api.list(&Default::default()).await {
-        for schedule in list.items {
-            if schedule.spec.kanidm_ref.name == test_name {
-                force_delete_and_wait(schedule_api.clone(), &schedule.name_any()).await;
-            }
-        }
-    }
-
-    let repo_api = Api::<KanidmBackupRepository>::namespaced(client.clone(), ns);
-    force_delete_and_wait(repo_api, repo_name).await;
-
-    let job_api = Api::<Job>::namespaced(client.clone(), ns);
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-upload")).await;
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-restore")).await;
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-verify")).await;
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-safety-backup")).await;
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-source-prep")).await;
-    force_delete_and_wait(job_api.clone(), &format!("{test_name}-discover-check")).await;
-    if let Ok(list) = job_api.list(&Default::default()).await {
-        for job in list.items {
-            let job_name = job.name_any();
-            if job_name.starts_with(&format!("{test_name}-upload-")) {
-                force_delete_and_wait(job_api.clone(), &job_name).await;
-            }
-        }
-    }
-
-    let cm_api = Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(client.clone(), ns);
-    force_delete_and_wait(cm_api.clone(), &format!("{test_name}-upload-op")).await;
-    force_delete_and_wait(cm_api.clone(), &format!("{test_name}-discover-check")).await;
-    if let Ok(list) = cm_api.list(&Default::default()).await {
-        for cm in list.items {
-            let cm_name = cm.name_any();
-            if cm_name.starts_with(&format!("{test_name}-upload-")) && cm_name.ends_with("-op") {
-                force_delete_and_wait(cm_api.clone(), &cm_name).await;
-            }
-        }
-    }
-
-    let kanidm_api = Api::<Kanidm>::namespaced(client.clone(), ns);
-    force_delete_and_wait(kanidm_api, test_name).await;
-
-    let secret_api = Api::<k8s_openapi::api::core::v1::Secret>::namespaced(client.clone(), ns);
-    force_delete_and_wait(secret_api, &format!("{test_name}-tls")).await;
-}
-
-fn is_repo_ready() -> impl kube::runtime::wait::Condition<KanidmBackupRepository> {
-    move |obj: Option<&KanidmBackupRepository>| {
-        obj.and_then(|repo| repo.status.as_ref())
-            .is_some_and(|status| {
-                status
-                    .conditions
-                    .iter()
-                    .any(|c| c.type_ == "Ready" && c.status == "True" && c.reason == "Accepted")
-            })
-    }
-}
 
 fn is_backup_phase(phase: KanidmBackupPhase) -> impl kube::runtime::wait::Condition<KanidmBackup> {
     move |obj: Option<&KanidmBackup>| {
@@ -232,92 +97,6 @@ async fn wait_for_operator_and_webhook_ready(client: &Client) {
     let deploy_api = Api::<Deployment>::namespaced(client.clone(), "kaniop");
     test_wait_for(deploy_api.clone(), "kaniop", is_deployment_ready()).await;
     test_wait_for(deploy_api, "kaniop-webhook", is_deployment_ready()).await;
-}
-
-async fn create_repository(client: &Client, name: &str, prefix: &str, secret: &str) {
-    let api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
-    force_delete_and_wait(api.clone(), name).await;
-    let repo = KanidmBackupRepository::new(
-        name,
-        KanidmBackupRepositorySpec {
-            s3: minio_s3_config(prefix),
-            authentication: minio_auth(secret),
-            encryption: None,
-            limits: None,
-        },
-    );
-    api.create(&PostParams::default(), &repo).await.unwrap();
-}
-
-async fn create_repository_with_encryption(
-    client: &Client,
-    name: &str,
-    prefix: &str,
-    secret: &str,
-    encryption: Option<RepositoryEncryption>,
-) {
-    let api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
-    force_delete_and_wait(api.clone(), name).await;
-    let repo = KanidmBackupRepository::new(
-        name,
-        KanidmBackupRepositorySpec {
-            s3: minio_s3_config(prefix),
-            authentication: minio_auth(secret),
-            encryption,
-            limits: None,
-        },
-    );
-    api.create(&PostParams::default(), &repo).await.unwrap();
-}
-
-async fn create_kek_secret(client: &Client, name: &str, key_value: &[u8]) {
-    let secret_api =
-        Api::<k8s_openapi::api::core::v1::Secret>::namespaced(client.clone(), "default");
-    force_delete_and_wait(secret_api.clone(), name).await;
-    let secret = k8s_openapi::api::core::v1::Secret {
-        metadata: kube::api::ObjectMeta {
-            name: Some(name.to_string()),
-            namespace: Some("default".to_string()),
-            ..Default::default()
-        },
-        string_data: Some(std::collections::BTreeMap::from([(
-            "encryption-key".to_string(),
-            String::from_utf8(key_value.to_vec()).unwrap(),
-        )])),
-        ..Default::default()
-    };
-    secret_api
-        .create(&PostParams::default(), &secret)
-        .await
-        .unwrap();
-}
-
-async fn trigger_backup_on_primary(name: &str, client: &Client) -> String {
-    let pod_api = Api::<Pod>::namespaced(client.clone(), "default");
-    let primary_pod = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}-0");
-
-    let backup_name = format!("backup-{}.json.gz", uuid::Uuid::new_v4());
-    let backup_path = format!("/data/{backup_name}");
-
-    let exec_result = pod_api
-        .exec(
-            &primary_pod,
-            vec![
-                "kanidmd".to_string(),
-                "database".to_string(),
-                "backup".to_string(),
-                backup_path.clone(),
-            ],
-            &kube::api::AttachParams::default().container("kanidm"),
-        )
-        .await
-        .unwrap();
-
-    kaniop_k8s_util::client::get_output(exec_result)
-        .await
-        .expect("backup command should succeed");
-
-    backup_name
 }
 
 e2e_test!(
@@ -553,7 +332,7 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let restore_name = format!("{name}-restore");
         let restore = KanidmRestore::new(
@@ -652,7 +431,7 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let restore_name = format!("{name}-restore");
         let restore = KanidmRestore::new(
@@ -728,7 +507,7 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let restore_name = format!("{name}-restore");
         let mut restore = KanidmRestore::new(
@@ -830,7 +609,7 @@ e2e_test!(
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
         let statefulset_api =
@@ -863,173 +642,30 @@ e2e_test!(
         .await;
 
         let backup_id = uuid::Uuid::new_v4().to_string();
-        let namespace_uid = "default";
-        let manifest_key = format!(
-            "e2e-remote-rt/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
-        );
-
-        let operation_doc = serde_json::json!({
-            "apiVersion": "backup.kaniop.rs/v1alpha1",
-            "kind": "OperationDocument",
-            "operation": "upload",
-            "payloadPath": format!("/data/{backup_name}"),
-            "bucket": MINIO_BUCKET,
-            "prefix": "e2e-remote-rt",
-            "endpoint": MINIO_ENDPOINT,
-            "region": MINIO_REGION,
-            "forcePathStyle": true,
-            "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
-            "backupId": backup_id,
-            "namespaceUid": namespace_uid,
-            "kanidmUid": kanidm_uid,
-            "kanidmName": name,
-            "domain": domain,
-            "kanidmVersion": "e2e",
-            "consistency": "kanidm-offline",
-            "reason": "e2e-test",
-            "resultPath": "/run/kaniop-result/result.json",
-            "maxConcurrentParts": 4,
-            "maxRetries": 3,
-        });
-
-        let data_mover_image = std::env::var("DATA_MOVER_IMAGE").unwrap_or_else(|_| {
-            format!(
-                "ghcr.io/pando85/kaniop-data-mover:{}",
-                option_env!("GIT_SHA").unwrap_or("aed6d7e")
-            )
-        });
-
-        let op_cm_name = format!("{name}-upload-op");
-        let cm_api =
-            Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(s.client.clone(), "default");
-        let op_cm = k8s_openapi::api::core::v1::ConfigMap {
-            metadata: kube::api::ObjectMeta {
-                name: Some(op_cm_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            data: Some(
-                [(
-                    "operation.json".to_string(),
-                    serde_json::to_string(&operation_doc).unwrap(),
-                )]
-                .into_iter()
-                .collect(),
+        let manifest_key = upload_backup_to_s3(
+            &s.client,
+            super::UploadOptions::new(
+                name,
+                "e2e-remote-rt",
+                &backup_name,
+                &backup_id,
+                &kanidm_uid,
+                &domain,
             ),
-            ..Default::default()
-        };
-        cm_api.create(&PostParams::default(), &op_cm).await.unwrap();
-
-        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
-        let upload_job_name = format!("{name}-upload");
-        let upload_job: Job = serde_json::from_value(json!({
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "metadata": {
-                "name": upload_job_name,
-                "namespace": "default"
-            },
-            "spec": {
-                "backoffLimit": 1,
-                "template": {
-                    "spec": {
-                        "restartPolicy": "Never",
-                        "containers": [{
-                            "name": "data-mover",
-                            "image": data_mover_image,
-                            "command": ["/bin/kaniop-data-mover", "upload"],
-                            "env": [
-                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
-                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
-                                {"name": "RUST_LOG", "value": "info"},
-                                {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
-                            ],
-                            "volumeMounts": [
-                                {"name": "data", "mountPath": "/data"},
-                                {"name": "operation", "mountPath": "/run/kaniop"},
-                                {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
-                                {"name": "result", "mountPath": "/run/kaniop-result"}
-                            ]
-                        }],
-                        "volumes": [
-                            {"name": "data", "persistentVolumeClaim": {"claimName": format!("kanidm-data-{sts_name}-0")}},
-                            {"name": "operation", "configMap": {"name": op_cm_name}},
-                            {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
-                            {"name": "result", "emptyDir": {}}
-                        ]
-                    }
-                }
-            }
-        }))
-        .unwrap();
-
-        job_api
-            .create(&PostParams::default(), &upload_job)
-            .await
-            .unwrap();
-
-        poll_until("upload job completes", || {
-            let job_api = job_api.clone();
-            let job_name = upload_job_name.clone();
-            async move {
-                let job = job_api.get(&job_name).await.ok()?;
-                if job
-                    .status
-                    .as_ref()
-                    .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
-                {
-                    Some(())
-                } else {
-                    None
-                }
-            }
-        })
-        .await;
-
-        let backup_cr_name = format!("kb-{}", &backup_id[..8]);
-        let backup_cr = KanidmBackup {
-            metadata: kube::api::ObjectMeta {
-                name: Some(backup_cr_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            spec: kaniop_backup_core::crd::KanidmBackupSpec {
-                backup_id: backup_id.clone(),
-                kanidm_ref: BackupKanidmRef {
-                    name: name.to_string(),
-                    uid: kanidm_uid.to_string(),
-                },
-                repository_ref: BackupRepositoryRef {
-                    name: repo_name.clone(),
-                },
-                manifest_key: manifest_key.clone(),
-            },
-            status: None,
-        };
-        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
-        backup_api
-            .create(&PostParams::default(), &backup_cr)
-            .await
-            .unwrap();
-
-        test_wait_for(
-            backup_api.clone(),
-            &backup_cr_name,
-            is_backup_phase(KanidmBackupPhase::Ready),
         )
         .await;
 
-        let mut sts = statefulset_api.get(&sts_name).await.unwrap();
-        sts.spec.as_mut().unwrap().replicas = Some(1);
-        sts.metadata.managed_fields = None;
-        statefulset_api
-            .patch(
-                &sts_name,
-                &kube::api::PatchParams::apply("e2e-test").force(),
-                &kube::api::Patch::Apply(&sts),
-            )
-            .await
-            .unwrap();
+        let backup_cr_name = create_backup_cr_and_wait(
+            &s.client,
+            &backup_id,
+            name,
+            &kanidm_uid,
+            &repo_name,
+            &manifest_key,
+        )
+        .await;
+
+        super::scale_statefulset_and_wait(&s.client, &sts_name, 1).await;
 
         test_wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
 
@@ -1103,7 +739,7 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let restore_name = format!("{name}-restore");
         let mut restore = KanidmRestore::new(
@@ -1226,7 +862,7 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let restore_name = format!("{name}-restore");
         let restore = KanidmRestore::new(
@@ -1489,167 +1125,29 @@ e2e_test!(
 
         let mut backup_ids = Vec::new();
         for _ in 0..3 {
-            let backup_name = trigger_backup_on_primary(name, &s.client).await;
+            let backup_name = trigger_backup_on_primary(&s.client, name).await;
             let backup_id = uuid::Uuid::new_v4().to_string();
-            let manifest_key = format!(
-                "e2e-retention/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
-            );
-
-            let operation_doc = serde_json::json!({
-                "apiVersion": "backup.kaniop.rs/v1alpha1",
-                "kind": "OperationDocument",
-                "operation": "upload",
-                "payloadPath": format!("/data/{backup_name}"),
-                "bucket": MINIO_BUCKET,
-                "prefix": "e2e-retention",
-                "endpoint": MINIO_ENDPOINT,
-                "region": MINIO_REGION,
-                "forcePathStyle": true,
-                "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
-                "backupId": backup_id,
-                "namespaceUid": namespace_uid,
-                "kanidmUid": kanidm_uid,
-                "kanidmName": name,
-                "domain": kanidm.spec.domain.clone(),
-                "kanidmVersion": "e2e",
-                "consistency": "kanidm-offline",
-                "reason": "e2e-test",
-                "resultPath": "/run/kaniop-result/result.json",
-                "maxConcurrentParts": 4,
-                "maxRetries": 3,
-            });
-
-            let data_mover_image = std::env::var("DATA_MOVER_IMAGE").unwrap_or_else(|_| {
-                format!(
-                    "ghcr.io/pando85/kaniop-data-mover:{}",
-                    option_env!("GIT_SHA").unwrap_or("aed6d7e")
-                )
-            });
-
-            let backup_id_short = &backup_id[..8];
-            let op_cm_name = format!("{name}-upload-{backup_id_short}-op");
-            let cm_api = Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(
-                s.client.clone(),
-                "default",
-            );
-            let op_cm = k8s_openapi::api::core::v1::ConfigMap {
-                metadata: kube::api::ObjectMeta {
-                    name: Some(op_cm_name.clone()),
-                    namespace: Some("default".to_string()),
-                    ..Default::default()
-                },
-                data: Some(
-                    [(
-                        "operation.json".to_string(),
-                        serde_json::to_string(&operation_doc).unwrap(),
-                    )]
-                    .into_iter()
-                    .collect(),
+            let manifest_key = upload_backup_to_s3(
+                &s.client,
+                super::UploadOptions::new(
+                    name,
+                    "e2e-retention",
+                    &backup_name,
+                    &backup_id,
+                    &kanidm_uid,
+                    &kanidm.spec.domain.clone(),
                 ),
-                ..Default::default()
-            };
-            cm_api.create(&PostParams::default(), &op_cm).await.unwrap();
-
-            let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
-            let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
-            let upload_job_name = format!("{name}-upload-{backup_id_short}");
-            let upload_job: Job = serde_json::from_value(json!({
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                    "name": upload_job_name,
-                    "namespace": "default"
-                },
-                "spec": {
-                    "backoffLimit": 1,
-                    "template": {
-                        "spec": {
-                            "restartPolicy": "Never",
-                            "containers": [{
-                                "name": "data-mover",
-                                "image": data_mover_image,
-                                "command": ["/bin/kaniop-data-mover", "upload"],
-                                "env": [
-                                    {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
-                                    {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
-                                    {"name": "RUST_LOG", "value": "info"},
-                                    {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
-                                ],
-                                "volumeMounts": [
-                                    {"name": "data", "mountPath": "/data"},
-                                    {"name": "operation", "mountPath": "/run/kaniop"},
-                                    {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
-                                    {"name": "result", "mountPath": "/run/kaniop-result"}
-                                ]
-                            }],
-                            "volumes": [
-                                {"name": "data", "persistentVolumeClaim": {"claimName": format!("kanidm-data-{sts_name}-0")}},
-                                {"name": "operation", "configMap": {"name": op_cm_name}},
-                                {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
-                                {"name": "result", "emptyDir": {}}
-                            ]
-                        }
-                    }
-                }
-            }))
-            .unwrap();
-
-            job_api
-                .create(&PostParams::default(), &upload_job)
-                .await
-                .unwrap();
-
-            poll_until("upload job completes", || {
-                let job_api = job_api.clone();
-                let job_name = upload_job_name.clone();
-                async move {
-                    let job = job_api.get(&job_name).await.ok()?;
-                    if job
-                        .status
-                        .as_ref()
-                        .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
-                    {
-                        Some(())
-                    } else {
-                        None
-                    }
-                }
-            })
-            .await;
-
-            let backup_cr_name = format!("kb-{}", &backup_id[..8]);
-            let backup_cr = KanidmBackup {
-                metadata: kube::api::ObjectMeta {
-                    name: Some(backup_cr_name.clone()),
-                    namespace: Some("default".to_string()),
-                    ..Default::default()
-                },
-                spec: KanidmBackupSpec {
-                    backup_id: backup_id.clone(),
-                    kanidm_ref: BackupKanidmRef {
-                        name: name.to_string(),
-                        uid: kanidm_uid.to_string(),
-                    },
-                    repository_ref: BackupRepositoryRef {
-                        name: repo_name.clone(),
-                    },
-                    manifest_key: manifest_key.clone(),
-                },
-                status: None,
-            };
-            let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
-            backup_api
-                .create(&PostParams::default(), &backup_cr)
-                .await
-                .unwrap();
-
-            test_wait_for(
-                backup_api.clone(),
-                &backup_cr_name,
-                is_backup_phase(KanidmBackupPhase::Ready),
             )
             .await;
-
+            let _backup_cr_name = create_backup_cr_and_wait(
+                &s.client,
+                &backup_id,
+                name,
+                &kanidm_uid,
+                &repo_name,
+                &manifest_key,
+            )
+            .await;
             backup_ids.push(backup_id);
         }
 
@@ -1921,165 +1419,31 @@ e2e_test!(
         let kanidm = s.kanidm_api.get(name).await.unwrap();
         let kanidm_uid = kanidm.uid().unwrap();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
         let backup_id = uuid::Uuid::new_v4().to_string();
-        let namespace_uid = "default";
-        let manifest_key = format!(
-            "e2e-finalizer/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
-        );
-
-        let operation_doc = serde_json::json!({
-            "apiVersion": "backup.kaniop.rs/v1alpha1",
-            "kind": "OperationDocument",
-            "operation": "upload",
-            "payloadPath": format!("/data/{backup_name}"),
-            "bucket": MINIO_BUCKET,
-            "prefix": "e2e-finalizer",
-            "endpoint": MINIO_ENDPOINT,
-            "region": MINIO_REGION,
-            "forcePathStyle": true,
-            "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
-            "backupId": backup_id,
-            "namespaceUid": namespace_uid,
-            "kanidmUid": kanidm_uid,
-            "kanidmName": name,
-            "domain": kanidm.spec.domain.clone(),
-            "kanidmVersion": "e2e",
-            "consistency": "kanidm-offline",
-            "reason": "e2e-test",
-            "resultPath": "/run/kaniop-result/result.json",
-            "maxConcurrentParts": 4,
-            "maxRetries": 3,
-        });
-
-        let data_mover_image = std::env::var("DATA_MOVER_IMAGE").unwrap_or_else(|_| {
-            format!(
-                "ghcr.io/pando85/kaniop-data-mover:{}",
-                option_env!("GIT_SHA").unwrap_or("aed6d7e")
-            )
-        });
-
-        let op_cm_name = format!("{name}-upload-op");
-        let cm_api =
-            Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(s.client.clone(), "default");
-        let op_cm = k8s_openapi::api::core::v1::ConfigMap {
-            metadata: kube::api::ObjectMeta {
-                name: Some(op_cm_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            data: Some(
-                [(
-                    "operation.json".to_string(),
-                    serde_json::to_string(&operation_doc).unwrap(),
-                )]
-                .into_iter()
-                .collect(),
+        let manifest_key = upload_backup_to_s3(
+            &s.client,
+            super::UploadOptions::new(
+                name,
+                "e2e-finalizer",
+                &backup_name,
+                &backup_id,
+                &kanidm_uid,
+                &kanidm.spec.domain.clone(),
             ),
-            ..Default::default()
-        };
-        cm_api.create(&PostParams::default(), &op_cm).await.unwrap();
-
-        let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
-        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
-        let upload_job_name = format!("{name}-upload");
-        let upload_job: Job = serde_json::from_value(json!({
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "metadata": {
-                "name": upload_job_name,
-                "namespace": "default"
-            },
-            "spec": {
-                "backoffLimit": 1,
-                "template": {
-                    "spec": {
-                        "restartPolicy": "Never",
-                        "containers": [{
-                            "name": "data-mover",
-                            "image": data_mover_image,
-                            "command": ["/bin/kaniop-data-mover", "upload"],
-                            "env": [
-                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
-                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
-                                {"name": "RUST_LOG", "value": "info"},
-                                {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
-                            ],
-                            "volumeMounts": [
-                                {"name": "data", "mountPath": "/data"},
-                                {"name": "operation", "mountPath": "/run/kaniop"},
-                                {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
-                                {"name": "result", "mountPath": "/run/kaniop-result"}
-                            ]
-                        }],
-                        "volumes": [
-                            {"name": "data", "persistentVolumeClaim": {"claimName": format!("kanidm-data-{sts_name}-0")}},
-                            {"name": "operation", "configMap": {"name": op_cm_name}},
-                            {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
-                            {"name": "result", "emptyDir": {}}
-                        ]
-                    }
-                }
-            }
-        }))
-        .unwrap();
-
-        job_api
-            .create(&PostParams::default(), &upload_job)
-            .await
-            .unwrap();
-
-        poll_until("upload job completes", || {
-            let job_api = job_api.clone();
-            let job_name = upload_job_name.clone();
-            async move {
-                let job = job_api.get(&job_name).await.ok()?;
-                if job
-                    .status
-                    .as_ref()
-                    .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
-                {
-                    Some(())
-                } else {
-                    None
-                }
-            }
-        })
+        )
         .await;
-
-        let backup_cr_name = format!("kb-{}", &backup_id[..8]);
-        let backup_cr = KanidmBackup {
-            metadata: kube::api::ObjectMeta {
-                name: Some(backup_cr_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            spec: KanidmBackupSpec {
-                backup_id: backup_id.clone(),
-                kanidm_ref: BackupKanidmRef {
-                    name: name.to_string(),
-                    uid: kanidm_uid.to_string(),
-                },
-                repository_ref: BackupRepositoryRef {
-                    name: repo_name.clone(),
-                },
-                manifest_key: manifest_key.clone(),
-            },
-            status: None,
-        };
-        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
-        backup_api
-            .create(&PostParams::default(), &backup_cr)
-            .await
-            .unwrap();
-
-        test_wait_for(
-            backup_api.clone(),
-            &backup_cr_name,
-            is_backup_phase(KanidmBackupPhase::Ready),
+        let backup_cr_name = create_backup_cr_and_wait(
+            &s.client,
+            &backup_id,
+            name,
+            &kanidm_uid,
+            &repo_name,
+            &manifest_key,
         )
         .await;
 
+        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
         let backup_with_finalizer = backup_api.get(&backup_cr_name).await.unwrap();
         assert!(
             backup_with_finalizer
@@ -2173,7 +1537,7 @@ e2e_test!(
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
         let statefulset_api =
@@ -2206,164 +1570,31 @@ e2e_test!(
         .await;
 
         let backup_id = uuid::Uuid::new_v4().to_string();
-        let namespace_uid = "default";
-        let manifest_key = format!(
-            "e2e-cse-rt/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
-        );
-
-        let operation_doc = serde_json::json!({
-            "apiVersion": "backup.kaniop.rs/v1alpha1",
-            "kind": "OperationDocument",
-            "operation": "upload",
-            "payloadPath": format!("/data/{backup_name}"),
-            "bucket": MINIO_BUCKET,
-            "prefix": "e2e-cse-rt",
-            "endpoint": MINIO_ENDPOINT,
-            "region": MINIO_REGION,
-            "forcePathStyle": true,
-            "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
-            "backupId": backup_id,
-            "namespaceUid": namespace_uid,
-            "kanidmUid": kanidm_uid,
-            "kanidmName": name,
-            "domain": domain,
-            "kanidmVersion": "e2e",
-            "consistency": "kanidm-offline",
-            "reason": "e2e-test",
-            "resultPath": "/run/kaniop-result/result.json",
-            "maxConcurrentParts": 4,
-            "maxRetries": 3,
-            "encryptionMode": "clientSide",
-        });
-
-        let data_mover_image = std::env::var("DATA_MOVER_IMAGE").unwrap_or_else(|_| {
-            format!(
-                "ghcr.io/pando85/kaniop-data-mover:{}",
-                option_env!("GIT_SHA").unwrap_or("aed6d7e")
+        let manifest_key = upload_backup_to_s3_with_encryption_key(
+            &s.client,
+            super::UploadOptions::new(
+                name,
+                "e2e-cse-rt",
+                &backup_name,
+                &backup_id,
+                &kanidm_uid,
+                &domain,
             )
-        });
-
-        let op_cm_name = format!("{name}-upload-op");
-        let cm_api =
-            Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(s.client.clone(), "default");
-        let op_cm = k8s_openapi::api::core::v1::ConfigMap {
-            metadata: kube::api::ObjectMeta {
-                name: Some(op_cm_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            data: Some(
-                [(
-                    "operation.json".to_string(),
-                    serde_json::to_string(&operation_doc).unwrap(),
-                )]
-                .into_iter()
-                .collect(),
-            ),
-            ..Default::default()
-        };
-        cm_api.create(&PostParams::default(), &op_cm).await.unwrap();
-
-        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
-        let upload_job_name = format!("{name}-upload");
-        let upload_job: Job = serde_json::from_value(json!({
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "metadata": {
-                "name": upload_job_name,
-                "namespace": "default"
-            },
-            "spec": {
-                "backoffLimit": 1,
-                "template": {
-                    "spec": {
-                        "restartPolicy": "Never",
-                        "containers": [{
-                            "name": "data-mover",
-                            "image": data_mover_image,
-                            "command": ["/bin/kaniop-data-mover", "upload"],
-                            "env": [
-                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
-                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
-                                {"name": "KANIOP_ENCRYPTION_KEY", "valueFrom": {"secretKeyRef": {"name": kek_secret_name, "key": "encryption-key"}}},
-                                {"name": "RUST_LOG", "value": "info"},
-                                {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
-                            ],
-                            "volumeMounts": [
-                                {"name": "data", "mountPath": "/data"},
-                                {"name": "operation", "mountPath": "/run/kaniop"},
-                                {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
-                                {"name": "result", "mountPath": "/run/kaniop-result"}
-                            ]
-                        }],
-                        "volumes": [
-                            {"name": "data", "persistentVolumeClaim": {"claimName": format!("kanidm-data-{sts_name}-0")}},
-                            {"name": "operation", "configMap": {"name": op_cm_name}},
-                            {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
-                            {"name": "result", "emptyDir": {}}
-                        ]
-                    }
-                }
-            }
-        }))
-        .unwrap();
-
-        job_api
-            .create(&PostParams::default(), &upload_job)
-            .await
-            .unwrap();
-
-        poll_until("upload job completes", || {
-            let job_api = job_api.clone();
-            let job_name = upload_job_name.clone();
-            async move {
-                let job = job_api.get(&job_name).await.ok()?;
-                if job
-                    .status
-                    .as_ref()
-                    .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
-                {
-                    Some(())
-                } else {
-                    None
-                }
-            }
-        })
+            .with_encryption(&kek_secret_name)
+            .with_extra_fields(Some(json!({"encryptionMode": "clientSide"}))),
+        )
         .await;
-
-        let backup_cr_name = format!("kb-{}", &backup_id[..8]);
-        let backup_cr = KanidmBackup {
-            metadata: kube::api::ObjectMeta {
-                name: Some(backup_cr_name.clone()),
-                namespace: Some("default".to_string()),
-                ..Default::default()
-            },
-            spec: KanidmBackupSpec {
-                backup_id: backup_id.clone(),
-                kanidm_ref: BackupKanidmRef {
-                    name: name.to_string(),
-                    uid: kanidm_uid.to_string(),
-                },
-                repository_ref: BackupRepositoryRef {
-                    name: repo_name.clone(),
-                },
-                manifest_key: manifest_key.clone(),
-            },
-            status: None,
-        };
-        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
-        backup_api
-            .create(&PostParams::default(), &backup_cr)
-            .await
-            .unwrap();
-
-        test_wait_for(
-            backup_api.clone(),
-            &backup_cr_name,
-            is_backup_phase(KanidmBackupPhase::Ready),
+        let backup_cr_name = create_backup_cr_and_wait(
+            &s.client,
+            &backup_id,
+            name,
+            &kanidm_uid,
+            &repo_name,
+            &manifest_key,
         )
         .await;
 
+        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
         let ready_backup = backup_api.get(&backup_cr_name).await.unwrap();
         let ready_status = ready_backup.status.as_ref().unwrap();
         assert!(
@@ -2479,7 +1710,7 @@ e2e_test!(
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
 
-        let backup_name = trigger_backup_on_primary(name, &s.client).await;
+        let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
         let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
         let statefulset_api =
@@ -2765,5 +1996,288 @@ e2e_test!(
 
             cleanup_test_resources(&s.client, name, &repo_name).await;
         }
+    }
+);
+
+e2e_test!(
+    #[serial(backup)]
+    backup_schedule_retention_keep_last_deletes_expired_cr_and_s3_prefix,
+    {
+        let name = "test-ret-keep2";
+        let repo_name = format!("{name}-repo");
+        let schedule_name = format!("{name}-schedule");
+
+        init_crypto_provider();
+        let client = Client::try_default().await.unwrap();
+        cleanup_test_resources(&client, name, &repo_name).await;
+        let schedule_api = Api::<KanidmBackupSchedule>::namespaced(client.clone(), "default");
+        force_delete_and_wait(schedule_api.clone(), &schedule_name).await;
+
+        let s = setup(
+            name,
+            Some(json!({
+                "storage": STORAGE_VOLUME_CLAIM_TEMPLATE_JSON["storage"].clone(),
+                "replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 1, "primaryNode": true}]
+            })),
+        )
+        .await;
+
+        create_repository(&s.client, &repo_name, "e2e-ret-keep2", MINIO_CREDS_SECRET).await;
+        let repo_api = Api::<KanidmBackupRepository>::namespaced(s.client.clone(), "default");
+        test_wait_for(repo_api, &repo_name, is_repo_ready()).await;
+
+        let schedule_api = Api::<KanidmBackupSchedule>::namespaced(s.client.clone(), "default");
+        let schedule = KanidmBackupSchedule::new(
+            &schedule_name,
+            KanidmBackupScheduleSpec {
+                kanidm_ref: ScheduleKanidmRef {
+                    name: name.to_string(),
+                },
+                repository_ref: ScheduleRepositoryRef {
+                    name: repo_name.to_string(),
+                },
+                schedule: "*/5 * * * *".to_string(),
+                time_zone: "UTC".to_string(),
+                suspend: false,
+                concurrency_policy: "Forbid".to_string(),
+                jitter_seconds: None,
+                local_versions: 3,
+                retention: Some(RetentionPolicySpec {
+                    keep_last: 2,
+                    daily: 0,
+                    weekly: 0,
+                    monthly: 0,
+                    min_age: "0h".to_string(),
+                }),
+            },
+        );
+        schedule_api
+            .create(&PostParams::default(), &schedule)
+            .await
+            .unwrap();
+
+        let kanidm = s.kanidm_api.get(name).await.unwrap();
+        let kanidm_uid = kanidm.uid().unwrap();
+        let namespace_uid = "default";
+
+        let mut backup_ids = Vec::new();
+        for _ in 0..3 {
+            let backup_name = trigger_backup_on_primary(&s.client, name).await;
+            let backup_id = uuid::Uuid::new_v4().to_string();
+            let manifest_key = upload_backup_to_s3(
+                &s.client,
+                super::UploadOptions::new(
+                    name,
+                    "e2e-ret-keep2",
+                    &backup_name,
+                    &backup_id,
+                    &kanidm_uid,
+                    &kanidm.spec.domain.clone(),
+                ),
+            )
+            .await;
+            let _backup_cr_name = create_backup_cr_and_wait(
+                &s.client,
+                &backup_id,
+                name,
+                &kanidm_uid,
+                &repo_name,
+                &manifest_key,
+            )
+            .await;
+            backup_ids.push(backup_id);
+        }
+
+        assert_eq!(backup_ids.len(), 3);
+
+        let expired_backup_id = &backup_ids[0];
+        let expired_cr_name = format!("kb-{}", &expired_backup_id[..8]);
+        let expired_prefix = format!(
+            "e2e-ret-keep2/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{expired_backup_id}/"
+        );
+
+        poll_until("schedule retention deletes expired backup CR", || {
+            let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
+            let expired_cr_name = expired_cr_name.clone();
+            async move {
+                if backup_api.get(&expired_cr_name).await.is_err() {
+                    Some(())
+                } else {
+                    None
+                }
+            }
+        })
+        .await;
+
+        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
+        let remaining: Vec<_> = backup_api
+            .list(&Default::default())
+            .await
+            .unwrap()
+            .items
+            .into_iter()
+            .filter(|b| b.spec.kanidm_ref.name == name && b.spec.repository_ref.name == repo_name)
+            .collect();
+        assert_eq!(
+            remaining.len(),
+            2,
+            "keepLast=2 should retain exactly 2 backup CRs, found {}",
+            remaining.len()
+        );
+
+        let discover_op = serde_json::json!({
+            "apiVersion": "backup.kaniop.rs/v1alpha1",
+            "kind": "OperationDocument",
+            "operation": "discover",
+            "bucket": MINIO_BUCKET,
+            "prefix": "e2e-ret-keep2",
+            "endpoint": MINIO_ENDPOINT,
+            "region": MINIO_REGION,
+            "forcePathStyle": true,
+            "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
+            "namespaceUid": namespace_uid,
+            "kanidmUid": kanidm_uid,
+            "resultPath": "/run/kaniop-result/result.json",
+            "maxResults": 1000,
+            "maxRetries": 3,
+        });
+
+        let discover_cm_name = format!("{name}-discover-check");
+        let cm_api =
+            Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(s.client.clone(), "default");
+        let discover_cm = k8s_openapi::api::core::v1::ConfigMap {
+            metadata: kube::api::ObjectMeta {
+                name: Some(discover_cm_name.clone()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            data: Some(
+                [(
+                    "operation.json".to_string(),
+                    serde_json::to_string(&discover_op).unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+        cm_api
+            .create(&PostParams::default(), &discover_cm)
+            .await
+            .unwrap();
+
+        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
+        let discover_job_name = format!("{name}-discover-check");
+        let discover_job: Job = serde_json::from_value(json!({
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": discover_job_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "backoffLimit": 1,
+                "template": {
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [{
+                            "name": "data-mover",
+                            "image": data_mover_image(),
+                            "command": ["/bin/kaniop-data-mover", "discover"],
+                            "env": [
+                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
+                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
+                                {"name": "RUST_LOG", "value": "info"},
+                                {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
+                            ],
+                            "terminationMessagePath": "/run/kaniop-result/result.json",
+                            "volumeMounts": [
+                                {"name": "operation", "mountPath": "/run/kaniop"},
+                                {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
+                                {"name": "result", "mountPath": "/run/kaniop-result"}
+                            ]
+                        }],
+                        "volumes": [
+                            {"name": "operation", "configMap": {"name": discover_cm_name}},
+                            {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
+                            {"name": "result", "emptyDir": {}}
+                        ]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        job_api
+            .create(&PostParams::default(), &discover_job)
+            .await
+            .unwrap();
+
+        poll_until("discover job completes", || {
+            let job_api = job_api.clone();
+            let job_name = discover_job_name.clone();
+            async move {
+                let job = job_api.get(&job_name).await.ok()?;
+                if job
+                    .status
+                    .as_ref()
+                    .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
+                {
+                    Some(())
+                } else {
+                    None
+                }
+            }
+        })
+        .await;
+
+        let pod_api = Api::<Pod>::namespaced(s.client.clone(), "default");
+        let pods = pod_api
+            .list(
+                &kube::api::ListParams::default().labels(&format!("job-name={discover_job_name}")),
+            )
+            .await
+            .unwrap();
+        let succeeded_pod = pods
+            .items
+            .iter()
+            .find(|p| {
+                p.status.as_ref().and_then(|s| s.phase.as_ref()) == Some(&"Succeeded".to_string())
+            })
+            .expect("discover job should have a succeeded pod");
+
+        let container_status = succeeded_pod
+            .status
+            .as_ref()
+            .unwrap()
+            .container_statuses
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|cs| cs.name == "data-mover")
+            .unwrap();
+        let termination_msg = container_status
+            .state
+            .as_ref()
+            .and_then(|s| s.terminated.as_ref())
+            .and_then(|t| t.message.as_ref())
+            .expect("termination message should exist");
+
+        let result: serde_json::Value = serde_json::from_str(termination_msg).unwrap();
+        let manifest_keys = result["discovery"]["manifestKeys"]
+            .as_array()
+            .expect("discovery should have manifestKeys");
+
+        for key in manifest_keys {
+            let key_str = key.as_str().unwrap();
+            assert!(
+                !key_str.contains(&expired_prefix),
+                "expired backup prefix should be deleted from S3, found: {key_str}"
+            );
+        }
+
+        cleanup_test_resources(&s.client, name, &repo_name).await;
+        let schedule_api = Api::<KanidmBackupSchedule>::namespaced(s.client.clone(), "default");
+        force_delete_and_wait(schedule_api, &schedule_name).await;
     }
 );

--- a/tests/e2e/test/kanidm/backup_transport.rs
+++ b/tests/e2e/test/kanidm/backup_transport.rs
@@ -1,15 +1,15 @@
 use serial_test::serial;
 
 use super::{
-    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, STORAGE_VOLUME_CLAIM_TEMPLATE_JSON,
-    is_kanidm,
+    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, MINIO_CREDS_SECRET,
+    STORAGE_VOLUME_CLAIM_TEMPLATE_JSON, create_repository, force_delete_and_wait, is_kanidm,
+    is_repo_ready,
 };
 use crate::test::{init_crypto_provider, poll_until, wait_for as test_wait_for};
 
 use kaniop_backup_core::crd::{
-    AuthMethod, KanidmBackup, KanidmBackupRepository, KanidmBackupRepositorySpec,
-    KanidmBackupSchedule, KanidmBackupScheduleSpec, RepositoryAuthentication, S3Config,
-    ScheduleKanidmRef, ScheduleRepositoryRef, SecretRef,
+    KanidmBackup, KanidmBackupRepository, KanidmBackupSchedule, KanidmBackupScheduleSpec,
+    ScheduleKanidmRef, ScheduleRepositoryRef,
 };
 use kaniop_operator::kanidm::crd::Kanidm;
 
@@ -22,70 +22,7 @@ use kube::client::Client;
 use serde_json::json;
 use std::time::Duration;
 
-const MINIO_ENDPOINT: &str = "https://minio.default.svc:9000";
-const MINIO_BUCKET: &str = "kaniop-backups";
-const MINIO_REGION: &str = "us-east-1";
-const MINIO_CA_CM: &str = "minio-ca";
-const MINIO_CREDS_SECRET: &str = "minio-creds";
-
 const TRANSPORT_SIDECAR_NAME: &str = "data-mover-transport";
-
-fn minio_s3_config(prefix: &str) -> S3Config {
-    S3Config {
-        bucket: MINIO_BUCKET.to_string(),
-        prefix: prefix.to_string(),
-        region: MINIO_REGION.to_string(),
-        endpoint: MINIO_ENDPOINT.to_string(),
-        force_path_style: true,
-        insecure: false,
-        ca_bundle_ref: Some(MINIO_CA_CM.to_string()),
-    }
-}
-
-fn minio_auth(secret_name: &str) -> RepositoryAuthentication {
-    let method = AuthMethod {
-        workload_identity: None,
-        secret_ref: Some(SecretRef {
-            name: secret_name.to_string(),
-        }),
-    };
-    RepositoryAuthentication {
-        writer: method.clone(),
-        reader: method.clone(),
-        deleter: method,
-    }
-}
-
-async fn force_delete_and_wait<K>(api: Api<K>, name: &str)
-where
-    K: kube::Resource
-        + Clone
-        + std::fmt::Debug
-        + for<'de> k8s_openapi::serde::Deserialize<'de>
-        + 'static
-        + Send,
-{
-    api.delete(name, &Default::default()).await.ok();
-    api.patch(
-        name,
-        &kube::api::PatchParams::default(),
-        &kube::api::Patch::Merge(json!({"metadata": {"finalizers": null}})),
-    )
-    .await
-    .ok();
-    poll_until(&format!("{name} deleted"), || {
-        let api = api.clone();
-        let name = name.to_string();
-        async move {
-            if api.get(&name).await.is_err() {
-                Some(())
-            } else {
-                None
-            }
-        }
-    })
-    .await;
-}
 
 async fn cleanup_transport_resources(client: &Client, kanidm_name: &str, repo_name: &str) {
     let ns = "default";
@@ -113,18 +50,6 @@ async fn cleanup_transport_resources(client: &Client, kanidm_name: &str, repo_na
 
     let kanidm_api = Api::<Kanidm>::namespaced(client.clone(), ns);
     force_delete_and_wait(kanidm_api, kanidm_name).await;
-}
-
-fn is_repo_ready() -> impl kube::runtime::wait::Condition<KanidmBackupRepository> {
-    move |obj: Option<&KanidmBackupRepository>| {
-        obj.and_then(|repo| repo.status.as_ref())
-            .is_some_and(|status| {
-                status
-                    .conditions
-                    .iter()
-                    .any(|c| c.type_ == "Ready" && c.status == "True" && c.reason == "Accepted")
-            })
-    }
 }
 
 e2e_test!(
@@ -182,20 +107,7 @@ e2e_test!(
         test_wait_for(kanidm_api.clone(), kanidm_name, is_kanidm("Available")).await;
 
         let repo_api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
-        force_delete_and_wait(repo_api.clone(), repo_name).await;
-        let repo = KanidmBackupRepository::new(
-            repo_name,
-            KanidmBackupRepositorySpec {
-                s3: minio_s3_config("e2e-transport"),
-                authentication: minio_auth(MINIO_CREDS_SECRET),
-                encryption: None,
-                limits: None,
-            },
-        );
-        repo_api
-            .create(&PostParams::default(), &repo)
-            .await
-            .unwrap();
+        create_repository(&client, repo_name, "e2e-transport", MINIO_CREDS_SECRET).await;
         test_wait_for(repo_api.clone(), repo_name, is_repo_ready()).await;
 
         let schedule_api = Api::<KanidmBackupSchedule>::namespaced(client.clone(), "default");
@@ -408,20 +320,7 @@ e2e_test!(
         test_wait_for(kanidm_api.clone(), kanidm_name, is_kanidm("Available")).await;
 
         let repo_api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
-        force_delete_and_wait(repo_api.clone(), repo_name).await;
-        let repo = KanidmBackupRepository::new(
-            repo_name,
-            KanidmBackupRepositorySpec {
-                s3: minio_s3_config("e2e-transport-np"),
-                authentication: minio_auth(MINIO_CREDS_SECRET),
-                encryption: None,
-                limits: None,
-            },
-        );
-        repo_api
-            .create(&PostParams::default(), &repo)
-            .await
-            .unwrap();
+        create_repository(&client, repo_name, "e2e-transport-np", MINIO_CREDS_SECRET).await;
         test_wait_for(repo_api.clone(), repo_name, is_repo_ready()).await;
 
         let schedule_api = Api::<KanidmBackupSchedule>::namespaced(client.clone(), "default");

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -5,6 +5,17 @@ mod replication;
 mod restore;
 mod upgrade;
 
+pub struct UploadOptions<'a> {
+    pub kanidm_name: &'a str,
+    pub prefix: &'a str,
+    pub backup_name: &'a str,
+    pub backup_id: &'a str,
+    pub kanidm_uid: &'a str,
+    pub domain: &'a str,
+    pub encryption: Option<&'a str>,
+    pub extra_operation_fields: Option<serde_json::Value>,
+}
+
 use crate::kanidm::get_dependency_version;
 use crate::test::{init_crypto_provider, wait_for};
 
@@ -12,6 +23,7 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use kaniop_backup_core::crd::KanidmBackupRepository;
 use kaniop_operator::kanidm::crd::Kanidm;
 use kaniop_operator::kanidm::reconcile::secret::SecretExt;
 use kaniop_operator::kanidm::reconcile::statefulset::{StatefulSetExt, TLS_SECRET_HASH_ANNOTATION};
@@ -333,6 +345,524 @@ async fn wait_for_replication_success_with_timeout(pod_api: &Api<Pod>, pod_names
         }
         sleep(Duration::from_secs(REPLICATION_POLL_INTERVAL_SECONDS)).await;
     }
+}
+
+pub const MINIO_ENDPOINT: &str = "https://minio.default.svc:9000";
+pub const MINIO_BUCKET: &str = "kaniop-backups";
+pub const MINIO_REGION: &str = "us-east-1";
+pub const MINIO_CA_CM: &str = "minio-ca";
+pub const MINIO_CREDS_SECRET: &str = "minio-creds";
+pub const MINIO_CREDS_INVALID_SECRET: &str = "minio-creds-invalid";
+
+pub fn minio_s3_config(prefix: &str) -> kaniop_backup_core::crd::S3Config {
+    kaniop_backup_core::crd::S3Config {
+        bucket: MINIO_BUCKET.to_string(),
+        prefix: prefix.to_string(),
+        region: MINIO_REGION.to_string(),
+        endpoint: MINIO_ENDPOINT.to_string(),
+        force_path_style: true,
+        insecure: false,
+        ca_bundle_ref: Some(MINIO_CA_CM.to_string()),
+    }
+}
+
+pub fn minio_auth(secret_name: &str) -> kaniop_backup_core::crd::RepositoryAuthentication {
+    use kaniop_backup_core::crd::{AuthMethod, RepositoryAuthentication, SecretRef};
+    let method = AuthMethod {
+        workload_identity: None,
+        secret_ref: Some(SecretRef {
+            name: secret_name.to_string(),
+        }),
+    };
+    RepositoryAuthentication {
+        writer: method.clone(),
+        reader: method.clone(),
+        deleter: method,
+    }
+}
+
+pub async fn force_delete_and_wait<K>(api: Api<K>, name: &str)
+where
+    K: kube::Resource
+        + Clone
+        + std::fmt::Debug
+        + for<'de> k8s_openapi::serde::Deserialize<'de>
+        + 'static
+        + Send,
+{
+    api.delete(name, &Default::default()).await.ok();
+    api.patch(
+        name,
+        &kube::api::PatchParams::default(),
+        &kube::api::Patch::Merge(json!({"metadata": {"finalizers": null}})),
+    )
+    .await
+    .ok();
+    crate::test::poll_until(&format!("{name} deleted"), || {
+        let api = api.clone();
+        let name = name.to_string();
+        async move {
+            if api.get(&name).await.is_err() {
+                Some(())
+            } else {
+                None
+            }
+        }
+    })
+    .await;
+}
+
+pub fn is_repo_ready() -> impl Condition<KanidmBackupRepository> {
+    move |obj: Option<&KanidmBackupRepository>| {
+        obj.and_then(|repo| repo.status.as_ref())
+            .is_some_and(|status| {
+                status
+                    .conditions
+                    .iter()
+                    .any(|c| c.type_ == "Ready" && c.status == "True" && c.reason == "Accepted")
+            })
+    }
+}
+
+pub async fn create_repository(client: &Client, name: &str, prefix: &str, secret: &str) {
+    use kaniop_backup_core::crd::{KanidmBackupRepository, KanidmBackupRepositorySpec};
+    let api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
+    force_delete_and_wait(api.clone(), name).await;
+    let repo = KanidmBackupRepository::new(
+        name,
+        KanidmBackupRepositorySpec {
+            s3: minio_s3_config(prefix),
+            authentication: minio_auth(secret),
+            encryption: None,
+            limits: None,
+        },
+    );
+    api.create(&PostParams::default(), &repo).await.unwrap();
+}
+
+pub async fn create_repository_with_encryption(
+    client: &Client,
+    name: &str,
+    prefix: &str,
+    secret: &str,
+    encryption: Option<kaniop_backup_core::crd::RepositoryEncryption>,
+) {
+    use kaniop_backup_core::crd::{KanidmBackupRepository, KanidmBackupRepositorySpec};
+    let api = Api::<KanidmBackupRepository>::namespaced(client.clone(), "default");
+    force_delete_and_wait(api.clone(), name).await;
+    let repo = KanidmBackupRepository::new(
+        name,
+        KanidmBackupRepositorySpec {
+            s3: minio_s3_config(prefix),
+            authentication: minio_auth(secret),
+            encryption,
+            limits: None,
+        },
+    );
+    api.create(&PostParams::default(), &repo).await.unwrap();
+}
+
+pub async fn create_kek_secret(client: &Client, name: &str, key_value: &[u8]) {
+    let secret_api = Api::<Secret>::namespaced(client.clone(), "default");
+    force_delete_and_wait(secret_api.clone(), name).await;
+    let secret = Secret {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some("default".to_string()),
+            ..Default::default()
+        },
+        string_data: Some(std::collections::BTreeMap::from([(
+            "encryption-key".to_string(),
+            String::from_utf8(key_value.to_vec()).unwrap(),
+        )])),
+        ..Default::default()
+    };
+    secret_api
+        .create(&PostParams::default(), &secret)
+        .await
+        .unwrap();
+}
+
+pub fn data_mover_image() -> String {
+    std::env::var("DATA_MOVER_IMAGE").unwrap_or_else(|_| {
+        format!(
+            "ghcr.io/pando85/kaniop-data-mover:{}",
+            option_env!("GIT_SHA").unwrap_or("aed6d7e")
+        )
+    })
+}
+
+pub async fn trigger_backup_on_primary(client: &Client, kanidm_name: &str) -> String {
+    let pod_api = Api::<Pod>::namespaced(client.clone(), "default");
+    let primary_pod = format!("{kanidm_name}-{DEFAULT_REPLICA_GROUP_NAME}-0");
+    let backup_name = format!("backup-{}.json.gz", uuid::Uuid::new_v4());
+    let backup_path = format!("/data/{backup_name}");
+    let exec_result = pod_api
+        .exec(
+            &primary_pod,
+            vec![
+                "kanidmd".to_string(),
+                "database".to_string(),
+                "backup".to_string(),
+                backup_path.clone(),
+            ],
+            &kube::api::AttachParams::default().container("kanidm"),
+        )
+        .await
+        .unwrap();
+    kaniop_k8s_util::client::get_output(exec_result)
+        .await
+        .expect("backup command should succeed");
+    backup_name
+}
+
+impl<'a> UploadOptions<'a> {
+    pub fn new(
+        kanidm_name: &'a str,
+        prefix: &'a str,
+        backup_name: &'a str,
+        backup_id: &'a str,
+        kanidm_uid: &'a str,
+        domain: &'a str,
+    ) -> Self {
+        Self {
+            encryption: None,
+            extra_operation_fields: None,
+            kanidm_name,
+            prefix,
+            backup_name,
+            backup_id,
+            kanidm_uid,
+            domain,
+        }
+    }
+
+    pub fn with_encryption(self, kek_secret_name: &'a str) -> Self {
+        Self {
+            encryption: Some(kek_secret_name),
+            ..self
+        }
+    }
+
+    pub fn with_extra_fields(self, extra_operation_fields: Option<serde_json::Value>) -> Self {
+        Self {
+            extra_operation_fields,
+            ..self
+        }
+    }
+}
+
+pub async fn upload_backup_to_s3(client: &Client, options: UploadOptions<'_>) -> String {
+    upload_backup_to_s3_internal(client, options).await
+}
+
+pub async fn upload_backup_to_s3_with_encryption_key(
+    client: &Client,
+    options: UploadOptions<'_>,
+) -> String {
+    upload_backup_to_s3_internal(client, options).await
+}
+
+async fn upload_backup_to_s3_internal(
+    client: &Client,
+    UploadOptions {
+        kanidm_name,
+        prefix,
+        backup_name,
+        backup_id,
+        kanidm_uid,
+        domain,
+        encryption: encryption_secret,
+        extra_operation_fields,
+    }: UploadOptions<'_>,
+) -> String {
+    use k8s_openapi::api::batch::v1::Job;
+    use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
+
+    let namespace_api: Api<Namespace> = Api::all(client.clone());
+    let default_ns = namespace_api.get("default").await.unwrap();
+    let namespace_uid = default_ns.metadata.uid.unwrap();
+
+    let manifest_key = format!(
+        "{prefix}/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
+    );
+
+    let mut operation_doc = json!({
+        "apiVersion": "backup.kaniop.rs/v1alpha1",
+        "kind": "OperationDocument",
+        "operation": "upload",
+        "payloadPath": format!("/data/{backup_name}"),
+        "bucket": MINIO_BUCKET,
+        "prefix": prefix,
+        "endpoint": MINIO_ENDPOINT,
+        "region": MINIO_REGION,
+        "forcePathStyle": true,
+        "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
+        "backupId": backup_id,
+        "namespaceUid": namespace_uid,
+        "kanidmUid": kanidm_uid,
+        "kanidmName": kanidm_name,
+        "domain": domain,
+        "kanidmVersion": "e2e",
+        "consistency": "kanidm-offline",
+        "reason": "e2e-test",
+        "resultPath": "/run/kaniop-result/result.json",
+        "maxConcurrentParts": 4,
+        "maxRetries": 3,
+    });
+    if let Some(extra) = extra_operation_fields {
+        json_patch::merge(&mut operation_doc, &extra);
+    }
+
+    let sts_name = format!("{kanidm_name}-{DEFAULT_REPLICA_GROUP_NAME}");
+    let pvc_name = format!("kanidm-data-{sts_name}-0");
+    let op_cm_name = format!("{kanidm_name}-upload-op");
+
+    let cm_api = Api::<ConfigMap>::namespaced(client.clone(), "default");
+    let op_cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(op_cm_name.clone()),
+            namespace: Some("default".to_string()),
+            ..Default::default()
+        },
+        data: Some(
+            [(
+                "operation.json".to_string(),
+                serde_json::to_string(&operation_doc).unwrap(),
+            )]
+            .into_iter()
+            .collect(),
+        ),
+        ..Default::default()
+    };
+    cm_api.create(&PostParams::default(), &op_cm).await.unwrap();
+
+    let job_api = Api::<Job>::namespaced(client.clone(), "default");
+    let upload_job_name = format!("{kanidm_name}-upload");
+
+    let mut env_vars: Vec<serde_json::Value> = vec![
+        serde_json::from_value(json!({"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}})).unwrap(),
+        serde_json::from_value(json!({"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}})).unwrap(),
+        serde_json::from_value(json!({"name": "RUST_LOG", "value": "info"})).unwrap(),
+        serde_json::from_value(json!({"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"})).unwrap(),
+    ];
+
+    if let Some(kek_name) = encryption_secret {
+        env_vars.push(
+            serde_json::from_value(json!({"name": "KANIOP_ENCRYPTION_KEY", "valueFrom": {"secretKeyRef": {"name": kek_name, "key": "encryption-key"}}})).unwrap(),
+        );
+    }
+
+    let upload_job: Job = serde_json::from_value(json!({
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": upload_job_name,
+            "namespace": "default"
+        },
+        "spec": {
+            "backoffLimit": 1,
+            "template": {
+                "spec": {
+                    "restartPolicy": "Never",
+                    "containers": [{
+                        "name": "data-mover",
+                        "image": data_mover_image(),
+                        "command": ["/bin/kaniop-data-mover", "upload"],
+                        "env": env_vars,
+                        "volumeMounts": [
+                            {"name": "data", "mountPath": "/data"},
+                            {"name": "operation", "mountPath": "/run/kaniop"},
+                            {"name": "ca-bundle", "mountPath": "/run/kaniop-ca-bundle"},
+                            {"name": "result", "mountPath": "/run/kaniop-result"}
+                        ]
+                    }],
+                    "volumes": [
+                        {"name": "data", "persistentVolumeClaim": {"claimName": pvc_name}},
+                        {"name": "operation", "configMap": {"name": op_cm_name}},
+                        {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
+                        {"name": "result", "emptyDir": {}}
+                    ]
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    job_api
+        .create(&PostParams::default(), &upload_job)
+        .await
+        .unwrap();
+
+    crate::test::poll_until("upload job completes", || {
+        let job_api = job_api.clone();
+        let job_name = upload_job_name.clone();
+        async move {
+            let job = job_api.get(&job_name).await.ok()?;
+            if job
+                .status
+                .as_ref()
+                .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
+            {
+                Some(())
+            } else {
+                None
+            }
+        }
+    })
+    .await;
+
+    job_api
+        .delete(&upload_job_name, &Default::default())
+        .await
+        .ok();
+    cm_api.delete(&op_cm_name, &Default::default()).await.ok();
+
+    manifest_key
+}
+
+pub async fn create_backup_cr_and_wait(
+    client: &Client,
+    backup_id: &str,
+    kanidm_name: &str,
+    kanidm_uid: &str,
+    repo_name: &str,
+    manifest_key: &str,
+) -> String {
+    use kaniop_backup_core::crd::{
+        BackupKanidmRef, BackupRepositoryRef, KanidmBackup, KanidmBackupPhase, KanidmBackupSpec,
+    };
+    let backup_cr_name = format!("kb-{}", &backup_id[..8]);
+    let backup_cr = KanidmBackup {
+        metadata: kube::api::ObjectMeta {
+            name: Some(backup_cr_name.clone()),
+            namespace: Some("default".to_string()),
+            ..Default::default()
+        },
+        spec: KanidmBackupSpec {
+            backup_id: backup_id.to_string(),
+            kanidm_ref: BackupKanidmRef {
+                name: kanidm_name.to_string(),
+                uid: kanidm_uid.to_string(),
+            },
+            repository_ref: BackupRepositoryRef {
+                name: repo_name.to_string(),
+            },
+            manifest_key: manifest_key.to_string(),
+        },
+        status: None,
+    };
+    let backup_api = Api::<KanidmBackup>::namespaced(client.clone(), "default");
+    backup_api
+        .create(&PostParams::default(), &backup_cr)
+        .await
+        .unwrap();
+    wait_for(backup_api, &backup_cr_name, |obj: Option<&KanidmBackup>| {
+        obj.and_then(|b| b.status.as_ref())
+            .is_some_and(|s| s.phase == KanidmBackupPhase::Ready)
+    })
+    .await;
+    backup_cr_name
+}
+
+pub async fn scale_statefulset_and_wait(client: &Client, sts_name: &str, replicas: i32) {
+    use k8s_openapi::api::apps::v1::StatefulSet;
+    let api = Api::<StatefulSet>::namespaced(client.clone(), "default");
+    let mut sts = api.get(sts_name).await.unwrap();
+    sts.spec.as_mut().unwrap().replicas = Some(replicas);
+    sts.metadata.managed_fields = None;
+    api.patch(
+        sts_name,
+        &kube::api::PatchParams::apply("e2e-test").force(),
+        &kube::api::Patch::Apply(&sts),
+    )
+    .await
+    .unwrap();
+    crate::test::poll_until(&format!("statefulset scaled to {replicas}"), || {
+        let api = api.clone();
+        let sts_name = sts_name.to_string();
+        async move {
+            let sts = api.get(&sts_name).await.ok()?;
+            let ready = sts
+                .status
+                .as_ref()
+                .and_then(|s| s.ready_replicas)
+                .unwrap_or(0);
+            if ready == replicas { Some(()) } else { None }
+        }
+    })
+    .await;
+}
+
+pub async fn cleanup_test_resources(client: &Client, kanidm_name: &str, repo_name: &str) {
+    use kaniop_backup_core::crd::{KanidmBackup, KanidmBackupRepository, KanidmBackupSchedule};
+    use kaniop_operator::kanidm::restore::KanidmRestore;
+
+    let ns = "default";
+
+    let restore_api = Api::<KanidmRestore>::namespaced(client.clone(), ns);
+    force_delete_and_wait(restore_api, &format!("{kanidm_name}-restore")).await;
+
+    let backup_api = Api::<KanidmBackup>::namespaced(client.clone(), ns);
+    if let Ok(list) = backup_api.list(&Default::default()).await {
+        for backup in list.items {
+            if backup.spec.kanidm_ref.name == kanidm_name {
+                force_delete_and_wait(backup_api.clone(), &backup.name_any()).await;
+            }
+        }
+    }
+
+    let schedule_api = Api::<KanidmBackupSchedule>::namespaced(client.clone(), ns);
+    if let Ok(list) = schedule_api.list(&Default::default()).await {
+        for schedule in list.items {
+            if schedule.spec.kanidm_ref.name == kanidm_name {
+                force_delete_and_wait(schedule_api.clone(), &schedule.name_any()).await;
+            }
+        }
+    }
+
+    let repo_api = Api::<KanidmBackupRepository>::namespaced(client.clone(), ns);
+    force_delete_and_wait(repo_api, repo_name).await;
+
+    let job_api = Api::<k8s_openapi::api::batch::v1::Job>::namespaced(client.clone(), ns);
+    for suffix in [
+        "-upload",
+        "-restore",
+        "-verify",
+        "-safety-backup",
+        "-source-prep",
+        "-discover-check",
+        "-corrupt-trunc",
+        "-corrupt-backup",
+    ] {
+        force_delete_and_wait(job_api.clone(), &format!("{kanidm_name}{suffix}")).await;
+    }
+    if let Ok(list) = job_api.list(&Default::default()).await {
+        for job in list.items {
+            let job_name = job.name_any();
+            if job_name.starts_with(&format!("{kanidm_name}-upload-")) {
+                force_delete_and_wait(job_api.clone(), &job_name).await;
+            }
+        }
+    }
+
+    let cm_api = Api::<k8s_openapi::api::core::v1::ConfigMap>::namespaced(client.clone(), ns);
+    force_delete_and_wait(cm_api.clone(), &format!("{kanidm_name}-upload-op")).await;
+    force_delete_and_wait(cm_api.clone(), &format!("{kanidm_name}-discover-check")).await;
+    if let Ok(list) = cm_api.list(&Default::default()).await {
+        for cm in list.items {
+            let cm_name = cm.name_any();
+            if cm_name.starts_with(&format!("{kanidm_name}-upload-")) && cm_name.ends_with("-op") {
+                force_delete_and_wait(cm_api.clone(), &cm_name).await;
+            }
+        }
+    }
+
+    let kanidm_api = Api::<Kanidm>::namespaced(client.clone(), ns);
+    force_delete_and_wait(kanidm_api, kanidm_name).await;
+
+    let secret_api = Api::<Secret>::namespaced(client.clone(), ns);
+    force_delete_and_wait(secret_api, &format!("{kanidm_name}-tls")).await;
 }
 
 e2e_test!(kanidm_create, {

--- a/tests/e2e/test/kanidm/mod.rs
+++ b/tests/e2e/test/kanidm/mod.rs
@@ -737,6 +737,14 @@ pub async fn create_backup_cr_and_wait(
         metadata: kube::api::ObjectMeta {
             name: Some(backup_cr_name.clone()),
             namespace: Some("default".to_string()),
+            labels: Some(
+                [
+                    ("kaniop.rs/backup-id".to_string(), backup_id.to_string()),
+                    ("kaniop.rs/repository".to_string(), repo_name.to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
             ..Default::default()
         },
         spec: KanidmBackupSpec {

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1969,6 +1969,7 @@ e2e_test!(
         assert!(restore_status.database_mutation_started);
 
         wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+        wait_for(s.kanidm_api.clone(), name, is_kanidm("Initialized")).await;
 
         let fresh_client = create_fresh_authenticated_client(name).await;
 

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1,16 +1,19 @@
 use serial_test::serial;
 
 use super::{
-    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, STORAGE_VOLUME_CLAIM_TEMPLATE_JSON,
-    has_statefulset_ready_replicas, is_kanidm, is_kanidm_false, is_statefulset_ready, setup,
-    wait_for, wait_for_replication_success_with_timeout,
+    DEFAULT_REPLICA_GROUP_NAME, KANIDM_DEFAULT_SPEC_JSON, MINIO_BUCKET, MINIO_CA_CM,
+    MINIO_CREDS_SECRET, MINIO_ENDPOINT, MINIO_REGION, STORAGE_VOLUME_CLAIM_TEMPLATE_JSON,
+    cleanup_test_resources, create_backup_cr_and_wait, create_repository,
+    has_statefulset_ready_replicas, is_kanidm, is_kanidm_false, is_statefulset_ready, minio_auth,
+    minio_s3_config, setup, upload_backup_to_s3, wait_for,
+    wait_for_replication_success_with_timeout,
 };
 use crate::test::{init_crypto_provider, poll_until};
 
 use kaniop_backup_core::crd::{
-    AuthMethod, BackupKanidmRef, BackupRepositoryRef, EncryptionMode, KanidmBackup,
-    KanidmBackupPhase, KanidmBackupRepository, KanidmBackupRepositorySpec, KanidmBackupSpec,
-    RepositoryAuthentication, RepositoryEncryption, S3Config, SecretRef,
+    BackupKanidmRef, BackupRepositoryRef, EncryptionMode, KanidmBackup, KanidmBackupPhase,
+    KanidmBackupRepository, KanidmBackupRepositorySpec, KanidmBackupSpec, RepositoryEncryption,
+    SecretRef,
 };
 use kaniop_operator::kanidm::crd::Kanidm;
 use kaniop_operator::kanidm::restore::{
@@ -1076,38 +1079,6 @@ e2e_test!(
     }
 );
 
-const RESTORE_MINIO_ENDPOINT: &str = "https://minio.default.svc:9000";
-const RESTORE_MINIO_BUCKET: &str = "kaniop-backups";
-const RESTORE_MINIO_REGION: &str = "us-east-1";
-const RESTORE_MINIO_CA_CM: &str = "minio-ca";
-const RESTORE_MINIO_CREDS_SECRET: &str = "minio-creds";
-
-fn restore_minio_s3_config(prefix: &str) -> S3Config {
-    S3Config {
-        bucket: RESTORE_MINIO_BUCKET.to_string(),
-        prefix: prefix.to_string(),
-        region: RESTORE_MINIO_REGION.to_string(),
-        endpoint: RESTORE_MINIO_ENDPOINT.to_string(),
-        force_path_style: true,
-        insecure: false,
-        ca_bundle_ref: Some(RESTORE_MINIO_CA_CM.to_string()),
-    }
-}
-
-fn restore_minio_auth(secret_name: &str) -> RepositoryAuthentication {
-    let method = AuthMethod {
-        workload_identity: None,
-        secret_ref: Some(SecretRef {
-            name: secret_name.to_string(),
-        }),
-    };
-    RepositoryAuthentication {
-        writer: method.clone(),
-        reader: method.clone(),
-        deleter: method,
-    }
-}
-
 e2e_test!(
     #[serial(restore)]
     restore_wrong_kek_fails_closed,
@@ -1199,8 +1170,8 @@ e2e_test!(
         let safety_repo = KanidmBackupRepository::new(
             &safety_repo_name,
             KanidmBackupRepositorySpec {
-                s3: restore_minio_s3_config("e2e-wrong-kek-safety"),
-                authentication: restore_minio_auth(RESTORE_MINIO_CREDS_SECRET),
+                s3: minio_s3_config("e2e-wrong-kek-safety"),
+                authentication: minio_auth(MINIO_CREDS_SECRET),
                 encryption: None,
                 limits: None,
             },
@@ -1228,8 +1199,8 @@ e2e_test!(
         let encrypted_repo = KanidmBackupRepository::new(
             &repo_name,
             KanidmBackupRepositorySpec {
-                s3: restore_minio_s3_config("e2e-wrong-kek"),
-                authentication: restore_minio_auth(RESTORE_MINIO_CREDS_SECRET),
+                s3: minio_s3_config("e2e-wrong-kek"),
+                authentication: minio_auth(MINIO_CREDS_SECRET),
                 encryption: Some(RepositoryEncryption {
                     mode: EncryptionMode::ClientSide,
                     key_id: None,
@@ -1301,10 +1272,10 @@ e2e_test!(
             "kind": "OperationDocument",
             "operation": "upload",
             "payloadPath": format!("/data/{backup_name}"),
-            "bucket": RESTORE_MINIO_BUCKET,
+            "bucket": MINIO_BUCKET,
             "prefix": "e2e-wrong-kek",
-            "endpoint": RESTORE_MINIO_ENDPOINT,
-            "region": RESTORE_MINIO_REGION,
+            "endpoint": MINIO_ENDPOINT,
+            "region": MINIO_REGION,
             "forcePathStyle": true,
             "caBundlePath": "/run/kaniop-ca-bundle/ca-bundle.pem",
             "backupId": backup_id,
@@ -1367,8 +1338,8 @@ e2e_test!(
                             "image": data_mover_image,
                             "command": ["/bin/kaniop-data-mover", "upload"],
                             "env": [
-                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": RESTORE_MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
-                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": RESTORE_MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
+                                {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_ACCESS_KEY_ID"}}},
+                                {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": MINIO_CREDS_SECRET, "key": "AWS_SECRET_ACCESS_KEY"}}},
                                 {"name": "KANIOP_ENCRYPTION_KEY", "valueFrom": {"secretKeyRef": {"name": kek_secret_name, "key": "encryption-key"}}},
                                 {"name": "RUST_LOG", "value": "info"},
                                 {"name": "SSL_CERT_FILE", "value": "/run/kaniop-ca-bundle/ca-bundle.pem"}
@@ -1383,7 +1354,7 @@ e2e_test!(
                         "volumes": [
                             {"name": "data", "persistentVolumeClaim": {"claimName": format!("kanidm-data-{sts_name}-0")}},
                             {"name": "operation", "configMap": {"name": op_cm_name}},
-                            {"name": "ca-bundle", "configMap": {"name": RESTORE_MINIO_CA_CM}},
+                            {"name": "ca-bundle", "configMap": {"name": MINIO_CA_CM}},
                             {"name": "result", "emptyDir": {}}
                         ]
                     }
@@ -1553,3 +1524,475 @@ async fn create_kek_secret_restore(client: &Client, name: &str, key_value: &[u8]
         .await
         .unwrap();
 }
+
+e2e_test!(
+    #[serial(restore)]
+    restore_truncated_remote_payload_fails_before_mutation_and_resumes_service,
+    {
+        let name = "test-trunc-remote-payload";
+        let repo_name = format!("{name}-repo");
+
+        init_crypto_provider();
+        let client = Client::try_default().await.unwrap();
+        cleanup_test_resources(&client, name, &repo_name).await;
+
+        let (s, kanidm_uid, image) = setup_kanidm_with_backup(name).await;
+
+        create_repository(
+            &s.client,
+            &repo_name,
+            "e2e-trunc-remote",
+            MINIO_CREDS_SECRET,
+        )
+        .await;
+        let repo_api = Api::<KanidmBackupRepository>::namespaced(s.client.clone(), "default");
+        wait_for(repo_api.clone(), &repo_name, super::is_repo_ready()).await;
+
+        let backup_name = trigger_backup_on_primary(&s, name).await;
+
+        let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+        let pvc_name = format!("kanidm-data-{sts_name}-0");
+        let trunc_job_name = format!("{name}-corrupt-trunc");
+        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
+        let trunc_job: Job = serde_json::from_value(json!({
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": trunc_job_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "backoffLimit": 1,
+                "template": {
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [{
+                            "name": "truncater",
+                            "image": "busybox:latest",
+                            "command": ["sh", "-c", format!("dd if=/data/{} bs=16 count=1 of=/data/{} 2>/dev/null", backup_name, backup_name)],
+                            "volumeMounts": [{
+                                "name": "data",
+                                "mountPath": "/data"
+                            }]
+                        }],
+                        "volumes": [{
+                            "name": "data",
+                            "persistentVolumeClaim": {"claimName": pvc_name}
+                        }]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        job_api
+            .create(&PostParams::default(), &trunc_job)
+            .await
+            .expect("trunc job create should succeed");
+
+        poll_until("trunc job completes", || {
+            let job_api = job_api.clone();
+            let job_name = trunc_job_name.clone();
+            async move {
+                let job = job_api.get(&job_name).await.ok()?;
+                if job
+                    .status
+                    .as_ref()
+                    .is_some_and(|s| s.succeeded.is_some_and(|v| v > 0))
+                {
+                    Some(())
+                } else {
+                    None
+                }
+            }
+        })
+        .await;
+
+        job_api
+            .delete(&trunc_job_name, &Default::default())
+            .await
+            .ok();
+
+        let backup_id = uuid::Uuid::new_v4().to_string();
+        let domain = s.kanidm_api.get(name).await.unwrap().spec.domain.clone();
+
+        let manifest_key = upload_backup_to_s3(
+            &s.client,
+            super::UploadOptions::new(
+                name,
+                "e2e-trunc-remote",
+                &backup_name,
+                &backup_id,
+                &kanidm_uid,
+                &domain,
+            ),
+        )
+        .await;
+
+        let backup_cr_name = create_backup_cr_and_wait(
+            &s.client,
+            &backup_id,
+            name,
+            &kanidm_uid,
+            &repo_name,
+            &manifest_key,
+        )
+        .await;
+
+        let restore_name = format!("{name}-restore");
+        let restore = KanidmRestore::new(
+            &restore_name,
+            KanidmRestoreSpec {
+                target_ref: KanidmRestoreTargetRef {
+                    name: name.to_string(),
+                    uid: kanidm_uid.to_string(),
+                },
+                source: KanidmRestoreSource {
+                    local: None,
+                    backup_ref: Some(KanidmRestoreBackupRefSource {
+                        name: backup_cr_name.clone(),
+                    }),
+                },
+                restore_image: image,
+                safety_backup: Some(SafetyBackupConfig {
+                    repository_ref: Some(SafetyBackupRepositoryRef {
+                        name: repo_name.clone(),
+                    }),
+                    skip: false,
+                }),
+            },
+        );
+
+        let restore_api = Api::<KanidmRestore>::namespaced(s.client.clone(), "default");
+        restore_api
+            .create(&PostParams::default(), &restore)
+            .await
+            .unwrap();
+
+        wait_for(
+            restore_api.clone(),
+            &restore_name,
+            is_restore_phase(KanidmRestorePhase::Failed),
+        )
+        .await;
+
+        let final_restore = restore_api.get(&restore_name).await.unwrap();
+        let status = final_restore.status.as_ref().unwrap();
+        assert_eq!(status.phase, KanidmRestorePhase::Failed);
+        assert!(
+            !status.database_mutation_started,
+            "database_mutation_started must be false after truncated remote payload failure"
+        );
+
+        wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+
+        cleanup_test_resources(&s.client, name, &repo_name).await;
+    }
+);
+
+e2e_test!(
+    #[serial(restore)]
+    restore_remote_semantic_drill_with_identity_data,
+    {
+        use crate::test::{create_fresh_authenticated_client, setup_kanidm_connection};
+        use kaniop_group::crd::KanidmGroup;
+        use kaniop_oauth2::crd::KanidmOAuth2Client;
+        use kaniop_person::crd::KanidmPersonAccount;
+        use kaniop_service_account::crd::KanidmServiceAccount;
+
+        let name = "test-semantic-drill";
+        let repo_name = format!("{name}-repo");
+
+        init_crypto_provider();
+        let client = Client::try_default().await.unwrap();
+
+        let person_name = format!("{name}-alice");
+        let group_name = format!("{name}-engineers");
+        let oauth2_name = format!("{name}-webapp");
+        let sa_name = format!("{name}-ci-bot");
+
+        let person_api = Api::<KanidmPersonAccount>::namespaced(client.clone(), "default");
+        let group_api = Api::<KanidmGroup>::namespaced(client.clone(), "default");
+        let oauth2_api = Api::<KanidmOAuth2Client>::namespaced(client.clone(), "default");
+        let sa_api = Api::<KanidmServiceAccount>::namespaced(client.clone(), "default");
+
+        person_api
+            .delete(&person_name, &Default::default())
+            .await
+            .ok();
+        group_api
+            .delete(&group_name, &Default::default())
+            .await
+            .ok();
+        oauth2_api
+            .delete(&oauth2_name, &Default::default())
+            .await
+            .ok();
+        sa_api.delete(&sa_name, &Default::default()).await.ok();
+
+        cleanup_test_resources(&client, name, &repo_name).await;
+
+        let s = setup(
+            name,
+            Some(json!({
+                "domain": format!("{name}.localhost"),
+                "ingress": {
+                    "annotations": {
+                        "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
+                    }
+                },
+                "storage": STORAGE_VOLUME_CLAIM_TEMPLATE_JSON["storage"].clone(),
+                "replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 1, "primaryNode": true}]
+            })),
+        )
+        .await;
+
+        create_repository(
+            &s.client,
+            &repo_name,
+            "e2e-semantic-drill",
+            MINIO_CREDS_SECRET,
+        )
+        .await;
+        let repo_api = Api::<KanidmBackupRepository>::namespaced(s.client.clone(), "default");
+        wait_for(repo_api.clone(), &repo_name, super::is_repo_ready()).await;
+
+        let kanidm_conn = setup_kanidm_connection(name).await;
+
+        let person = KanidmPersonAccount::new(
+            &person_name,
+            serde_json::from_value(json!({
+                "kanidmRef": {"name": name},
+                "personAttributes": {
+                    "displayname": "Alice Drill",
+                    "mail": ["alice-drill@example.com"],
+                },
+            }))
+            .unwrap(),
+        );
+        person_api
+            .create(&PostParams::default(), &person)
+            .await
+            .unwrap();
+
+        let group = KanidmGroup::new(
+            &group_name,
+            serde_json::from_value(json!({
+                "kanidmRef": {"name": name},
+                "mail": ["engineers-drill@example.com"],
+            }))
+            .unwrap(),
+        );
+        group_api
+            .create(&PostParams::default(), &group)
+            .await
+            .unwrap();
+
+        let oauth2 = KanidmOAuth2Client::new(
+            &oauth2_name,
+            serde_json::from_value(json!({
+                "kanidmRef": {"name": name},
+                "redirectUrl": ["https://webapp-drill.example.com/callback"],
+                "displayname": "Drill WebApp",
+                "origin": "https://webapp-drill.example.com",
+                "public": false,
+            }))
+            .unwrap(),
+        );
+        oauth2_api
+            .create(&PostParams::default(), &oauth2)
+            .await
+            .unwrap();
+
+        let sa = KanidmServiceAccount::new(
+            &sa_name,
+            serde_json::from_value(json!({
+                "kanidmRef": {"name": name},
+                "serviceAccountAttributes": {
+                    "displayname": "CI Drill Bot",
+                },
+            }))
+            .unwrap(),
+        );
+        sa_api.create(&PostParams::default(), &sa).await.unwrap();
+
+        let kanidm = s.kanidm_api.get(name).await.unwrap();
+        let kanidm_uid = kanidm.uid().unwrap();
+        let image = kanidm.spec.image.clone();
+        let domain = kanidm.spec.domain.clone();
+
+        let person_kanidm = kanidm_conn
+            .kanidm_client
+            .idm_person_account_get(&person_name)
+            .await
+            .unwrap()
+            .expect("person should exist before backup");
+        let person_displayname = person_kanidm
+            .attrs
+            .get("displayname")
+            .and_then(|v| v.first())
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(person_displayname, "Alice Drill");
+
+        let backup_name = trigger_backup_on_primary(&s, name).await;
+
+        let backup_id = uuid::Uuid::new_v4().to_string();
+
+        let manifest_key = upload_backup_to_s3(
+            &s.client,
+            super::UploadOptions::new(
+                name,
+                "e2e-semantic-drill",
+                &backup_name,
+                &backup_id,
+                &kanidm_uid,
+                &domain,
+            ),
+        )
+        .await;
+
+        let backup_cr_name = create_backup_cr_and_wait(
+            &s.client,
+            &backup_id,
+            name,
+            &kanidm_uid,
+            &repo_name,
+            &manifest_key,
+        )
+        .await;
+
+        person_api
+            .delete(&person_name, &Default::default())
+            .await
+            .unwrap();
+        poll_until("person deleted after backup", || {
+            let person_api = person_api.clone();
+            let person_name = person_name.clone();
+            async move {
+                if person_api.get(&person_name).await.is_err() {
+                    Some(())
+                } else {
+                    None
+                }
+            }
+        })
+        .await;
+
+        let mut group_after = group_api.get(&group_name).await.unwrap();
+        group_after.metadata.annotations = Some(
+            [("post-backup-mutation".to_string(), "true".to_string())]
+                .into_iter()
+                .collect(),
+        );
+        group_after.metadata.managed_fields = None;
+        group_api
+            .patch(
+                &group_name,
+                &PatchParams::apply("e2e-test").force(),
+                &Patch::Apply(&group_after),
+            )
+            .await
+            .unwrap();
+
+        let restore_name = format!("{name}-restore");
+        let restore = KanidmRestore::new(
+            &restore_name,
+            KanidmRestoreSpec {
+                target_ref: KanidmRestoreTargetRef {
+                    name: name.to_string(),
+                    uid: kanidm_uid.to_string(),
+                },
+                source: KanidmRestoreSource {
+                    local: None,
+                    backup_ref: Some(KanidmRestoreBackupRefSource {
+                        name: backup_cr_name.clone(),
+                    }),
+                },
+                restore_image: image,
+                safety_backup: Some(SafetyBackupConfig {
+                    repository_ref: Some(SafetyBackupRepositoryRef {
+                        name: repo_name.clone(),
+                    }),
+                    skip: false,
+                }),
+            },
+        );
+
+        let restore_api = Api::<KanidmRestore>::namespaced(s.client.clone(), "default");
+        restore_api
+            .create(&PostParams::default(), &restore)
+            .await
+            .unwrap();
+
+        wait_for(
+            restore_api.clone(),
+            &restore_name,
+            is_restore_phase(KanidmRestorePhase::Completed),
+        )
+        .await;
+
+        let final_restore = restore_api.get(&restore_name).await.unwrap();
+        let restore_status = final_restore.status.unwrap();
+        assert_eq!(restore_status.phase, KanidmRestorePhase::Completed);
+        assert!(restore_status.database_mutation_started);
+
+        wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
+
+        let fresh_client = create_fresh_authenticated_client(name).await;
+
+        let restored_person = fresh_client
+            .idm_person_account_get(&person_name)
+            .await
+            .unwrap();
+        assert!(
+            restored_person.is_some(),
+            "person should be recovered after restore to the backup point"
+        );
+        let restored_displayname = restored_person
+            .unwrap()
+            .attrs
+            .get("displayname")
+            .and_then(|v| v.first())
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            restored_displayname, "Alice Drill",
+            "person displayname should match the backup point"
+        );
+
+        let restored_group = fresh_client.idm_group_get(&group_name).await.unwrap();
+        assert!(restored_group.is_some(), "group should exist after restore");
+
+        let restored_oauth2 = fresh_client.idm_oauth2_rs_get(&oauth2_name).await.unwrap();
+        assert!(
+            restored_oauth2.is_some(),
+            "OAuth2 client should exist after restore"
+        );
+
+        let restored_sa = fresh_client
+            .idm_service_account_get(&sa_name)
+            .await
+            .unwrap();
+        assert!(
+            restored_sa.is_some(),
+            "service account should exist after restore"
+        );
+
+        person_api
+            .delete(&person_name, &Default::default())
+            .await
+            .ok();
+        group_api
+            .delete(&group_name, &Default::default())
+            .await
+            .ok();
+        oauth2_api
+            .delete(&oauth2_name, &Default::default())
+            .await
+            .ok();
+        sa_api.delete(&sa_name, &Default::default()).await.ok();
+
+        cleanup_test_resources(&s.client, name, &repo_name).await;
+    }
+);

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1810,6 +1810,7 @@ e2e_test!(
                 "kanidmRef": {"name": name},
                 "serviceAccountAttributes": {
                     "displayname": "CI Drill Bot",
+                    "entryManagedBy": "idm_admin",
                 },
             }))
             .unwrap(),

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1639,6 +1639,23 @@ e2e_test!(
         )
         .await;
 
+        let backup_api = Api::<KanidmBackup>::namespaced(s.client.clone(), "default");
+        let mismatched_sha256 =
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        let patch = serde_json::json!({
+            "status": {
+                "payloadSha256": mismatched_sha256
+            }
+        });
+        backup_api
+            .patch_status(
+                &backup_cr_name,
+                &PatchParams::apply("e2e-test"),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .unwrap();
+
         let restore_name = format!("{name}-restore");
         let restore = KanidmRestore::new(
             &restore_name,
@@ -1816,6 +1833,19 @@ e2e_test!(
             .unwrap(),
         );
         sa_api.create(&PostParams::default(), &sa).await.unwrap();
+
+        let kanidm_client = &kanidm_conn.kanidm_client;
+        poll_until("person exists in kanidm", || {
+            let pn = person_name.clone();
+            async move {
+                kanidm_client
+                    .idm_person_account_get(&pn)
+                    .await
+                    .ok()
+                    .flatten()
+            }
+        })
+        .await;
 
         let kanidm = s.kanidm_api.get(name).await.unwrap();
         let kanidm_uid = kanidm.uid().unwrap();

--- a/tests/e2e/test/mod.rs
+++ b/tests/e2e/test/mod.rs
@@ -359,10 +359,14 @@ pub async fn create_fresh_authenticated_client(kanidm_name: &str) -> KanidmClien
         .unwrap();
 
     let secret_api = Api::<Secret>::namespaced(client.clone(), "default");
-    let admin_secret = secret_api
-        .get(&format!("{kanidm_name}-admin-passwords"))
-        .await
-        .unwrap();
+    let secret_name = format!("{kanidm_name}-admin-passwords");
+    poll_until("admin secret exists", || {
+        let secret_api = secret_api.clone();
+        let secret_name = secret_name.clone();
+        async move { secret_api.get(&secret_name).await.ok() }
+    })
+    .await;
+    let admin_secret = secret_api.get(&secret_name).await.unwrap();
     let secret_data = admin_secret.data.unwrap();
     let password_bytes = secret_data.get("IDM_ADMIN_PASSWORD").unwrap();
     let idm_admin_password = std::str::from_utf8(&password_bytes.0).unwrap();


### PR DESCRIPTION
## Summary

Addresses the immediate production defects found while reviewing backup and restore, and implements a focused subset of #1000.

- derive deterministic UUIDv5 backup IDs and recognize legacy UUIDv7 manifests during rollout to avoid repeated uploads
- propagate manifest creation time and consistency into `KanidmBackup` status, with automatic revalidation of existing Ready backups missing metadata
- expose discovery truncation, validation failures, and deferred deletions through conditions, metrics, and alerts
- add retention-to-S3 deletion, truncated-payload recovery, and semantic remote restore coverage
- document payload verification semantics, KEK escrow requirements, and the backup workload security boundary

## Migration behavior

Existing UUIDv7 manifests are not rewritten or deleted. The transport extracts their embedded timestamps and matches them against retained local backup filenames before applying the deterministic UUIDv5 scheme to new backups.

Existing Ready `KanidmBackup` resources missing `createdAt` or consistency metadata are returned to `Discovering` once and revalidated from their manifests. This enables retention without using Kubernetes CR creation time as a substitute for backup creation time.

## Scope from #1000

Included:

- retention and complete S3-prefix deletion coverage
- corrupt/truncated payload failure before database mutation and service resumption
- semantic remote restore drill with representative identity resources
- retention/discovery observability
- Ready and KEK lifecycle documentation

Deferred:

- cross-cluster UID override design
- KEK rekey tooling
- S3 Object Lock support
- removal of the experimental transport condition pending an upstream Kanidm completion contract
- HA restart fault injection

## Validation

- `make lint`
- `make test`
- `helm unittest charts/kaniop` (199 tests)
- `make check-e2e-shards` (185 tests across 6 shards)
- `mdbook build Documentation`

Closes part of #1000.