### PR TITLE
fix(backup): run transport as native sidecar

### DIFF
--- a/libs/operator/src/kanidm/reconcile/statefulset.rs
+++ b/libs/operator/src/kanidm/reconcile/statefulset.rs
@@ -2427,7 +2427,9 @@ consumer_cert = "dummy-cert-read-replica-1"
         assert!(
             pod.init_containers
                 .as_ref()
-                .is_none_or(|containers| containers.iter().all(|c| c.name != "data-mover-transport"))
+                .is_none_or(|containers| containers
+                    .iter()
+                    .all(|c| c.name != "data-mover-transport"))
         );
     }
 
@@ -2451,7 +2453,9 @@ consumer_cert = "dummy-cert-read-replica-1"
         assert!(
             pod.init_containers
                 .as_ref()
-                .is_none_or(|containers| containers.iter().all(|c| c.name != "data-mover-transport"))
+                .is_none_or(|containers| containers
+                    .iter()
+                    .all(|c| c.name != "data-mover-transport"))
         );
     }
 

--- a/libs/operator/src/kanidm/reconcile/statefulset.rs
+++ b/libs/operator/src/kanidm/reconcile/statefulset.rs
@@ -287,7 +287,7 @@ impl StatefulSetExt for Kanidm {
         let pod_labels = self.generate_pod_labels(replica_group);
         let labels = self.generate_sts_labels(&pod_labels);
         let env = self.generate_env_vars(replica_group);
-        let init_containers = self.generate_init_containers(replica_group, backup_config)?;
+        let mut init_containers = self.generate_init_containers(replica_group, backup_config)?;
         let ports = self.generate_container_ports();
         let probe = self.generate_probe();
         let volume_mounts = self.generate_volume_mounts(backup_config);
@@ -300,16 +300,17 @@ impl StatefulSetExt for Kanidm {
             backup_config,
         )?;
         let transport_config = backup_config.and_then(|config| config.transport.as_ref());
+        let transport_name = super::transport::TRANSPORT_SIDECAR_NAME;
 
+        // The transport is operator-managed. Remove any stale regular-container placement from
+        // the desired pod and any same-name user init container before injecting the native
+        // sidecar. This also makes upgrades from the previous topology deterministic.
+        containers.retain(|c| c.name != transport_name);
+        init_containers.retain(|c| c.name != transport_name);
         if replica_group.primary_node {
             if let Some(config) = transport_config {
-                let sidecar = self.build_transport_sidecar(config, replica_group)?;
-                containers.push(sidecar);
-            } else {
-                containers.retain(|c| c.name != super::transport::TRANSPORT_SIDECAR_NAME);
+                init_containers.push(self.build_transport_sidecar(config, replica_group)?);
             }
-        } else {
-            containers.retain(|c| c.name != super::transport::TRANSPORT_SIDECAR_NAME);
         }
 
         let dns_policy = self.generate_dns_policy();
@@ -990,6 +991,9 @@ impl Kanidm {
             volume_mounts: Some(volume_mounts),
             security_context: Some(hardened_security_context()),
             resources: Some(default_resource_requirements()),
+            // Native sidecar semantics: restart independently without participating in Pod
+            // readiness. Deliberately do not configure a readiness probe on this container.
+            restart_policy: Some("Always".to_string()),
             ..Container::default()
         })
     }
@@ -2231,6 +2235,7 @@ consumer_cert = "dummy-cert-read-replica-1"
             .await;
         }
     }
+
     #[test]
     fn backup_enables_generated_config_and_native_online_backup_stanza() {
         use crate::kanidm::crd::{KanidmStorage, PersistentVolumeClaimTemplate};
@@ -2286,7 +2291,7 @@ consumer_cert = "dummy-cert-read-replica-1"
     }
 
     #[test]
