### PR TITLE
fix(backup): expose backup date and Kanidm version

### DIFF
--- a/.github/workflows/crd-migration-e2e.yml
+++ b/.github/workflows/crd-migration-e2e.yml
@@ -161,11 +161,40 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install kind
-        uses: helm/kind-action@v1.14.0
-        with:
-          version: v0.32.0
-          install_only: true
+      - name: Install kind and kubectl
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: v0.32.0
+          # renovate: datasource=github-releases depName=kubernetes/kubernetes
+          KUBECTL_VERSION: v1.35.0
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kind..."
+            if curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64" && \
+               chmod +x /tmp/kind && sudo mv /tmp/kind /usr/local/bin/kind; then
+              echo "kind installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kind after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kubectl..."
+            if curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+               chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/local/bin/kubectl; then
+              echo "kubectl installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kubectl after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Install helm
         env:
@@ -269,11 +298,40 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install kind
-        uses: helm/kind-action@v1.14.0
-        with:
-          version: v0.32.0
-          install_only: true
+      - name: Install kind and kubectl
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: v0.32.0
+          # renovate: datasource=github-releases depName=kubernetes/kubernetes
+          KUBECTL_VERSION: v1.35.0
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kind..."
+            if curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64" && \
+               chmod +x /tmp/kind && sudo mv /tmp/kind /usr/local/bin/kind; then
+              echo "kind installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kind after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kubectl..."
+            if curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+               chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/local/bin/kubectl; then
+              echo "kubectl installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kubectl after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Install helm
         env:
@@ -372,11 +430,40 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install kind
-        uses: helm/kind-action@v1.14.0
-        with:
-          version: v0.32.0
-          install_only: true
+      - name: Install kind and kubectl
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: v0.32.0
+          # renovate: datasource=github-releases depName=kubernetes/kubernetes
+          KUBECTL_VERSION: v1.35.0
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kind..."
+            if curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64" && \
+               chmod +x /tmp/kind && sudo mv /tmp/kind /usr/local/bin/kind; then
+              echo "kind installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kind after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kubectl..."
+            if curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+               chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/local/bin/kubectl; then
+              echo "kubectl installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kubectl after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Install helm
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -320,12 +320,45 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v7
 
-      - name: Install kind
-        uses: helm/kind-action@v1.14.0
-        with:
+      - name: Install kind and kubectl
+        env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-          version: v0.33.0
-          install_only: true
+          KIND_VERSION: v0.33.0
+          # renovate: datasource=github-releases depName=kubernetes/kubernetes
+          KUBECTL_VERSION: v1.35.0
+        run: |
+          set -euo pipefail
+          case "${CARGO_TARGET}" in
+            x86_64-*)  KIND_ARCH="amd64"; KUBECTL_ARCH="amd64" ;;
+            aarch64-*) KIND_ARCH="arm64"; KUBECTL_ARCH="arm64" ;;
+            *) echo "Unsupported target: ${CARGO_TARGET}" && exit 1 ;;
+          esac
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kind..."
+            if curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${KIND_ARCH}" && \
+               chmod +x /tmp/kind && sudo mv /tmp/kind /usr/local/bin/kind; then
+              echo "kind installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kind after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt} to install kubectl..."
+            if curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl" && \
+               chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/local/bin/kubectl; then
+              echo "kubectl installed successfully"
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install kubectl after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Install helm
         env:

--- a/cmd/data-mover/src/commands/download.rs
+++ b/cmd/data-mover/src/commands/download.rs
@@ -83,6 +83,9 @@ fn build_download_result(manifest: &KanidmBackupManifest, manifest_key: &str) ->
     result.payload_size_bytes = Some(manifest.payload.size_bytes);
     result.created_at = Some(manifest.created_at.clone());
     result.consistency = Some(manifest.backup.consistency.clone());
+    result.reason = Some(manifest.backup.reason.clone());
+    result.kanidm_version = Some(manifest.source.kanidm_version.clone());
+    result.image_digest = manifest.source.image_digest.clone();
     result
 }
 
