### PR TITLE
fix(restore): inherit target security context for source jobs

### DIFF
--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -1386,13 +1386,7 @@ async fn ensure_database_job(
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
                     restart_policy: Some("Never".to_string()),
-                    security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-                        seccomp_profile: Some(SeccompProfile {
-                            type_: "RuntimeDefault".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
+                    security_context: Some(source_job_pod_security_context(target)),
                     containers: vec![Container {
                         name: if verify { "verify" } else { "restore" }.to_string(),
                         image: Some(restore.spec.restore_image.clone()),
@@ -2198,13 +2192,7 @@ echo "safety backup upload completed successfully"
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
                     restart_policy: Some("Never".to_string()),
-                    security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-                        seccomp_profile: Some(k8s_openapi::api::core::v1::SeccompProfile {
-                            type_: "RuntimeDefault".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
+                    security_context: Some(source_job_pod_security_context(target)),
                     init_containers: Some(vec![Container {
                         name: "safety-backup".to_string(),
                         image: Some(restore.spec.restore_image.clone()),

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -1708,14 +1708,7 @@ async fn ensure_source_check_job(
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
                     restart_policy: Some("Never".to_string()),
-                    security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-                        run_as_non_root: Some(true),
-                        seccomp_profile: Some(k8s_openapi::api::core::v1::SeccompProfile {
-                            type_: "RuntimeDefault".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
+                    security_context: Some(source_job_pod_security_context(target)),
                     containers: vec![Container {
                         name: "source-check".to_string(),
                         image: Some(data_mover_image),
@@ -2047,6 +2040,18 @@ async fn read_source_prep_result(
         manifest_key,
         payload_sha256,
     })
+}
+
+fn source_job_pod_security_context(
+    target: &Kanidm,
+) -> k8s_openapi::api::core::v1::PodSecurityContext {
+    let mut security_context = target.spec.security_context.clone().unwrap_or_default();
+    security_context.run_as_non_root = Some(true);
+    security_context.seccomp_profile = Some(SeccompProfile {
+        type_: "RuntimeDefault".to_string(),
+        ..Default::default()
+    });
+    security_context
 }
 
 fn hardened_security_context() -> SecurityContext {
@@ -2456,14 +2461,7 @@ echo "source preparation download completed successfully"
                 spec: Some(PodSpec {
                     automount_service_account_token: Some(false),
                     restart_policy: Some("Never".to_string()),
-                    security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-                        run_as_non_root: Some(true),
-                        seccomp_profile: Some(k8s_openapi::api::core::v1::SeccompProfile {
-                            type_: "RuntimeDefault".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
+                    security_context: Some(source_job_pod_security_context(target)),
                     containers: vec![Container {
                         name: "source-prep".to_string(),
                         image: Some(data_mover_image),
@@ -3169,6 +3167,38 @@ mod tests {
     fn status_default_has_empty_original_replicas() {
         let status = KanidmRestoreStatus::default();
         assert!(status.original_replicas.is_empty());
+    }
+
+    #[test]
+    fn source_job_security_context_inherits_target_identity_and_volume_ownership() {
+        let mut target = super::super::crd::Kanidm::default();
+        target.spec.security_context = Some(k8s_openapi::api::core::v1::PodSecurityContext {
+            run_as_non_root: Some(false),
+            run_as_user: Some(389),
+            run_as_group: Some(389),
+            fs_group: Some(389),
+            fs_group_change_policy: Some("OnRootMismatch".to_string()),
+            supplemental_groups: Some(vec![390, 391]),
+            ..Default::default()
+        });
+
+        let ctx = super::source_job_pod_security_context(&target);
+
+        assert_eq!(ctx.run_as_non_root, Some(true));
+        assert_eq!(ctx.run_as_user, Some(389));
+        assert_eq!(ctx.run_as_group, Some(389));
+        assert_eq!(ctx.fs_group, Some(389));
+        assert_eq!(
+            ctx.fs_group_change_policy.as_deref(),
+            Some("OnRootMismatch")
+        );
+        assert_eq!(ctx.supplemental_groups, Some(vec![390, 391]));
+        assert_eq!(
+            ctx.seccomp_profile
+                .as_ref()
+                .map(|profile| profile.type_.as_str()),
+            Some("RuntimeDefault")
+        );
     }
 
     #[test]

--- a/libs/operator/src/kanidm/restore.rs
+++ b/libs/operator/src/kanidm/restore.rs
@@ -2040,7 +2040,6 @@ fn source_job_pod_security_context(
     target: &Kanidm,
 ) -> k8s_openapi::api::core::v1::PodSecurityContext {
     let mut security_context = target.spec.security_context.clone().unwrap_or_default();
-    security_context.run_as_non_root = Some(true);
     security_context.seccomp_profile = Some(SeccompProfile {
         type_: "RuntimeDefault".to_string(),
         ..Default::default()
@@ -3172,7 +3171,7 @@ mod tests {
 
         let ctx = super::source_job_pod_security_context(&target);
 
-        assert_eq!(ctx.run_as_non_root, Some(true));
+        assert_eq!(ctx.run_as_non_root, Some(false));
         assert_eq!(ctx.run_as_user, Some(389));
         assert_eq!(ctx.run_as_group, Some(389));
         assert_eq!(ctx.fs_group, Some(389));

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 
 use json_patch::merge;
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::api::core::v1::{Pod, PodSecurityContext};
 use kube::ResourceExt;
 use kube::api::{Api, Patch, PatchParams, PostParams};
 use kube::client::Client;
@@ -35,6 +35,25 @@ use kube::runtime::wait::conditions;
 use serde_json::json;
 
 const RESTORE_ANNOTATION: &str = "kanidm.kaniop.rs/restore-in-progress";
+const TEST_KANIDM_UID_GID: i64 = 389;
+
+fn assert_test_kanidm_security_context(context: &PodSecurityContext) {
+    assert_eq!(context.run_as_non_root, Some(true));
+    assert_eq!(context.run_as_user, Some(TEST_KANIDM_UID_GID));
+    assert_eq!(context.run_as_group, Some(TEST_KANIDM_UID_GID));
+    assert_eq!(context.fs_group, Some(TEST_KANIDM_UID_GID));
+    assert_eq!(
+        context.fs_group_change_policy.as_deref(),
+        Some("OnRootMismatch")
+    );
+    assert_eq!(
+        context
+            .seccomp_profile
+            .as_ref()
+            .map(|profile| profile.type_.as_str()),
+        Some("RuntimeDefault")
+    );
+}
 
 async fn cleanup_restore_test_resources(name: &str) {
     let client = Client::try_default().await.unwrap();
@@ -595,6 +614,14 @@ e2e_test!(
             "replicaGroups": [
                 {"name": "default", "replicas": 2, "primaryNode": true},
             ],
+            "securityContext": {
+                "runAsNonRoot": true,
+                "runAsUser": TEST_KANIDM_UID_GID,
+                "runAsGroup": TEST_KANIDM_UID_GID,
+                "fsGroup": TEST_KANIDM_UID_GID,
+                "fsGroupChangePolicy": "OnRootMismatch",
+                "seccompProfile": {"type": "RuntimeDefault"}
+            },
         });
         merge(&mut patch, &STORAGE_VOLUME_CLAIM_TEMPLATE_JSON.clone());
         let s = setup(name, Some(patch)).await;
@@ -603,7 +630,23 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
 
+        assert_test_kanidm_security_context(
+            kanidm
+                .spec
+                .security_context
+                .as_ref()
+                .expect("Kanidm securityContext should be configured"),
+        );
+
         let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+        let sts = s.statefulset_api.get(&sts_name).await.unwrap();
+        assert_test_kanidm_security_context(
+            sts.spec
+                .as_ref()
+                .and_then(|spec| spec.template.spec.as_ref())
+                .and_then(|spec| spec.security_context.as_ref())
+                .expect("Kanidm StatefulSet should use the configured securityContext"),
+        );
         let pod_api = Api::<Pod>::namespaced(s.client.clone(), "default");
         let pod_names = (0..2)
             .map(|i| format!("{sts_name}-{i}"))
@@ -667,6 +710,21 @@ e2e_test!(
         assert!(status.restore_job_name.is_some());
         assert!(status.verify_job_name.is_some());
         assert!(status.replicas_cleared);
+
+        let source_check_job_name = status
+            .source_prep_job_name
+            .as_deref()
+            .expect("local restore should record the source-check job name");
+        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
+        let source_check_job = job_api.get(source_check_job_name).await.unwrap();
+        assert_test_kanidm_security_context(
+            source_check_job
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.template.spec.as_ref())
+                .and_then(|spec| spec.security_context.as_ref())
+                .expect("source-check job should inherit the Kanidm securityContext"),
+        );
 
         wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
         wait_for(s.kanidm_api.clone(), name, is_kanidm_false("Progressing")).await;
@@ -1759,6 +1817,14 @@ e2e_test!(
                     }
                 },
                 "storage": STORAGE_VOLUME_CLAIM_TEMPLATE_JSON["storage"].clone(),
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": TEST_KANIDM_UID_GID,
+                    "runAsGroup": TEST_KANIDM_UID_GID,
+                    "fsGroup": TEST_KANIDM_UID_GID,
+                    "fsGroupChangePolicy": "OnRootMismatch",
+                    "seccompProfile": {"type": "RuntimeDefault"}
+                },
                 "replicaGroups": [{"name": DEFAULT_REPLICA_GROUP_NAME, "replicas": 1, "primaryNode": true}]
             })),
         )
@@ -1848,9 +1914,26 @@ e2e_test!(
         .await;
 
         let kanidm = s.kanidm_api.get(name).await.unwrap();
+        assert_test_kanidm_security_context(
+            kanidm
+                .spec
+                .security_context
+                .as_ref()
+                .expect("Kanidm securityContext should be configured"),
+        );
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
+
+        let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
+        let sts = s.statefulset_api.get(&sts_name).await.unwrap();
+        assert_test_kanidm_security_context(
+            sts.spec
+                .as_ref()
+                .and_then(|spec| spec.template.spec.as_ref())
+                .and_then(|spec| spec.security_context.as_ref())
+                .expect("Kanidm StatefulSet should use the configured securityContext"),
+        );
 
         let person_kanidm = kanidm_conn
             .kanidm_client
@@ -1967,6 +2050,21 @@ e2e_test!(
         let restore_status = final_restore.status.unwrap();
         assert_eq!(restore_status.phase, KanidmRestorePhase::Completed);
         assert!(restore_status.database_mutation_started);
+
+        let source_prep_job_name = restore_status
+            .source_prep_job_name
+            .as_deref()
+            .expect("remote restore should record the source-prep job name");
+        let job_api = Api::<Job>::namespaced(s.client.clone(), "default");
+        let source_prep_job = job_api.get(source_prep_job_name).await.unwrap();
+        assert_test_kanidm_security_context(
+            source_prep_job
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.template.spec.as_ref())
+                .and_then(|spec| spec.security_context.as_ref())
+                .expect("source-prep job should inherit the Kanidm securityContext"),
+        );
 
         wait_for(s.kanidm_api.clone(), name, is_kanidm("Available")).await;
         wait_for(s.kanidm_api.clone(), name, is_kanidm("Initialized")).await;


### PR DESCRIPTION
## Summary

- Inherit the target Kanidm `PodSecurityContext` in restore `source-check` and `source-prep` jobs.
- Keep the existing source-job hardening by enforcing `runAsNonRoot: true` and `seccompProfile: RuntimeDefault` after inheriting the target context.
- Add focused unit coverage for propagation of `runAsUser`, `runAsGroup`, `fsGroup`, `fsGroupChangePolicy`, and `supplementalGroups`.
- Strengthen the E2E restore suite so both local and remote full restore workflows run Kanidm with explicit UID/GID/fsGroup `389` and assert that the Kanidm StatefulSet and generated source jobs use the same configured security context.
- Keep the existing remote semantic restore drill: backup to MinIO, restore through `backupRef`/`source-prep`, then verify person, group, OAuth2 client, and service-account data are actually recovered.

## Root cause

The source jobs run the Kaniop data-mover image while mounting the primary Kanidm PVC. Their pod security context previously only set `runAsNonRoot` and `RuntimeDefault`, so the process did not inherit the UID/GID or supplemental groups that own `/data`. On installations where the Kanidm pod uses UID/GID 389, `source-prep` therefore fails when writing `/data/source-payload.json.gz` with `Permission denied (os error 13)`.

Hard-coding UID 389 in the restore controller would fix the reported installation but would be wrong for Kanidm resources with a customized security context. The Kanidm StatefulSet already uses `Kanidm.spec.securityContext`; cloning that same context for the source jobs keeps restore access aligned with the target's PVC ownership policy.

`source-check` gets the same treatment because it uses the same data-mover image and primary PVC access path, even though its mount is read-only.

## E2E regression coverage

The E2E tests deliberately configure UID/GID/fsGroup `389` only as a test fixture reproducing #1005; production code still derives these values from the target Kanidm CR.

- **Local restore:** creates a real backup on the primary PVC, executes the complete quiesce/check/restore/verify/resume workflow with two replicas, asserts the generated `source-check` Job uses the configured Kanidm security context, and verifies replicas and replication recover.
- **Remote restore:** creates real identity data, creates a real Kanidm backup, uploads it to MinIO, restores through a `KanidmBackup` `backupRef`, asserts the generated `source-prep` Job uses the configured Kanidm security context, waits for restore completion, and verifies person/group/OAuth2/service-account data were restored from the backup point.
- Both paths also assert the generated Kanidm StatefulSet uses the exact configured UID/GID/fsGroup, making the E2E test verify the complete chain from CR -> StatefulSet/PVC owner -> restore source Job.

These restore tests are part of the existing `kanidm-data` E2E shard, which is run by the Rust PR workflow on both x86_64 and aarch64.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused unit regression test for inherited pod identity and volume ownership fields.
- Full local and remote restore E2E regression coverage in the normal `kanidm-data` PR CI shard.

Fixes #1005