-    fn transport_sidecar_present_for_primary_group_with_config() {
+    fn transport_sidecar_is_native_sidecar_for_primary_group_with_config() {
         use super::StatefulSetExt;
         use crate::kanidm::reconcile::transport::{BackupConfig, TransportSidecarConfig};
         use kaniop_backup_core::crd::{AuthMethod, SecretRef};
@@ -2316,11 +2321,20 @@ consumer_cert = "dummy-cert-read-replica-1"
             .create_statefulset(&replica_group, None, Some(&config))
             .unwrap();
         let pod = sts.spec.unwrap().template.spec.unwrap();
-        let containers = pod.containers;
-
-        let sidecar = containers.iter().find(|c| c.name == "data-mover-transport");
-        assert!(sidecar.is_some());
-        let sidecar = sidecar.unwrap();
+        assert!(
+            pod.containers
+                .iter()
+                .all(|c| c.name != "data-mover-transport")
+        );
+        let sidecar = pod
+            .init_containers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "data-mover-transport")
+            .expect("transport native sidecar should be present");
+        assert_eq!(sidecar.restart_policy.as_deref(), Some("Always"));
+        assert!(sidecar.readiness_probe.is_none());
         assert_eq!(
             sidecar.image.as_deref(),
             Some("ghcr.io/pando85/kaniop-data-mover:latest")
@@ -2405,10 +2419,16 @@ consumer_cert = "dummy-cert-read-replica-1"
             .create_statefulset(&replica_group, None, Some(&config))
             .unwrap();
         let pod = sts.spec.unwrap().template.spec.unwrap();
-        let containers = pod.containers;
-
-        let sidecar = containers.iter().find(|c| c.name == "data-mover-transport");
-        assert!(sidecar.is_none());
+        assert!(
+            pod.containers
+                .iter()
+                .all(|c| c.name != "data-mover-transport")
+        );
+        assert!(
+            pod.init_containers
+                .as_ref()
+                .is_none_or(|containers| containers.iter().all(|c| c.name != "data-mover-transport"))
+        );
     }
 
     #[test]
@@ -2423,10 +2443,16 @@ consumer_cert = "dummy-cert-read-replica-1"
             .create_statefulset(&replica_group, None, None)
             .unwrap();
         let pod = sts.spec.unwrap().template.spec.unwrap();
-        let containers = pod.containers;
-
-        let sidecar = containers.iter().find(|c| c.name == "data-mover-transport");
-        assert!(sidecar.is_none());
+        assert!(
+            pod.containers
+                .iter()
+                .all(|c| c.name != "data-mover-transport")
+        );
+        assert!(
+            pod.init_containers
+                .as_ref()
+                .is_none_or(|containers| containers.iter().all(|c| c.name != "data-mover-transport"))
+        );
     }
 
     #[test]
@@ -2462,7 +2488,9 @@ consumer_cert = "dummy-cert-read-replica-1"
         let pod = sts.spec.unwrap().template.spec.unwrap();
 
         let sidecar = pod
-            .containers
+            .init_containers
+            .as_ref()
+            .unwrap()
             .iter()
             .find(|c| c.name == "data-mover-transport")
             .unwrap();
@@ -2511,7 +2539,9 @@ consumer_cert = "dummy-cert-read-replica-1"
         let pod = sts.spec.unwrap().template.spec.unwrap();
 
         let sidecar = pod
-            .containers
+            .init_containers
+            .as_ref()
+            .unwrap()
             .iter()
             .find(|c| c.name == "data-mover-transport")
             .unwrap();
@@ -2566,7 +2596,9 @@ consumer_cert = "dummy-cert-read-replica-1"
         let pod = sts.spec.unwrap().template.spec.unwrap();
 
         let sidecar = pod
-            .containers
+            .init_containers
+            .as_ref()
+            .unwrap()
             .iter()
             .find(|c| c.name == "data-mover-transport")
             .unwrap();