@@ -313,7 +316,7 @@ mod tests {
                 kanidm_uid: kanidm_uid.to_string(),
                 domain: domain.to_string(),
                 kanidm_version: "1.10.4".to_string(),
-                image_digest: None,
+                image_digest: Some("sha256:abc".to_string()),
             },
             backup: ManifestBackup {
                 mode: "full".to_string(),
@@ -401,6 +404,9 @@ mod tests {
         assert_eq!(result.payload_size_bytes, Some(1024));
         assert_eq!(result.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
         assert_eq!(result.consistency.as_deref(), Some("kanidm-offline"));
+        assert_eq!(result.reason.as_deref(), Some("scheduled"));
+        assert_eq!(result.kanidm_version.as_deref(), Some("1.10.4"));
+        assert_eq!(result.image_digest.as_deref(), Some("sha256:abc"));
     }
 
     #[test]

--- a/cmd/data-mover/src/commands/transport.rs
+++ b/cmd/data-mover/src/commands/transport.rs
@@ -19,8 +19,8 @@ use crate::s3::{S3Config, S3Error, SseHeaders, create_bucket};
 use super::listing::{extract_backup_id_from_manifest_key, list_manifest_keys};
 use super::load_operation;
 use super::upload_shared::{
-    ManifestParams, UploadEncryptionConfig, build_manifest, upload_manifest_conditional,
-    upload_payload_streaming, verify_commit,
+    ManifestParams, UploadEncryptionConfig, build_manifest_with_created_at,
+    upload_manifest_conditional, upload_payload_streaming, verify_commit,
 };
 
 pub async fn run(operation_doc_path: &str) -> Result<(), i32> {
@@ -439,6 +439,20 @@ fn extract_filename_timestamp_ms(path: &Path, file_prefix: &str) -> Option<u64> 
     None
 }
 
+fn candidate_created_at(candidate: &CandidateFile, file_prefix: &str) -> String {
+    if let Some(ts_ms) = extract_filename_timestamp_ms(&candidate.path, file_prefix) {
+        if let Some(dt) = DateTime::from_timestamp_millis(ts_ms as i64) {
+            return dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        }
+    }
+
+    warn!(
+        path = %candidate.path.display(),
+        "could not parse backup timestamp from filename; falling back to file mtime"
+    );
+    DateTime::<chrono::Utc>::from(candidate.mtime).to_rfc3339()
+}
+
 fn candidate_matches_legacy_v7(
     path: &Path,
     file_prefix: &str,
@@ -533,7 +547,9 @@ async fn upload_candidate(
         client_side_meta,
     };
 
-    let manifest = build_manifest(&params, &payload_key, &local_checksum);
+    let created_at = candidate_created_at(candidate, &op.file_prefix);
+    let manifest =
+        build_manifest_with_created_at(&params, &payload_key, &local_checksum, created_at);
     let manifest_json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| UploadError::Transient(format!("failed to serialize manifest: {e}")))?;
 
@@ -935,6 +951,35 @@ mod tests {
     fn extract_filename_timestamp_ms_returns_none_for_wrong_prefix() {
         let path = Path::new("/data/backups/backup-2026-08-18T02:03:41Z.json.gz");
         assert_eq!(extract_filename_timestamp_ms(path, "other-"), None);
+    }
+
+    #[test]
+    fn candidate_created_at_uses_filename_timestamp() {
+        let candidate = CandidateFile {
+            path: PathBuf::from(
+                "/data/backups/backup-2026-08-18T02:03:41.123456789+00:00.json.gz",
+            ),
+            size: 1,
+            mtime: SystemTime::UNIX_EPOCH,
+        };
+        assert_eq!(
+            candidate_created_at(&candidate, "backup-"),
+            "2026-08-18T02:03:41.123Z"
+        );
+    }
+
+    #[test]
+    fn candidate_created_at_falls_back_to_mtime() {
+        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_723_943_021);
+        let candidate = CandidateFile {
+            path: PathBuf::from("/data/backups/backup-unknown-format.json.gz"),
+            size: 1,
+            mtime,
+        };
+        assert_eq!(
+            candidate_created_at(&candidate, "backup-"),
+            DateTime::<chrono::Utc>::from(mtime).to_rfc3339()
+        );
     }
 
     #[test]

--- a/cmd/data-mover/src/commands/transport.rs
+++ b/cmd/data-mover/src/commands/transport.rs
@@ -956,9 +956,7 @@ mod tests {
     #[test]
     fn candidate_created_at_uses_filename_timestamp() {
         let candidate = CandidateFile {
-            path: PathBuf::from(
-                "/data/backups/backup-2026-08-18T02:03:41.123456789+00:00.json.gz",
-            ),
+            path: PathBuf::from("/data/backups/backup-2026-08-18T02:03:41.123456789+00:00.json.gz"),
             size: 1,
             mtime: SystemTime::UNIX_EPOCH,
         };

--- a/cmd/data-mover/src/commands/upload_shared.rs
+++ b/cmd/data-mover/src/commands/upload_shared.rs
@@ -243,11 +243,25 @@ pub fn build_manifest(
     payload_key: &str,
     checksum_result: &checksum::ChecksumResult,
 ) -> KanidmBackupManifest {
+    build_manifest_with_created_at(
+        params,
+        payload_key,
+        checksum_result,
+        chrono::Utc::now().to_rfc3339(),
+    )
+}
+
+pub fn build_manifest_with_created_at(
+    params: &ManifestParams,
+    payload_key: &str,
+    checksum_result: &checksum::ChecksumResult,
+    created_at: String,
+) -> KanidmBackupManifest {
     KanidmBackupManifest {
         api_version: MANIFEST_API_VERSION_V1.to_string(),
         kind: MANIFEST_KIND.to_string(),
         backup_id: params.backup_id.to_string(),
-        created_at: chrono::Utc::now().to_rfc3339(),
+        created_at,
         source: ManifestSource {
             namespace_uid: params.namespace_uid.to_string(),
             kanidm_name: params.kanidm_name.to_string(),
@@ -441,6 +455,25 @@ mod tests {
         assert_eq!(manifest.payload.sha256, "abc123");
         assert_eq!(manifest.payload.size_bytes, 1024);
         assert!(manifest.validate().is_ok());
+    }
+
+    #[test]
+    fn build_manifest_with_created_at_preserves_backup_timestamp() {
+        let params = test_manifest_params();
+        let checksum_result = checksum::ChecksumResult {
+            sha256: "abc123".to_string(),
+            size_bytes: 1024,
+        };
+        let payload_key = "prod/v1/tenants/ns-uid/clusters/k-uid/backups/019c7c76-f423-7a12-8f41-2bea7588a303/payload/backup.json";
+        let created_at = "2026-08-18T02:03:41.123456789Z";
+        let manifest = build_manifest_with_created_at(
+            &params,
+            payload_key,
+            &checksum_result,
+            created_at.to_string(),
+        );
+
+        assert_eq!(manifest.created_at, created_at);
     }
 
     #[tokio::test]

--- a/libs/backup-core/src/crd.rs
+++ b/libs/backup-core/src/crd.rs
@@ -454,8 +454,9 @@ pub struct KanidmBackupScheduleStatus {
     shortname = "kb",
     namespaced,
     status = "KanidmBackupStatus",
-    printcolumn = r#"{"name":"BackupID","type":"string","jsonPath":".spec.backupId"}"#,
     printcolumn = r#"{"name":"Kanidm","type":"string","jsonPath":".spec.kanidmRef.name"}"#,
+    printcolumn = r#"{"name":"Backup Date","type":"string","jsonPath":".status.createdAt"}"#,
+    printcolumn = r#"{"name":"Version","type":"string","jsonPath":".status.kanidmVersion"}"#,
     printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
     printcolumn = r#"{"name":"Consistency","type":"string","jsonPath":".status.consistency"}"#,
     printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
@@ -618,5 +619,20 @@ mod tests {
         assert_eq!(spec.weekly, 4);
         assert_eq!(spec.monthly, 12);
         assert_eq!(spec.min_age, "24h");
+    }
+
+    #[test]
+    fn backup_printer_columns_show_date_and_version() {
+        use kube::CustomResourceExt;
+
+        let crd = serde_json::to_value(KanidmBackup::crd()).unwrap();
+        let columns = &crd["spec"]["versions"][0]["additionalPrinterColumns"];
+        let serialized = serde_json::to_string(columns).unwrap();
+
+        assert!(serialized.contains("Backup Date"));
+        assert!(serialized.contains(".status.createdAt"));
+        assert!(serialized.contains("Version"));
+        assert!(serialized.contains(".status.kanidmVersion"));
+        assert!(!serialized.contains("BackupID"));
     }
 }

--- a/libs/backup-core/src/result.rs
+++ b/libs/backup-core/src/result.rs
@@ -50,6 +50,12 @@ pub struct ResultDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consistency: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kanidm_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ResultError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion: Option<DeletionResult>,
@@ -101,6 +107,9 @@ impl ResultDocument {
             payload_size_bytes: None,
             created_at: None,
             consistency: None,
+            reason: None,
+            kanidm_version: None,
+            image_digest: None,
             error: None,
             deletion: None,
             discovery: None,
@@ -121,6 +130,9 @@ impl ResultDocument {
             payload_size_bytes: None,
             created_at: None,
             consistency: None,
+            reason: None,
+            kanidm_version: None,
+            image_digest: None,
             error: Some(ResultError {
                 code: code.to_string(),
                 message: message.to_string(),
@@ -205,6 +217,9 @@ mod tests {
         let json = result.to_json().unwrap();
         assert!(!json.contains("backupId"));
         assert!(!json.contains("manifestKey"));
+        assert!(!json.contains("reason"));
+        assert!(!json.contains("kanidmVersion"));
+        assert!(!json.contains("imageDigest"));
         assert!(!json.contains("error"));
         assert!(!json.contains("discovery"));
     }
@@ -294,6 +309,9 @@ mod tests {
             payload_size_bytes: None,
             created_at: None,
             consistency: None,
+            reason: None,
+            kanidm_version: None,
+            image_digest: None,
             error: None,
             deletion: None,
             discovery: Some(DiscoverResult {
@@ -334,6 +352,9 @@ mod tests {
             payload_size_bytes: None,
             created_at: None,
             consistency: None,
+            reason: None,
+            kanidm_version: None,
+            image_digest: None,
             error: None,
             deletion: None,
             discovery: Some(DiscoverResult {
@@ -353,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn created_at_and_consistency_roundtrip() {
+    fn manifest_metadata_roundtrip() {
         let mut result = ResultDocument::success("download");
         result.backup_id = Some("019c7c76-f423-7a12-8f41-2bea7588a303".to_string());
         result.manifest_key = Some("v1/tenants/ns/clusters/k/backups/b/manifest.json".to_string());
@@ -362,23 +383,32 @@ mod tests {
         result.payload_size_bytes = Some(1024);
         result.created_at = Some("2026-08-18T02:03:41Z".to_string());
         result.consistency = Some("kanidm-offline".to_string());
+        result.reason = Some("restore-safety".to_string());
+        result.kanidm_version = Some("1.10.4".to_string());
+        result.image_digest = Some("sha256:abc".to_string());
         let json = result.to_json().unwrap();
         let parsed = parse_result_document(&json).unwrap();
         assert_eq!(parsed.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
         assert_eq!(parsed.consistency.as_deref(), Some("kanidm-offline"));
+        assert_eq!(parsed.reason.as_deref(), Some("restore-safety"));
+        assert_eq!(parsed.kanidm_version.as_deref(), Some("1.10.4"));
+        assert_eq!(parsed.image_digest.as_deref(), Some("sha256:abc"));
         assert_eq!(result, parsed);
     }
 
     #[test]
-    fn created_at_and_consistency_omitted_when_none() {
+    fn manifest_metadata_omitted_when_none() {
         let result = ResultDocument::success("download");
         let json = result.to_json().unwrap();
         assert!(!json.contains("createdAt"));
         assert!(!json.contains("consistency"));
+        assert!(!json.contains("reason"));
+        assert!(!json.contains("kanidmVersion"));
+        assert!(!json.contains("imageDigest"));
     }
 
     #[test]
-    fn backward_compatible_parse_without_created_at_or_consistency() {
+    fn backward_compatible_parse_without_manifest_metadata() {
         let json = r#"{
             "apiVersion": "backup.kaniop.rs/v1alpha1",
             "kind": "ResultDocument",
@@ -394,6 +424,9 @@ mod tests {
         let parsed = parse_result_document(json).unwrap();
         assert!(parsed.created_at.is_none());
         assert!(parsed.consistency.is_none());
+        assert!(parsed.reason.is_none());
+        assert!(parsed.kanidm_version.is_none());
+        assert!(parsed.image_digest.is_none());
         assert_eq!(
             parsed.backup_id.as_deref(),
             Some("019c7c76-f423-7a12-8f41-2bea7588a303")

--- a/libs/backup/src/controller/backup.rs
+++ b/libs/backup/src/controller/backup.rs
@@ -478,7 +478,10 @@ fn is_kube_not_found(err: &kube::Error) -> bool {
 
 fn needs_metadata_backfill(status: &KanidmBackupStatus) -> bool {
     status.phase == KanidmBackupPhase::Ready
-        && (status.created_at.is_none() || status.consistency.is_none())
+        && (status.created_at.is_none()
+            || status.consistency.is_none()
+            || status.reason.is_none()
+            || status.kanidm_version.is_none())
 }
 
 async fn get_repository(
@@ -601,6 +604,9 @@ async fn reconcile_apply(
                 );
                 status.phase = KanidmBackupPhase::Discovering;
                 status.consistency = None;
+                status.reason = None;
+                status.kanidm_version = None;
+                status.image_digest = None;
                 status.created_at = None;
                 status.conditions.retain(|c| c.type_ != "Ready");
                 patch_backup_status(&ctx, &namespace, &name, &status).await?;
@@ -769,7 +775,9 @@ async fn handle_discovering(
                 {
                     status.phase = KanidmBackupPhase::Ready;
                     status.consistency = result.consistency;
-                    status.reason = Some("validated".to_string());
+                    status.reason = result.reason;
+                    status.kanidm_version = result.kanidm_version;
+                    status.image_digest = result.image_digest;
                     status.size_bytes = result.payload_size_bytes;
                     status.payload_sha256 = result.payload_sha256;
                     status.created_at = result.created_at;
@@ -1805,6 +1813,8 @@ mod tests {
         let status = KanidmBackupStatus {
             phase: KanidmBackupPhase::Ready,
             consistency: Some("kanidm-offline".to_string()),
+            reason: Some("scheduled".to_string()),
+            kanidm_version: Some("1.10.4".to_string()),
             created_at: None,
             ..Default::default()
         };
@@ -1817,17 +1827,45 @@ mod tests {
             phase: KanidmBackupPhase::Ready,
             created_at: Some("2026-08-18T02:03:41Z".to_string()),
             consistency: None,
+            reason: Some("scheduled".to_string()),
+            kanidm_version: Some("1.10.4".to_string()),
             ..Default::default()
         };
         assert!(needs_metadata_backfill(&status));
     }
 
     #[test]
-    fn needs_metadata_backfill_ready_with_both() {
+    fn needs_metadata_backfill_ready_without_reason() {
         let status = KanidmBackupStatus {
             phase: KanidmBackupPhase::Ready,
             created_at: Some("2026-08-18T02:03:41Z".to_string()),
             consistency: Some("kanidm-offline".to_string()),
+            kanidm_version: Some("1.10.4".to_string()),
+            ..Default::default()
+        };
+        assert!(needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn needs_metadata_backfill_ready_without_version() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            created_at: Some("2026-08-18T02:03:41Z".to_string()),
+            consistency: Some("kanidm-offline".to_string()),
+            reason: Some("scheduled".to_string()),
+            ..Default::default()
+        };
+        assert!(needs_metadata_backfill(&status));
+    }
+
+    #[test]
+    fn needs_metadata_backfill_ready_with_manifest_metadata() {
+        let status = KanidmBackupStatus {
+            phase: KanidmBackupPhase::Ready,
+            created_at: Some("2026-08-18T02:03:41Z".to_string()),
+            consistency: Some("kanidm-offline".to_string()),
+            reason: Some("scheduled".to_string()),
+            kanidm_version: Some("1.10.4".to_string()),
             ..Default::default()
         };
         assert!(!needs_metadata_backfill(&status));
@@ -1845,19 +1883,24 @@ mod tests {
     }
 
     #[test]
-    fn result_document_propagates_created_at_to_status() {
+    fn result_document_propagates_manifest_metadata_to_status() {
         let mut result = kaniop_backup_core::result::ResultDocument::success("download");
         result.backup_id = Some("019c7c76-f423-7a12-8f41-2bea7588a303".to_string());
         result.manifest_key = Some("key/manifest.json".to_string());
         result.created_at = Some("2026-08-18T02:03:41Z".to_string());
         result.consistency = Some("kanidm-offline".to_string());
+        result.reason = Some("scheduled".to_string());
+        result.kanidm_version = Some("1.10.4".to_string());
+        result.image_digest = Some("sha256:abc".to_string());
         result.payload_size_bytes = Some(1024);
         result.payload_sha256 = Some("abc".to_string());
 
         let status = KanidmBackupStatus {
             phase: KanidmBackupPhase::Ready,
             consistency: result.consistency.clone(),
-            reason: Some("validated".to_string()),
+            reason: result.reason.clone(),
+            kanidm_version: result.kanidm_version.clone(),
+            image_digest: result.image_digest.clone(),
             size_bytes: result.payload_size_bytes,
             payload_sha256: result.payload_sha256,
             created_at: result.created_at.clone(),
@@ -1866,6 +1909,9 @@ mod tests {
 
         assert_eq!(status.created_at.as_deref(), Some("2026-08-18T02:03:41Z"));
         assert_eq!(status.consistency.as_deref(), Some("kanidm-offline"));
+        assert_eq!(status.reason.as_deref(), Some("scheduled"));
+        assert_eq!(status.kanidm_version.as_deref(), Some("1.10.4"));
+        assert_eq!(status.image_digest.as_deref(), Some("sha256:abc"));
         assert_eq!(status.phase, KanidmBackupPhase::Ready);
     }
 
@@ -1903,6 +1949,9 @@ mod tests {
         let mut status = KanidmBackupStatus {
             phase: KanidmBackupPhase::Ready,
             consistency: Some("kanidm-offline".to_string()),
+            reason: Some("scheduled".to_string()),
+            kanidm_version: Some("1.10.4".to_string()),
+            image_digest: Some("sha256:abc".to_string()),
             created_at: None,
             ..Default::default()
         };
@@ -1911,11 +1960,17 @@ mod tests {
 
         status.phase = KanidmBackupPhase::Discovering;
         status.consistency = None;
+        status.reason = None;
+        status.kanidm_version = None;
+        status.image_digest = None;
         status.created_at = None;
         status.conditions.retain(|c| c.type_ != "Ready");
 
         assert_eq!(status.phase, KanidmBackupPhase::Discovering);
         assert!(status.consistency.is_none());
+        assert!(status.reason.is_none());
+        assert!(status.kanidm_version.is_none());
+        assert!(status.image_digest.is_none());
         assert!(status.created_at.is_none());
         assert!(!needs_metadata_backfill(&status));
     }

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -608,6 +608,12 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
+        let kanidm_version = kanidm
+            .status
+            .as_ref()
+            .and_then(|s| s.version.as_ref())
+            .map(|v| v.image_tag.clone())
+            .unwrap_or_else(|| "unknown".to_string());
 
         let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
@@ -651,7 +657,8 @@ e2e_test!(
                 &backup_id,
                 &kanidm_uid,
                 &domain,
-            ),
+            )
+            .with_extra_fields(Some(json!({"kanidmVersion": kanidm_version}))),
         )
         .await;
 

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -1536,6 +1536,12 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
+        let kanidm_version = kanidm
+            .status
+            .as_ref()
+            .and_then(|s| s.version.as_ref())
+            .map(|v| v.image_tag.clone())
+            .unwrap_or_else(|| "unknown".to_string());
 
         let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
@@ -1581,7 +1587,10 @@ e2e_test!(
                 &domain,
             )
             .with_encryption(&kek_secret_name)
-            .with_extra_fields(Some(json!({"encryptionMode": "clientSide"}))),
+            .with_extra_fields(Some(json!({
+                "encryptionMode": "clientSide",
+                "kanidmVersion": kanidm_version
+            }))),
         )
         .await;
         let backup_cr_name = create_backup_cr_and_wait(

--- a/tests/e2e/test/kanidm/backup.rs
+++ b/tests/e2e/test/kanidm/backup.rs
@@ -1709,6 +1709,12 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
+        let kanidm_version = kanidm
+            .status
+            .as_ref()
+            .and_then(|s| s.version.as_ref())
+            .map(|v| v.image_tag.clone())
+            .unwrap_or_else(|| "unknown".to_string());
 
         let backup_name = trigger_backup_on_primary(&s.client, name).await;
 
@@ -1764,7 +1770,7 @@ e2e_test!(
             "kanidmUid": kanidm_uid,
             "kanidmName": name,
             "domain": domain,
-            "kanidmVersion": "e2e",
+            "kanidmVersion": kanidm_version,
             "consistency": "kanidm-offline",
             "reason": "e2e-test",
             "resultPath": "/run/kaniop-result/result.json",

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1931,6 +1931,12 @@ e2e_test!(
         let kanidm_uid = kanidm.uid().unwrap();
         let image = kanidm.spec.image.clone();
         let domain = kanidm.spec.domain.clone();
+        let kanidm_version = kanidm
+            .status
+            .as_ref()
+            .and_then(|s| s.version.as_ref())
+            .map(|v| v.image_tag.clone())
+            .unwrap_or_else(|| "unknown".to_string());
 
         let sts_name = format!("{name}-{DEFAULT_REPLICA_GROUP_NAME}");
         let sts = s.statefulset_api.get(&sts_name).await.unwrap();
@@ -1969,7 +1975,8 @@ e2e_test!(
                 &backup_id,
                 &kanidm_uid,
                 &domain,
-            ),
+            )
+            .with_extra_fields(Some(json!({"kanidmVersion": kanidm_version}))),
         )
         .await;
 

--- a/tests/e2e/test/kanidm/restore.rs
+++ b/tests/e2e/test/kanidm/restore.rs
@@ -1323,7 +1323,14 @@ e2e_test!(
             "e2e-wrong-kek/v1/tenants/{namespace_uid}/clusters/{kanidm_uid}/backups/{backup_id}/manifest.json"
         );
 
-        let domain = s.kanidm_api.get(name).await.unwrap().spec.domain.clone();
+        let kanidm_after = s.kanidm_api.get(name).await.unwrap();
+        let domain = kanidm_after.spec.domain.clone();
+        let kanidm_version = kanidm_after
+            .status
+            .as_ref()
+            .and_then(|s| s.version.as_ref())
+            .map(|v| v.image_tag.clone())
+            .unwrap_or_else(|| "unknown".to_string());
 
         let operation_doc = serde_json::json!({
             "apiVersion": "backup.kaniop.rs/v1alpha1",
@@ -1341,7 +1348,7 @@ e2e_test!(
             "kanidmUid": kanidm_uid,
             "kanidmName": name,
             "domain": domain,
-            "kanidmVersion": "e2e",
+            "kanidmVersion": kanidm_version,
             "consistency": "kanidm-offline",
             "reason": "e2e-test",
             "resultPath": "/run/kaniop-result/result.json",

--- a/tests/e2e/test/mail_sender.rs
+++ b/tests/e2e/test/mail_sender.rs
@@ -529,23 +529,31 @@ e2e_test!(mail_sender_idempotent_reconcile, {
     create_smtp_secret(&s.client, &smtp_secret_name, "smtp-user", "smtp-password").await;
 
     let kanidm_api = Api::<Kanidm>::namespaced(s.client.clone(), "default");
-    let mut kanidm = kanidm_api.get(name).await.unwrap();
-    kanidm.spec.mail_sender = Some(MailSenderSpec {
-        relay: "smtps://smtp.example.com".to_string(),
-        credentials_secret: kaniop_operator::kanidm::crd::MailSenderCredentialsSecret {
-            name: smtp_secret_name.clone(),
+    let kanidm_api_clone = kanidm_api.clone();
+    let smtp_secret_name_clone = smtp_secret_name.clone();
+    let retryable_initial_patch = || async {
+        let kanidm = kanidm_api_clone.get(name).await?;
+        let mut patch_kanidm = kanidm.clone();
+        patch_kanidm.spec.mail_sender = Some(MailSenderSpec {
+            relay: "smtps://smtp.example.com".to_string(),
+            credentials_secret: kaniop_operator::kanidm::crd::MailSenderCredentialsSecret {
+                name: smtp_secret_name_clone.clone(),
+                ..Default::default()
+            },
+            from_address: "kanidm@example.com".to_string(),
             ..Default::default()
-        },
-        from_address: "kanidm@example.com".to_string(),
-        ..Default::default()
-    });
-    kanidm.metadata.managed_fields = None;
-    kanidm_api
-        .patch(
-            name,
-            &PatchParams::apply("e2e-test").force(),
-            &Patch::Apply(&kanidm),
-        )
+        });
+        patch_kanidm.metadata.managed_fields = None;
+        kanidm_api_clone
+            .patch(
+                name,
+                &PatchParams::apply("e2e-test").force(),
+                &Patch::Apply(&patch_kanidm),
+            )
+            .await
+    };
+    retryable_initial_patch
+        .retry(ExponentialBuilder::default().with_max_times(5))
         .await
         .unwrap();
 
@@ -566,15 +574,15 @@ e2e_test!(mail_sender_idempotent_reconcile, {
         .unwrap();
     assert!(kanidm_sa.is_some());
 
-    let kanidm_api_clone = kanidm_api.clone();
-    let smtp_secret_name_clone = smtp_secret_name.clone();
+    let kanidm_api_clone2 = kanidm_api.clone();
+    let smtp_secret_name_clone2 = smtp_secret_name.clone();
     let retryable_patch = || async {
-        let kanidm = kanidm_api_clone.get(name).await?;
+        let kanidm = kanidm_api_clone2.get(name).await?;
         let mut patch_kanidm = kanidm.clone();
         patch_kanidm.spec.mail_sender = Some(MailSenderSpec {
             relay: "smtps://smtp.example.com".to_string(),
             credentials_secret: kaniop_operator::kanidm::crd::MailSenderCredentialsSecret {
-                name: smtp_secret_name_clone.clone(),
+                name: smtp_secret_name_clone2.clone(),
                 ..Default::default()
             },
             from_address: "kanidm@example.com".to_string(),
@@ -582,7 +590,7 @@ e2e_test!(mail_sender_idempotent_reconcile, {
             ..Default::default()
         });
         patch_kanidm.metadata.managed_fields = None;
-        kanidm_api_clone
+        kanidm_api_clone2
             .patch(
                 name,
                 &PatchParams::apply("e2e-test").force(),

--- a/tests/e2e/test/mail_sender.rs
+++ b/tests/e2e/test/mail_sender.rs
@@ -307,6 +307,7 @@ e2e_test!(mail_sender_update, {
     };
     retryable_patch
         .retry(ExponentialBuilder::default().with_max_times(5))
+        .sleep(tokio::time::sleep)
         .await
         .unwrap();
 
@@ -361,6 +362,7 @@ e2e_test!(mail_sender_update, {
     };
     retryable_update
         .retry(ExponentialBuilder::default().with_max_times(5))
+        .sleep(tokio::time::sleep)
         .await
         .unwrap();
 
@@ -554,6 +556,7 @@ e2e_test!(mail_sender_idempotent_reconcile, {
     };
     retryable_initial_patch
         .retry(ExponentialBuilder::default().with_max_times(5))
+        .sleep(tokio::time::sleep)
         .await
         .unwrap();
 
@@ -600,6 +603,7 @@ e2e_test!(mail_sender_idempotent_reconcile, {
     };
     retryable_patch
         .retry(ExponentialBuilder::default().with_max_times(5))
+        .sleep(tokio::time::sleep)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- replace the default `BackupID` printer column with the actual backup creation date and add a Kanidm version column
- make scheduled online backup manifests use the timestamp encoded by Kanidm in the backup filename instead of manifest upload time, with file mtime only as a defensive fallback for malformed legacy names
- propagate manifest `reason`, `kanidmVersion`, and `imageDigest` through validation into `KanidmBackup.status`
- revalidate existing `Ready` backup CRs that are missing catalog metadata so they are backfilled from the immutable manifest
- keep the `ResultDocument` extension backward compatible by making the added metadata fields optional

## Semantics

`BACKUP DATE` comes from `status.createdAt`, which for Kanidm-generated scheduled backups now reflects the RFC3339 timestamp in the backup filename (`backup-<timestamp>.json.gz`). It deliberately does not use the `KanidmBackup` CR creation timestamp or the S3 upload/manifest commit time.

`AGE` remains the Kubernetes resource age, so operators can distinguish when the backup was created from when its catalog CR was discovered.

## Tests

Added/expanded unit coverage for:

- generated `KanidmBackup` printer columns
- authoritative manifest creation timestamps
- filename timestamp extraction and mtime fallback
- result-document metadata round trips and backward-compatible deserialization
- manifest metadata propagation into backup status and metadata backfill detection