--- a/tests/e2e/test/kanidm/backup_transport.rs
+++ b/tests/e2e/test/kanidm/backup_transport.rs
@@ -137,18 +137,15 @@ e2e_test!(
         let sts_api = Api::<StatefulSet>::namespaced(client.clone(), "default");
         let sts_name = format!("{kanidm_name}-{DEFAULT_REPLICA_GROUP_NAME}");
 
-        poll_until("transport sidecar appears in StatefulSet", || {
+        poll_until("transport native sidecar appears in StatefulSet", || {
             let sts_api = sts_api.clone();
             let sts_name = sts_name.clone();
             async move {
                 let sts = sts_api.get(&sts_name).await.ok()?;
-                let has_sidecar = sts
-                    .spec
+                let pod_spec = sts.spec.as_ref()?.template.spec.as_ref()?;
+                let has_sidecar = pod_spec
+                    .init_containers
                     .as_ref()?
-                    .template
-                    .spec
-                    .as_ref()?
-                    .containers
                     .iter()
                     .any(|c| c.name == TRANSPORT_SIDECAR_NAME);
                 if has_sidecar { Some(()) } else { None }
@@ -157,18 +154,33 @@ e2e_test!(
         .await;
 
         let sts = sts_api.get(&sts_name).await.unwrap();
-        let sidecar = sts
+        let pod_spec = sts
             .spec
             .as_ref()
             .unwrap()
             .template
             .spec
             .as_ref()
+            .unwrap();
+        assert!(
+            pod_spec
+                .containers
+                .iter()
+                .all(|c| c.name != TRANSPORT_SIDECAR_NAME),
+            "transport must not be a regular application container"
+        );
+        let sidecar = pod_spec
+            .init_containers
+            .as_ref()
             .unwrap()
-            .containers
             .iter()
             .find(|c| c.name == TRANSPORT_SIDECAR_NAME)
-            .expect("transport sidecar should be present");
+            .expect("transport native sidecar should be present");
+        assert_eq!(sidecar.restart_policy.as_deref(), Some("Always"));
+        assert!(
+            sidecar.readiness_probe.is_none(),
+            "transport sidecar readiness must not gate Kanidm Pod readiness"
+        );
         assert!(
             sidecar
                 .image
@@ -350,7 +362,7 @@ e2e_test!(
         let sts_api = Api::<StatefulSet>::namespaced(client.clone(), "default");
         let sts_name = format!("{kanidm_name}-{DEFAULT_REPLICA_GROUP_NAME}");
 
-        poll_until("transport sidecar appears in StatefulSet", || {
+        poll_until("transport native sidecar appears in StatefulSet", || {
             let sts_api = sts_api.clone();
             let sts_name = sts_name.clone();
             async move {
@@ -361,7 +373,8 @@ e2e_test!(
                     .template
                     .spec
                     .as_ref()?
-                    .containers
+                    .init_containers
+                    .as_ref()?
                     .iter()
                     .any(|c| c.name == TRANSPORT_SIDECAR_NAME);
                 if has_sidecar { Some(()) } else { None }
@@ -379,11 +392,20 @@ e2e_test!(
             let sidecar_status = pod
                 .status
                 .as_ref()
-                .and_then(|s| s.container_statuses.as_ref())
+                .and_then(|s| s.init_container_statuses.as_ref())
                 .and_then(|statuses| statuses.iter().find(|cs| cs.name == TRANSPORT_SIDECAR_NAME));
+            let pod_ready = pod
+                .status
+                .as_ref()
+                .and_then(|s| s.conditions.as_ref())
+                .is_some_and(|conditions| {
+                    conditions
+                        .iter()
+                        .any(|condition| condition.type_ == "Ready" && condition.status == "True")
+                });
 
             if let Some(cs) = sidecar_status {
-                if cs.ready && cs.restart_count == 0 {
+                if cs.ready && cs.restart_count == 0 && pod_ready {
                     break;
                 }
             }
@@ -400,26 +422,28 @@ e2e_test!(
                     .await
                     .unwrap_or_default();
                 panic!(
-                    "Timeout waiting for non-primary sidecar to be Ready with 0 restarts. Logs:\n{logs}"
+                    "Timeout waiting for non-primary native sidecar and Ready Kanidm Pod. Logs:\n{logs}"
                 );
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
 
         let primary_pod = format!("{sts_name}-0");
-        let primary_sidecar_ok = poll_until("primary sidecar is ready", || {
+        let primary_sidecar_ok = poll_until("primary native sidecar and Pod are ready", || {
             let pod_api = pod_api.clone();
             let primary_pod = primary_pod.clone();
             async move {
                 let pod = pod_api.get(&primary_pod).await.ok()?;
-                let cs = pod
-                    .status
-                    .as_ref()?
-                    .container_statuses
+                let status = pod.status.as_ref()?;
+                let cs = status
+                    .init_container_statuses
                     .as_ref()?
                     .iter()
                     .find(|cs| cs.name == TRANSPORT_SIDECAR_NAME)?;
-                if cs.ready && cs.restart_count == 0 {
+                let pod_ready = status.conditions.as_ref()?.iter().any(|condition| {
+                    condition.type_ == "Ready" && condition.status == "True"
+                });
+                if cs.ready && cs.restart_count == 0 && pod_ready {
                     Some(())
                 } else {
                     None
@@ -428,7 +452,7 @@ e2e_test!(
         });
         tokio::time::timeout(Duration::from_secs(300), primary_sidecar_ok)
             .await
-            .expect("primary sidecar should become ready");
+            .expect("primary native sidecar and Kanidm Pod should become ready");
 
         cleanup_transport_resources(&client, kanidm_name, repo_name).await;
         let secret_api_cleanup =

--- a/tests/e2e/test/kanidm/backup_transport.rs
+++ b/tests/e2e/test/kanidm/backup_transport.rs
@@ -154,14 +154,7 @@ e2e_test!(
         .await;
 
         let sts = sts_api.get(&sts_name).await.unwrap();
-        let pod_spec = sts
-            .spec
-            .as_ref()
-            .unwrap()
-            .template
-            .spec
-            .as_ref()
-            .unwrap();
+        let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
         assert!(
             pod_spec
                 .containers
@@ -440,9 +433,11 @@ e2e_test!(
                     .as_ref()?
                     .iter()
                     .find(|cs| cs.name == TRANSPORT_SIDECAR_NAME)?;
-                let pod_ready = status.conditions.as_ref()?.iter().any(|condition| {
-                    condition.type_ == "Ready" && condition.status == "True"
-                });
+                let pod_ready = status
+                    .conditions
+                    .as_ref()?
+                    .iter()
+                    .any(|condition| condition.type_ == "Ready" && condition.status == "True");
                 if cs.ready && cs.restart_count == 0 && pod_ready {
                     Some(())
                 } else {


### PR DESCRIPTION
## Summary

Move `data-mover-transport` from a regular application container to a Kubernetes native sidecar (`initContainers` + `restartPolicy: Always`).

This separates backup transport health from Kanidm serving readiness: the transport intentionally has no `readinessProbe`, so runtime transport failures/restarts do not make an otherwise healthy Kanidm Pod unready and remove it from Service endpoints.

## Changes

- inject `data-mover-transport` as a restartable init container on the primary replica group
- explicitly remove the old regular-container placement during reconciliation, making upgrades deterministic
- keep the existing image, command, auth, mounts, security context, resources, primary-node self-gating, and upload retry behavior unchanged
- deliberately leave the transport without a readiness probe
- update transport tests to assert:
  - the transport is absent from `spec.containers`
  - it is present in `spec.initContainers`
  - `restartPolicy` is `Always`
  - no readiness probe is configured
  - runtime status is reported through `initContainerStatuses`
  - Kanidm Pods reach `Ready=True`

## Why

Backup upload availability and Kanidm serving availability are separate health domains. With the transport as a normal `spec.containers[]` entry, a data-mover process exit/restart can make the whole Pod NotReady even while `kanidmd` is healthy.

Kubernetes native sidecars provide the lifecycle semantics we want: the sidecar can restart independently after startup, and its readiness only participates in Pod readiness when a readiness probe is configured.

## Compatibility / limitation

The repository currently builds against Kubernetes 1.32 APIs. Native sidecars are enabled by default since Kubernetes 1.29.

This isolates **runtime** transport failures from Kanidm readiness. Initial Pod startup still requires Kubernetes to start the native sidecar at least once, so an image pull failure or another failure that prevents the sidecar from ever starting can still block initial Kanidm startup. Completely isolating that failure mode would require moving transport to a separate Pod, which would introduce PVC attachment/lifecycle complexity and is outside this change.

## Validation

- focused StatefulSet/integration assertions updated for native-sidecar topology and readiness semantics
- backup transport e2e updated to inspect `initContainerStatuses` and assert Pod `Ready=True`
- full CI is expected to validate formatting, compilation, unit tests, and e2e coverage
